### PR TITLE
Only display master nodes metrics in `K8s API performance` dashboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Only display master nodes metrics in `K8s API performance` dashboard.
+
 ## [2.4.0] - 2022-05-04
 
 ### Added

--- a/helm/dashboards/dashboards/shared/private/api-performance.json
+++ b/helm/dashboards/dashboards/shared/private/api-performance.json
@@ -21,8 +21,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 72,
-  "iteration": 1651674436225,
+  "id": 10,
+  "iteration": 1651735143944,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -273,7 +273,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "100 * (1 - avg(irate(node_cpu_seconds_total{mode=\"idle\",cluster_id=\"$cluster_id\",node!=\"\"}[$__rate_interval])) by (node))",
+          "expr": "100 * (1 - avg(irate(node_cpu_seconds_total{mode=\"idle\",cluster_id=\"$cluster_id\",node!=\"\"}[$__rate_interval])) by (node)) unless on (node) kube_node_role{cluster_id=\"$cluster_id\",role!=\"master\"}",
           "interval": "",
           "legendFormat": "{{ node }}",
           "refId": "A"
@@ -444,7 +444,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "1 - sum(node_memory_MemFree_bytes{cluster_id=\"$cluster_id\",node!=\"\"}) by (node) / sum(node_memory_MemTotal_bytes{cluster_id=\"$cluster_id\",node!=\"\"}) by (node)",
+          "expr": "(1 - sum(node_memory_MemFree_bytes{cluster_id=\"$cluster_id\",node!=\"\"}) by (node) / sum(node_memory_MemTotal_bytes{cluster_id=\"$cluster_id\",node!=\"\"}) by (node)) unless on (node) kube_node_role{cluster_id=\"$cluster_id\",role!=\"master\"}",
           "interval": "",
           "legendFormat": "{{ node }}",
           "refId": "A"
@@ -607,9 +607,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "at6t6",
-          "value": "at6t6"
+          "selected": true,
+          "text": "peu01",
+          "value": "peu01"
         },
         "definition": "label_values(up, cluster_id)",
         "hide": 0,
@@ -631,7 +631,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
Hide worker nodes metrics from the k8s API performance dashboard.

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
