### PR TITLE
Add get/update scripts for dashboards

### DIFF
--- a/scripts/get-dashboard.sh
+++ b/scripts/get-dashboard.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Get a single dashboard
+#
+# Retrieve a dashboard as json and optionally stores it
+#
+# $ get-dashboard.sh xIIDfwMMk test
+# $ ls test
+# xIIDfwMMk.json
+
+# First argument is dashboard uid
+#
+# Use list-dashboards to get dashboard uid
+
+# Second argument is folder output
+#
+# e.g. bob becomes bob/UID.json
+# otherwise stdout is used
+
+set -e
+
+OUTPUT=/dev/stdout
+
+TMP=$(mktemp --tmpdir curl.XXXXXXXXXX)
+trap "rm -rf $TMP" EXIT
+
+HTTP_CODE=$(curl --output "$TMP" --write '%{http_code}' --silent --show-error --header "Authorization: Bearer $GRAFANA_API_KEY" https://giantswarm.grafana.net/api/dashboards/uid/$1)
+if [[ ${HTTP_CODE} -lt 200 || ${HTTP_CODE} -gt 299 ]] ; then
+	echo $HTTP_CODE
+	cat "$TMP"
+	exit 1
+fi
+
+if [ -n "$2" ]; then
+	mkdir -p "$2"
+	OUTPUT="$2/$1.json"
+fi
+
+cat "$TMP" > "$OUTPUT"

--- a/scripts/get-dashboard.sh
+++ b/scripts/get-dashboard.sh
@@ -34,6 +34,7 @@ fi
 if [ -n "$2" ]; then
 	mkdir -p "$2"
 	OUTPUT="$2/$1.json"
+	jq . "$TMP" > "$OUTPUT"
+else
+	cat "$TMP" > "$OUTPUT"
 fi
-
-cat "$TMP" > "$OUTPUT"

--- a/scripts/get-dashboards.sh
+++ b/scripts/get-dashboards.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Get all dashboards from given folder
+#
+# Retrive all dashboards from given folder, as json and store them
+#
+# $ get-dashboards.sh 0 test
+# L65Jdq3Zk:Alerts
+# ...
+# $ ls test
+# L65Jdq3Zk.json
+# ...
+
+# First argument is folder id
+#
+# see list-dashboards.sh
+
+# Second argument is folder output
+#
+# see get-dashboard.sh
+
+script_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P)"
+
+$script_path/list-dashboards.sh $1 | while read d; do
+	uid=$(echo -n "$d" | cut -d: -f1)
+	echo "$d"
+	$script_path/get-dashboard.sh $uid $2
+done

--- a/scripts/list-dashboards.sh
+++ b/scripts/list-dashboards.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# List dashboards
+#
+# List dashboards contained in the given folder
+#
+# $ list-dashboards.sh
+# L65Jdq3Zk:Alerts
+# ...
+
+# First argument is the folder id
+#
+# Use list-folders to get folder id.
+# Not providing a folder id will show all dashboard accross all folders
+
+curl -sSH "Authorization: Bearer $GRAFANA_API_KEY" "https://giantswarm.grafana.net/api/search?type=dash-db&folderIds=$1" | jq -cr '.[]|(.uid + ":" + .title)'

--- a/scripts/list-folders.sh
+++ b/scripts/list-folders.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# List folders
+#
+# Folders are used to group dashboards
+#
+# $ list-folders.sh
+# {"id":40,"uid":"bm_2ocRGz","title":"Official"}
+# ...
+
+curl -sSH "Authorization: Bearer $GRAFANA_API_KEY" https://giantswarm.grafana.net/api/folders | jq -cr '.[]'

--- a/scripts/update-dashboard.sh
+++ b/scripts/update-dashboard.sh
@@ -20,5 +20,6 @@ HTTP_CODE=$(curl --output "$OUTPUT" --write '%{http_code}' --silent --show-error
 if [[ ${HTTP_CODE} -lt 200 || ${HTTP_CODE} -gt 299 ]] ; then
 	echo -n "HTTP $HTTP_CODE "
 	cat "$OUTPUT"
+	echo
 	exit 1
 fi

--- a/scripts/update-dashboard.sh
+++ b/scripts/update-dashboard.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Update dashboard
+#
+# Upload the given file as new dashboard version
+# A version notes is added during upload
+
+# First argument is the dashboard file
+#
+# This file contains the dashboard data, this can be retrieved via the UI or with get-dashboard.
+
+set -e
+
+OUTPUT=$(mktemp --tmpdir curl.XXXXXXXXXX)
+INPUT=$(mktemp --tmpdir dashboard.XXXXXXXXXX)
+trap "rm -rf $INPUT $OUTPUT" EXIT
+
+jq '.message="update by giantswarm/dashboards"' $1 > $INPUT
+HTTP_CODE=$(curl --output "$OUTPUT" --write '%{http_code}' --silent --show-error --request POST --data @$INPUT --header "Content-Type: application/json" --header "Authorization: Bearer $GRAFANA_API_KEY" https://giantswarm.grafana.net/api/dashboards/db)
+if [[ ${HTTP_CODE} -lt 200 || ${HTTP_CODE} -gt 299 ]] ; then
+	echo -n "HTTP $HTTP_CODE "
+	cat "$OUTPUT"
+	exit 1
+fi

--- a/scripts/update-dashboards.sh
+++ b/scripts/update-dashboards.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Update multiple dashboards
+#
+# Upload all dashboards found in the given directory
+
+# First argument is folder input
+#
+# This folder holds one file for each dashboard in the same form as get-dashboard result.
+
+script_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P)"
+
+ls $1 | while read f; do
+	d=$(cat "$1/$f" |jq -r '.dashboard.uid + ":" + .dashboard.title')
+	echo "$d"
+	$script_path/update-dashboard.sh "$1/$f"
+done


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15028

Here is a bunch of scripts I used to automate update of dashboard we manually keep in Cortex.

Those dashboard had outadted `cluster_type` labels, so I could batch rename all of those using those scripts and some sed magic.

e.g.

```console
$ ./scripts/get-dashboards.sh 0 root
L65Jdq3Zk:Alerts
...
$ replace 'cluster_type=\\\"tenant_cluster\\\"' 'cluster_type=~\\\"tenant_cluster|workload_cluster\\\"' .
$ replace 'cluster_type=\\\"workload_cluster\\\"' 'cluster_type=~\\\"tenant_cluster|workload_cluster\\\"' .
$ replace 'cluster_type=\\\"management_cluster\\\"' 'cluster_type=~\\\"control_plane|management_cluster\\\"' .
$ ./scripts/update-dashboards.sh root
L65Jdq3Zk:Alerts
...
```