### PR TITLE
Update RSS feed URL in Home dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update Home dashboard to only show release notes related to dashboards.
+
 ## [0.1.1] - 2021-06-25
 
 ### Fixed

--- a/helm/dashboards/dashboards/shared/home.json
+++ b/helm/dashboards/dashboards/shared/home.json
@@ -15,17 +15,12 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
+  "id": null,
   "links": [],
   "panels": [
     {
       "datasource": null,
       "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
       "gridPos": {
         "h": 7,
         "w": 11,
@@ -37,36 +32,33 @@
         "content": "<div style=\"color: #fff; padding: 30px; height: 100%; background: no-repeat url(https://user-images.githubusercontent.com/273727/122764477-cc0d7880-d29f-11eb-9379-62a551323b32.png); background-size: cover; background-position: center top 50%\">\n<div style=\"line-height: 55px\">\n<img src=\"https://s.giantswarm.io/brand/1/logo-white.svg\" style=\"display: inline-block; width: 220px; height: 55px; margin-bottom: 13px; margin-left: -15px; padding-right: 20px;\"/>\n<span class=\"h1\" style=\"display: inline-block; padding-top: 15px; margin-bottom: 0; line-height: 20px\">Grafana Dashboards</span>\n</div>\n<p>Open the <b>Dashboards</b> / <b>Manage</b> menu to the left to find all dashboards, or select one from below:</p>\n<ul>\n<li><b><a href=\"/d/L65Jdq3Zk/alerts\">Alerts</a></b>: find out which alerts are currently active for an installations, and see which are overruled by silences or inhibitions.</li>\n<li><b><a href=\"/d/qMN01qkWz/nodes-overview\">Nodes overview</a></b>: basic metrics on the nodes in your Kubernetes clusters.</li>\n</ul>\n</div>",
         "mode": "html"
       },
-      "pluginVersion": "7.3.5",
+      "pluginVersion": "8.0.3",
       "timeFrom": null,
       "timeShift": null,
-      "title": "",
       "type": "text"
     },
     {
       "datasource": null,
       "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "folderId": 0,
       "gridPos": {
         "h": 22,
         "w": 13,
         "x": 11,
         "y": 0
       },
-      "headings": true,
       "id": 3,
-      "limit": 30,
       "links": [],
-      "query": "",
-      "recent": true,
-      "search": false,
-      "starred": true,
+      "options": {
+        "folderId": 0,
+        "maxItems": 30,
+        "query": "",
+        "showHeadings": true,
+        "showRecentlyViewed": true,
+        "showSearch": false,
+        "showStarred": true,
+        "tags": []
+      },
+      "pluginVersion": "8.0.3",
       "tags": [],
       "title": "Visited dashboards",
       "type": "dashlist"
@@ -74,12 +66,6 @@
     {
       "datasource": null,
       "description": "Here you find latest release notes explaining changes on dashboards. Also find these at docs.giantswarm.io > Changes and releases.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
       "gridPos": {
         "h": 15,
         "w": 11,
@@ -96,13 +82,14 @@
       ],
       "options": {
         "feedUrl": "https://docs.giantswarm.io/changes/dashboards/index.xml",
+        "showImage": false,
         "useProxy": false
       },
       "title": "Latest changes on dashboards",
       "type": "news"
     }
   ],
-  "schemaVersion": 26,
+  "schemaVersion": 30,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/helm/dashboards/dashboards/shared/home.json
+++ b/helm/dashboards/dashboards/shared/home.json
@@ -95,7 +95,7 @@
         }
       ],
       "options": {
-        "feedUrl": "https://docs.giantswarm.io/changes/index.xml",
+        "feedUrl": "https://docs.giantswarm.io/changes/dashboards/index.xml",
         "useProxy": false
       },
       "title": "Latest changes on dashboards",


### PR DESCRIPTION
This PR changes the RSS feed URL in the Home dashboard to show release notes only from the giantswarm/dashboards repository.

Also updates the schema for Grafana 8.