### PR TITLE
Dex dashboard: add panel for more details, exclude health check requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add new panel to Dex dashboard to show requests with more details.
+- Dex dashboard:
+  - Add new panel to show requests with more details.
+  - Exclude health check requests (handler `/healthz`) from the successful requests graph.
 
 ## [1.9.0] - 2022-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add new panel to Dex dashboard to show requests with more details.
+
 ## [1.9.0] - 2022-01-13
 
 ### Added
 
 - Add a new dashboard showing success and error responses for SSO via `dex`.
-
 
 ## [1.8.1] - 2021-12-02
 

--- a/helm/dashboards/dashboards/shared/dex.json
+++ b/helm/dashboards/dashboards/shared/dex.json
@@ -23,7 +23,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": 16,
-  "iteration": 1641987763525,
+  "iteration": 1642588229858,
   "links": [],
   "panels": [
     {
@@ -404,6 +404,106 @@
       ],
       "title": "Dex Error Response Codes",
       "type": "timeseries"
+    },
+    {
+      "description": "Excluding health checks to /healthz",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisGridShow": true,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 23,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "mean",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P685D3FF52274927C"
+          },
+          "exemplar": true,
+          "expr": "sum(increase(http_requests_total{cluster_id=\"$cluster_id\",service=\"dex\",handler!=\"/healthz\"}[1m])) by (handler, method, code) > 0",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ method }} {{ handler }} - status {{ code }}",
+          "refId": "A"
+        }
+      ],
+      "title": "All Dex requests",
+      "type": "timeseries"
     }
   ],
   "refresh": "",
@@ -475,6 +575,6 @@
   "timezone": "UTC",
   "title": "Dex",
   "uid": "w7T9TUtnz",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/helm/dashboards/dashboards/shared/dex.json
+++ b/helm/dashboards/dashboards/shared/dex.json
@@ -22,9 +22,9 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 16,
   "iteration": 1642588229858,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "gridPos": {
@@ -103,7 +103,6 @@
       "type": "stat"
     },
     {
-      "datasource": "Promxy",
       "description": "Successful dex responses in the last 5 minutes.",
       "fieldConfig": {
         "defaults": {
@@ -211,6 +210,10 @@
       "pluginVersion": "8.0.3",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P685D3FF52274927C"
+          },
           "exemplar": true,
           "expr": "sum (increase(http_requests_total{cluster_id=\"$cluster_id\",service=\"dex\", code=~\"^[1]..$|[2]..$|^[3]..$\",handler!=\"/healthz\"}[5m]))by (code)",
           "format": "time_series",
@@ -220,6 +223,10 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P685D3FF52274927C"
+          },
           "expr": "health",
           "format": "time_series",
           "intervalFactor": 1,
@@ -494,7 +501,7 @@
             "uid": "P685D3FF52274927C"
           },
           "exemplar": true,
-          "expr": "sum(increase(http_requests_total{cluster_id=\"$cluster_id\",service=\"dex\",handler!=\"/healthz\"}[1m])) by (handler, method, code) > 0",
+          "expr": "sum(increase(http_requests_total{cluster_id=\"$cluster_id\",service=\"dex\",handler!=\"/healthz\"}[1m])) by (handler, method, code)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -521,8 +528,9 @@
     "list": [
       {
         "current": {
-          "text": "All",
-          "value": "$__all"
+          "selected": false,
+          "text": "talos",
+          "value": "talos"
         },
         "definition": "label_values(http_requests_total{service=\"dex\"}, cluster_id)",
         "hide": 0,

--- a/helm/dashboards/dashboards/shared/dex.json
+++ b/helm/dashboards/dashboards/shared/dex.json
@@ -212,7 +212,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum (increase(http_requests_total{cluster_id=\"$cluster_id\",service=\"dex\", code=~\"^[1]..$|[2]..$|^[3]..$\"}[5m]))by (code)",
+          "expr": "sum (increase(http_requests_total{cluster_id=\"$cluster_id\",service=\"dex\", code=~\"^[1]..$|[2]..$|^[3]..$\",handler!=\"/healthz\"}[5m]))by (code)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
This PR

- adds a new panel to the Dex dashboard which shows requests/response codes with more details (HTTP method, path)
- excludes requests to `/healthz` from the successful requests graph, to make actual usage more visible.

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
