### PR TITLE
workload/management cluster renaming in dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ To upload a dashboard while editing, run:
 ```
 ./scripts/upload-dashboard.sh metrics.json
 ```
+
+## Requirements
+
+* jsonnet: https://github.com/google/jsonnet
+* grafonnet: https://github.com/grafana/grafonnet-lib

--- a/dashboards/metrics.jsonnet
+++ b/dashboards/metrics.jsonnet
@@ -12,21 +12,21 @@ stdlib.dashboard(
   stdlib.variable('customer', 'Customer', 'label_values(prometheus_tsdb_head_series, customer)')
 )
 .addTemplate(
-  stdlib.variable('control_plane', 'Control Plane', 'label_values(prometheus_tsdb_head_series{customer=~"$customer"}, installation)')
+  stdlib.variable('management_cluster', 'Management Cluster', 'label_values(prometheus_tsdb_head_series{customer=~"$customer"}, installation)')
 )
 
 .addPanel(
   stdlib.singleSeriesChart(
     'Number of Time Series In Prometheus (Total)',
-    'sum(prometheus_tsdb_head_series{customer=~"$customer", cluster_id=~"$control_plane"})',
+    'sum(prometheus_tsdb_head_series{customer=~"$customer", cluster_id=~"$management_cluster"})',
     'Time Series',
   ),
   gridPos={x: 0, y: 0, w: 8, h: 9},
 )
 .addPanel(
   stdlib.multiSeriesChart(
-    'Number of Time Series In Prometheus (Per Control Plane)',
-    'sum(avg(prometheus_tsdb_head_series{customer=~"$customer", cluster_id=~"$control_plane"}) by (customer, cluster_id)) by (cluster_id)',
+    'Number of Time Series In Prometheus (Per Management Cluster)',
+    'sum(avg(prometheus_tsdb_head_series{customer=~"$customer", cluster_id=~"$management_cluster"}) by (customer, cluster_id)) by (cluster_id)',
     '{{cluster_id}}',
   ),
   gridPos={x: 8, y: 0, w: 8, h: 9}
@@ -34,7 +34,7 @@ stdlib.dashboard(
 .addPanel(
   stdlib.multiSeriesChart(
     'Number of Time Series In Prometheus (Per Customer)',
-    'sum(avg(prometheus_tsdb_head_series{customer=~"$customer", cluster_id=~"$control_plane"}) by (customer, cluster_id)) by (customer)',
+    'sum(avg(prometheus_tsdb_head_series{customer=~"$customer", cluster_id=~"$management_cluster"}) by (customer, cluster_id)) by (customer)',
     '{{customer}}',
   ),
   gridPos={x: 16, y: 0, w: 8, h: 9}
@@ -43,7 +43,7 @@ stdlib.dashboard(
 .addPanel(
   stdlib.singleSeriesChart(
     'Memory Usage Of Prometheus (Total)',
-    'sum(aggregation:prometheus:memory_usage{customer=~"$customer", cluster_id=~"$control_plane"})',
+    'sum(aggregation:prometheus:memory_usage{customer=~"$customer", cluster_id=~"$management_cluster"})',
     'Memory',
     format='decbytes',
   ),
@@ -51,8 +51,8 @@ stdlib.dashboard(
 )
 .addPanel(
   stdlib.multiSeriesChart(
-    'Memory Usage Of Prometheus (Per Control Plane)',
-    'aggregation:prometheus:memory_usage{customer=~"$customer", cluster_id=~"$control_plane"}',
+    'Memory Usage Of Prometheus (Per Management Cluster)',
+    'aggregation:prometheus:memory_usage{customer=~"$customer", cluster_id=~"$management_cluster"}',
     '{{cluster_id}}',
     format='decbytes',
   ),
@@ -60,8 +60,8 @@ stdlib.dashboard(
 )
 .addPanel(
   stdlib.multiSeriesChart(
-    'Percentage Of Node Memory (Per Control Plane)',
-    'aggregation:prometheus:memory_percentage{customer=~"$customer", cluster_id=~"$control_plane"}',
+    'Percentage Of Node Memory (Per Management Cluster)',
+    'aggregation:prometheus:memory_percentage{customer=~"$customer", cluster_id=~"$management_cluster"}',
     '{{cluster_id}}',
     format='percent',
   ),
@@ -70,8 +70,8 @@ stdlib.dashboard(
 
 .addPanel(
   stdlib.stackedPercentageChart(
-    'Percentage Time Series (Per Control Plane)',
-    'sum(prometheus_tsdb_head_series{customer=~"$customer", cluster_id=~"$control_plane"}) by (cluster_id) / scalar(sum(prometheus_tsdb_head_series{cluster_id!=""}))',
+    'Percentage Time Series (Per Management Cluster)',
+    'sum(prometheus_tsdb_head_series{customer=~"$customer", cluster_id=~"$management_cluster"}) by (cluster_id) / scalar(sum(prometheus_tsdb_head_series{cluster_id!=""}))',
     '{{cluster_id}}',
   ),
   gridPos={x: 0, y: 18, w: 8, h: 9}
@@ -79,15 +79,15 @@ stdlib.dashboard(
 .addPanel(
   stdlib.stackedPercentageChart(
     'Percentage Time Series (Per Customer)',
-    'sum(prometheus_tsdb_head_series{customer=~"$customer", cluster_id=~"$control_plane"}) by (customer) / scalar(sum(prometheus_tsdb_head_series{customer!=""}))',
+    'sum(prometheus_tsdb_head_series{customer=~"$customer", cluster_id=~"$management_cluster"}) by (customer) / scalar(sum(prometheus_tsdb_head_series{customer!=""}))',
     '{{cluster_id}}',
   ),
   gridPos={x: 8, y: 18, w: 8, h: 9}
 )
 .addPanel(
   stdlib.stackedPercentageChart(
-    'Percentage Memory (Per Control Plane)',
-    'sum(aggregation:prometheus:memory_usage{customer=~"$customer", cluster_id=~"$control_plane"}) by (cluster_id) / scalar(sum(aggregation:prometheus:memory_usage{cluster_id!=""}))',
+    'Percentage Memory (Per Management Cluster)',
+    'sum(aggregation:prometheus:memory_usage{customer=~"$customer", cluster_id=~"$management_cluster"}) by (cluster_id) / scalar(sum(aggregation:prometheus:memory_usage{cluster_id!=""}))',
     '{{cluster_id}}',
   ),
   gridPos={x: 16, y: 18, w: 8, h: 9}

--- a/scripts/make-dashboards.sh
+++ b/scripts/make-dashboards.sh
@@ -19,7 +19,7 @@ for dashboard in $DASHBOARD_DIRECTORY/*; do
     echo "Making dashboard $dashboard.jsonnet"
 
     jsonnet \
-        --jpath $GOPATH/src/github.com/grafana/grafonnet-lib/ \
+        --jpath ~/go/src/github.com/grafana/grafonnet-lib/ \
         $DASHBOARD_DIRECTORY/$dashboard.jsonnet > $OUTPUT_DIRECTORY/$dashboard.json
 done
 

--- a/scripts/make-dashboards.sh
+++ b/scripts/make-dashboards.sh
@@ -19,7 +19,7 @@ for dashboard in $DASHBOARD_DIRECTORY/*; do
     echo "Making dashboard $dashboard.jsonnet"
 
     jsonnet \
-        --jpath ~/go/src/github.com/grafana/grafonnet-lib/ \
+        --jpath $GOPATH/src/github.com/grafana/grafonnet-lib/ \
         $DASHBOARD_DIRECTORY/$dashboard.jsonnet > $OUTPUT_DIRECTORY/$dashboard.json
 done
 


### PR DESCRIPTION
Towards: giantswarm/giantswarm#15028

Renaming tenant cluster and control plane respectively to workload cluster and management cluster.