### PR TITLE
Adds metrics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ To upload the dashboards, run:
 ```
 ./scripts/upload-dashboards.sh
 ```
+
+To upload a dashboard while editing, run:
+```
+./scripts/upload-dashboard.sh metrics.json
+```

--- a/dashboards/metrics.jsonnet
+++ b/dashboards/metrics.jsonnet
@@ -1,0 +1,149 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+
+local singleSeriesChart(title, query, legend, format='short') =
+  grafana.graphPanel.new(
+    title,
+    fill=0,
+    format=format,
+    legend_show=false,
+    min=0,
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      query,
+      legendFormat=legend,
+    )
+  );
+
+local multiSeriesChart(title, query, legend, format='short') =
+  grafana.graphPanel.new(
+    title,
+    fill=0,
+    format=format,
+    legend_current=true,
+    legend_alignAsTable=true,
+    legend_rightSide=true,
+    legend_show=true,
+    legend_sort="current",
+    legend_sortDesc=true,
+    legend_values=true,
+    min=0,
+    shared_tooltip=false,
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      query,
+      legendFormat=legend,
+    )
+  );
+
+local stackedPercentageChart(title, query, legend) =
+  grafana.graphPanel.new(
+    title,
+    fill=10,
+    format='percentunit',
+    legend_current=true,
+    legend_alignAsTable=true,
+    legend_rightSide=true,
+    legend_show=true,
+    legend_sort="current",
+    legend_sortDesc=true,
+    legend_values=true,
+    max=100,
+    min=0,
+    percentage=true,
+    shared_tooltip=false,
+    stack=true,
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      query,
+      legendFormat=legend,
+    )
+  );
+
+grafana.dashboard.new(
+  'Metrics',
+  schemaVersion=16,
+  tags=['atlas'],
+  time_from='now-7d',
+  uid='metrics',
+)
+
+.addPanel(
+  singleSeriesChart(
+    'Number of Time Series In Prometheus (Total)',
+    'sum(prometheus_tsdb_head_series)',
+    'Time Series',
+  ),
+  gridPos={x: 0, y: 0, h: 8},
+)
+.addPanel(
+  multiSeriesChart(
+    'Number of Time Series In Prometheus (Per Control Plane)',
+    'sum(avg(prometheus_tsdb_head_series{customer!=""}) by (customer, cluster_id)) by (cluster_id)',
+    '{{cluster_id}}',
+  ),
+  gridPos={x: 6, y: 0, h: 8}
+)
+.addPanel(
+  multiSeriesChart(
+    'Number of Time Series In Prometheus (Per Customer)',
+    'sum(avg(prometheus_tsdb_head_series{customer!=""}) by (customer, cluster_id)) by (customer)',
+    '{{customer}}',
+  ),
+  gridPos={x: 12, y: 0, h: 8}
+)
+
+.addPanel(
+  singleSeriesChart(
+    'Memory Usage Of Prometheus (Total)',
+    'sum(aggregation:prometheus:memory_usage)',
+    'Memory',
+    format='decbytes',
+  ),
+  gridPos={x: 0, y: 8, h: 8},
+)
+.addPanel(
+  multiSeriesChart(
+    'Memory Usage Of Prometheus (Per Control Plane)',
+    'aggregation:prometheus:memory_usage',
+    '{{cluster_id}}',
+    format='decbytes',
+  ),
+  gridPos={x: 6, y: 8, h: 8}
+)
+.addPanel(
+  multiSeriesChart(
+    'Percentage Of Node Memory (Per Control Plane)',
+    'aggregation:prometheus:memory_percentage',
+    '{{cluster_id}}',
+    format='percent',
+  ),
+  gridPos={x: 12, y: 8, h: 8}
+)
+
+.addPanel(
+  stackedPercentageChart(
+    'Percentage Time Series (Per Control Plane)',
+    'sum(prometheus_tsdb_head_series{cluster_id!=""}) by (cluster_id) / scalar(sum(prometheus_tsdb_head_series{cluster_id!=""}))',
+    '{{cluster_id}}',
+  ),
+  gridPos={x: 0, y: 16, h: 8}
+)
+.addPanel(
+  stackedPercentageChart(
+    'Percentage Time Series (Per Customer)',
+    'sum(prometheus_tsdb_head_series{customer!=""}) by (customer) / scalar(sum(prometheus_tsdb_head_series{customer!=""}))',
+    '{{cluster_id}}',
+  ),
+  gridPos={x: 6, y: 16, h: 8}
+)
+.addPanel(
+  stackedPercentageChart(
+    'Percentage Memory (Per Control Plane)',
+    'sum(aggregation:prometheus:memory_usage{cluster_id!=""}) by (cluster_id) / scalar(sum(aggregation:prometheus:memory_usage{cluster_id!=""}))',
+    '{{cluster_id}}',
+  ),
+  gridPos={x: 12, y: 16, h: 8}
+)

--- a/scripts/upload-dashboard.sh
+++ b/scripts/upload-dashboard.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eu
+
+GRAFANA_URL="https://giantswarm.grafana.net"
+FOLDER_ID="31"  # Playground folder
+OUTPUT_DIRECTORY="./output"
+
+if [ -z $GRAFANA_API_KEY ]; then
+    echo "Grafana API key not set"
+    exit 1
+fi
+
+filename=$1
+dashboard_data=`cat $OUTPUT_DIRECTORY/$filename`
+
+curl \
+    --header "Authorization: Bearer $GRAFANA_API_KEY" \
+    --header "Content-Type: application/json" \
+    --request "POST" \
+    --data "{\"dashboard\": $dashboard_data, \"folderId\": $FOLDER_ID, \"overwrite\": true}" \
+    $GRAFANA_URL/api/dashboards/db
+echo
+
+echo "Uploaded dashboard"

--- a/scripts/upload-dashboards.sh
+++ b/scripts/upload-dashboards.sh
@@ -3,7 +3,7 @@
 set -eu
 
 GRAFANA_URL="https://giantswarm.grafana.net"
-FOLDER_ID="40"
+FOLDER_ID="40"  # Official folder
 OUTPUT_DIRECTORY="./output"
 
 if [ -z $GRAFANA_API_KEY ]; then


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10428

This PR adds a copy of the existing Metrics dashboard (see https://giantswarm.grafana.net/d/wzd0R_qZz/metrics), but built using Grafonnet instead of manually. See https://giantswarm.grafana.net/d/metrics/metrics for the playground copy.

We also add a script that is useful for uploading dashboards during test