### PR TITLE
Replace built-in threshold with dynamic metric

### DIFF
--- a/dashboards/service-level.jsonnet
+++ b/dashboards/service-level.jsonnet
@@ -136,7 +136,7 @@ stdlib.dashboard(
   )
   .addSeriesOverride({alias: "/.*(5m)/", color: "#8AB8FF"})
   .addSeriesOverride({alias: "/.*(1h)/", color: "#1250B0"})
-  .addSeriesOverride({alias: "/.*(SLO High Threshold)/", color: "#E02F44"}),
+  .addSeriesOverride({alias: "/.*(SLO High Threshold)/", color: "#E02F44", linewidth: 2}),
   gridPos={x:0, y: 9, w: 12, h: 9},
 )
 .addPanel(
@@ -160,6 +160,6 @@ stdlib.dashboard(
   )
   .addSeriesOverride({alias: "/.*(30m)/", color: "#CA95E5"})
   .addSeriesOverride({alias: "/.*(6h)/", color: "#7C2EA3"})
-  .addSeriesOverride({alias: "/.*(SLO Low Threshold)/", color: "#E02F44"}),
+  .addSeriesOverride({alias: "/.*(SLO Low Threshold)/", color: "#E02F44", linewidth: 2}),
   gridPos={x:12, y: 9, w: 12, h: 9},
 )

--- a/dashboards/service-level.jsonnet
+++ b/dashboards/service-level.jsonnet
@@ -136,7 +136,7 @@ stdlib.dashboard(
   )
   .addSeriesOverride({alias: "/.*(5m)/", color: "#8AB8FF"})
   .addSeriesOverride({alias: "/.*(1h)/", color: "#1250B0"})
-  .addSeriesOverride({alias: "/.*(SLO High Threshold)/", color: "#E02F44", linewidth: 2}),
+  .addSeriesOverride({alias: "/.*(SLO High Threshold)/", color: "#E02F44", linewidth: 3}),
   gridPos={x:0, y: 9, w: 12, h: 9},
 )
 .addPanel(
@@ -160,6 +160,6 @@ stdlib.dashboard(
   )
   .addSeriesOverride({alias: "/.*(30m)/", color: "#CA95E5"})
   .addSeriesOverride({alias: "/.*(6h)/", color: "#7C2EA3"})
-  .addSeriesOverride({alias: "/.*(SLO Low Threshold)/", color: "#E02F44", linewidth: 2}),
+  .addSeriesOverride({alias: "/.*(SLO Low Threshold)/", color: "#E02F44", linewidth: 3}),
   gridPos={x:12, y: 9, w: 12, h: 9},
 )

--- a/dashboards/service-level.jsonnet
+++ b/dashboards/service-level.jsonnet
@@ -128,7 +128,7 @@ stdlib.dashboard(
         legend: '{{service}} / {{installation}} / {{cluster_id}} (1h)',
       },
       {
-        query: 'min(slo_target_high{service=~"$service", installation=~"$installation", cluster_id=~"$cluster_id"}) by (service)',
+        query: 'min(slo_threshold_high{service=~"$service", installation=~"$installation", cluster_id=~"$cluster_id"}) by (service)',
         legend: 'SLO High Threshold - {{service}}',
       }
     ],
@@ -152,7 +152,7 @@ stdlib.dashboard(
         legend: '{{service}} / {{installation}} / {{cluster_id}} (6h)',
       },
       {
-        query: 'min(slo_target_low{service=~"$service", installation=~"$installation", cluster_id=~"$cluster_id"}) by (service)',
+        query: 'min(slo_threshold_low{service=~"$service", installation=~"$installation", cluster_id=~"$cluster_id"}) by (service)',
         legend: 'SLO Low Threshold - {{service}}',
       }
     ],

--- a/dashboards/service-level.jsonnet
+++ b/dashboards/service-level.jsonnet
@@ -15,14 +15,7 @@ local burnRateChart(title, queries, threshold) =
     legend_values=true,
     min=0,
     shared_tooltip=false,
-    thresholds=[{
-      colorMode: "critical",
-      fill: true,
-      line: true,
-      op: "gt",
-      value: threshold,
-      yaxis: 'left',
-    }],
+    thresholds=[],
   )
   .addTargets(
     [grafana.prometheus.target(q.query, legendFormat=q.legend) for q in queries],
@@ -133,12 +126,17 @@ stdlib.dashboard(
       {
         query: 'slo_errors_per_request:ratio_rate1h{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"}',
         legend: '{{service}} / {{installation}} / {{cluster_id}} (1h)',
+      },
+      {
+        query: 'min(slo_target_high{service=~"$service", installation=~"$installation", cluster_id=~"$cluster_id"}) by (service)',
+        legend: 'SLO High Threshold - {{service}}',
       }
     ],
     0.036
   )
   .addSeriesOverride({alias: "/.*(5m)/", color: "#8AB8FF"})
-  .addSeriesOverride({alias: "/.*(1h)/", color: "#1250B0"}),
+  .addSeriesOverride({alias: "/.*(1h)/", color: "#1250B0"})
+  .addSeriesOverride({alias: "/.*(SLO High Threshold)/", color: "#E02F44"}),
   gridPos={x:0, y: 9, w: 12, h: 9},
 )
 .addPanel(
@@ -152,11 +150,16 @@ stdlib.dashboard(
       {
         query: 'slo_errors_per_request:ratio_rate6h{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"}',
         legend: '{{service}} / {{installation}} / {{cluster_id}} (6h)',
+      },
+      {
+        query: 'min(slo_target_low{service=~"$service", installation=~"$installation", cluster_id=~"$cluster_id"}) by (service)',
+        legend: 'SLO Low Threshold - {{service}}',
       }
     ],
     0.012
   )
   .addSeriesOverride({alias: "/.*(30m)/", color: "#CA95E5"})
-  .addSeriesOverride({alias: "/.*(6h)/", color: "#7C2EA3"}),
+  .addSeriesOverride({alias: "/.*(6h)/", color: "#7C2EA3"})
+  .addSeriesOverride({alias: "/.*(SLO Low Threshold)/", color: "#E02F44"}),
   gridPos={x:12, y: 9, w: 12, h: 9},
 )


### PR DESCRIPTION
We want different services to configure their own SLO targets, so we can no longer use a static value to represent the SLO target as a threshold in grafana. Instead, I added a new query to the visualizations so that the SLO target metric is printed. I used a "series override" to customize the color of the metric, but I don't know how to shade (change background) above the metric line, like when using a build-in threshold.