### PR TITLE
make slo target gauges depend on variables

### DIFF
--- a/dashboards/service-level.jsonnet
+++ b/dashboards/service-level.jsonnet
@@ -180,7 +180,7 @@ stdlib.dashboard(
   ])
   .addTarget(
     grafana.prometheus.target(
-      '1- min(slo_target) by (service)',
+      '1- min(slo_target{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"}) by (service)',
       legendFormat='',
     )
   ),


### PR DESCRIPTION
Let's make the slo target gauges that are shown depend on the variables we select, so that we do not always see everything including testing.