### PR TITLE
fix ceph dashboard datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Make `kube-proxy` dashboard UX compliant.
+- Fix `ceph-cluster` dashboard datasource.
 
 ## [2.1.0] - 2022-04-05
 

--- a/helm/dashboards/dashboards/kvm/public/ceph-cluster-usage.json
+++ b/helm/dashboards/dashboards/kvm/public/ceph-cluster-usage.json
@@ -91,7 +91,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -190,7 +190,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -259,7 +259,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -328,7 +328,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -397,7 +397,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -474,7 +474,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -550,7 +550,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -619,7 +619,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -688,7 +688,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -757,7 +757,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -826,7 +826,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -895,7 +895,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -964,7 +964,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1035,7 +1035,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1127,7 +1127,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1204,7 +1204,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1281,7 +1281,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1354,7 +1354,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1427,7 +1427,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1504,7 +1504,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1581,7 +1581,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1658,7 +1658,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1734,7 +1734,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1821,7 +1821,7 @@
       "panels": [
         {
           "columns": [],
-          "datasource": "Promxy",
+          "datasource": "default",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1884,7 +1884,7 @@
         },
         {
           "columns": [],
-          "datasource": "Promxy",
+          "datasource": "default",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1947,7 +1947,7 @@
         },
         {
           "columns": [],
-          "datasource": "Promxy",
+          "datasource": "default",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -2028,7 +2028,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Promxy",
+          "datasource": "default",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -2128,7 +2128,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Promxy",
+          "datasource": "default",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -2228,7 +2228,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Promxy",
+          "datasource": "default",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -2328,7 +2328,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Promxy",
+          "datasource": "default",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -2454,7 +2454,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -2594,7 +2594,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "decimals": 0,
       "editable": true,
       "error": false,
@@ -2712,7 +2712,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -2829,7 +2829,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2932,7 +2932,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -3035,7 +3035,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -3137,7 +3137,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -3237,7 +3237,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -3339,7 +3339,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -3462,7 +3462,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -3572,7 +3572,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -3853,7 +3853,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -3981,7 +3981,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -4109,7 +4109,7 @@
         "mode": "opacity"
       },
       "dataFormat": "timeseries",
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -4179,7 +4179,7 @@
         "mode": "opacity"
       },
       "dataFormat": "timeseries",
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -4248,7 +4248,7 @@
         "mode": "opacity"
       },
       "dataFormat": "timeseries",
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -4317,7 +4317,7 @@
         "mode": "opacity"
       },
       "dataFormat": "timeseries",
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -4380,7 +4380,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -4488,7 +4488,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "decimals": null,
       "fieldConfig": {
         "defaults": {
@@ -4619,7 +4619,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -4727,7 +4727,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -4829,7 +4829,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Promxy",
+      "datasource": "default",
       "fieldConfig": {
         "defaults": {
           "custom": {}


### PR DESCRIPTION
This PR

- Fixes the datasource in ceph cluster usage dashboard from Promxy to default.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
