### PR TITLE
Adds shared crosshairs to official dashboards

### DIFF
--- a/dashboards/stdlib.jsonnet
+++ b/dashboards/stdlib.jsonnet
@@ -1,9 +1,10 @@
 local grafana = import 'grafonnet/grafana.libsonnet';
 
 {
-  dashboard(title, uid, tags, time_from='now-1h', refresh='1m')::
+  dashboard(title, uid, tags, time_from='now-1h', refresh='1m', graphTooltip='shared_crosshair')::
     grafana.dashboard.new(
       title,
+      graphTooltip=graphTooltip,
       schemaVersion=16,
       tags=tags,
       timezone='utc',


### PR DESCRIPTION
e.g:

<img width="1680" alt="Screenshot 2020-09-29 at 15 32 11" src="https://user-images.githubusercontent.com/297653/94572448-f4180000-0268-11eb-8dc8-95f9c5db1060.png">

now all official dashboards have the shared crosshair, which makes correlating events _much_ easier (default argument allows dashboards to opt out if they wish)