### PR TITLE
Add Kyverno policy dashboards

### DIFF
--- a/helm/dashboards/dashboards/shared/private/kyverno-policy-overview.json
+++ b/helm/dashboards/dashboards/shared/private/kyverno-policy-overview.json
@@ -1,0 +1,577 @@
+{
+    "__inputs": [	
+        {	
+            "name": "DS_PROMETHEUS",	
+            "label": "prometheus",	
+            "description": "",	
+            "type": "datasource",	
+            "pluginId": "prometheus",	
+            "pluginName": "Prometheus"	
+        }	
+    ],	
+    "__requires": [	
+        {	
+            "type": "grafana",	
+            "id": "grafana",	
+            "name": "Grafana",	
+            "version": "7.1.5"	
+        },	
+        {	
+            "type": "datasource",	
+            "id": "prometheus",	
+            "name": "Prometheus",	
+            "version": "1.0.0"	
+        }	
+    ],
+    "annotations": {
+        "list": [
+        {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+        }
+        ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 66,
+    "links": [],
+    "panels": [
+        {
+        "datasource": null,
+        "fieldConfig": {
+            "defaults": {
+            "custom": {
+                "align": null
+            },
+            "decimals": 0,
+            "mappings": [],
+            "min": 0,
+            "noValue": "0",
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "#EAB839",
+                    "value": 1
+                }
+                ]
+            },
+            "unit": "none"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": {{ .Values.policyReportOverview.failingSummaryRow.height }},
+            "w": 15,
+            "x": 0,
+            "y": 0
+        },
+        "id": 4,
+        "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "last"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "showUnfilled": true
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+            {
+            "expr": "sum(policy_report_result{policy=~\"$policy\", category=~\"$category\", severity=~\"$severity\", source=~\"$source\", kind=~\"$kind\", exported_namespace=~\"$namespace\", status=~\"fail|error\"} > 0) by (exported_namespace)",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "{{`{{ exported_namespace }}`}}",
+            "refId": "A"
+            }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Failing Policies by Namespace",
+        "type": "bargauge"
+        },
+        {
+        "datasource": null,
+        "fieldConfig": {
+            "defaults": {
+            "custom": {},
+            "decimals": 0,
+            "mappings": [],
+            "min": 0,
+            "noValue": "0",
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "#EAB839",
+                    "value": 3
+                }
+                ]
+            }
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": {{ .Values.policyReportOverview.failingSummaryRow.height }},
+            "w": 9,
+            "x": 15,
+            "y": 0
+        },
+        "id": 5,
+        "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "vertical",
+            "reduceOptions": {
+            "calcs": [
+                "last"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "textMode": "auto"
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+            {
+            "expr": "sum(cluster_policy_report_result{policy=~\"$policy\", category=~\"$category\", severity=~\"$severity\", source=~\"$source\", kind=~\"$kind\", status=~\"fail|error\"} > 0) by (status)",
+            "format": "time_series",
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "{{`{{ status }}`}}",
+            "refId": "A"
+            }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Failing ClusterPolicies",
+        "type": "stat"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+            "defaults": {
+            "custom": {}
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": {{ .Values.policyReportOverview.failingTimeline.height }},
+            "w": 24,
+            "x": 0,
+            "y": 10
+        },
+        "hiddenSeries": false,
+        "id": 11,
+        "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null as zero",
+        "percentage": false,
+        "pluginVersion": "7.1.5",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(cluster_policy_report_result{policy=~\"$policy\", category=~\"$category\", severity=~\"$severity\", source=~\"$source\", kind=~\"$kind\", status=~\"fail|error\"} > 0) by (policy)",
+            "interval": "",
+            "legendFormat": "{{`{{ policy }}`}}",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(policy_report_result{policy=~\"$policy\", category=~\"$category\", severity=~\"$severity\", source=~\"$source\", kind=~\"$kind\", exported_namespace=~\"$namespace\", status=~\"fail|error\"} > 0) by (policy)",
+            "interval": "",
+            "legendFormat": "{{`{{ policy }}`}}",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Failing Policies Graph",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "decimals": 0,
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+            },
+            {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false,
+            "alignLevel": null
+        }
+        },
+        {
+        "datasource": null,
+        "fieldConfig": {
+            "defaults": {
+            "custom": {
+                "align": null
+            },
+            "mappings": [],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            }
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": {{ .Values.policyReportOverview.failingPolicyRuleTable.height }},
+            "w": 24,
+            "x": 0,
+            "y": 18
+        },
+        "id": 7,
+        "options": {
+            "showHeader": true
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+            {
+            "expr": "sum(policy_report_result{policy=~\"$policy\", category=~\"$category\", severity=~\"$severity\", source=~\"$source\", kind=~\"$kind\", exported_namespace=~\"$namespace\", status=~\"fail|error\"}) by (exported_namespace,policy,rule,kind,name,status,category,severity,source)",
+            "format": "table",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "{{`{{ exported_namespace }}`}}: {{`{{ policy }}`}}",
+            "refId": "A"
+            }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Failing PolicyRules",
+        "transformations": [
+            {
+            "id": "organize",
+            "options": {
+                "excludeByName": {
+                "Time": true,
+                "Value": true
+                },
+                "indexByName": {
+                "category": 0,
+                "severity": 1,
+                "exported_namespace": 2,
+                "kind": 3,
+                "name": 4,
+                "policy": 5,
+                "rule": 6,
+                "status": 7
+                },
+                "renameByName": {
+                "exported_namespace": "namespace"
+                }
+            }
+            }
+        ],
+        "type": "table"
+        },
+        {
+        "datasource": null,
+        "fieldConfig": {
+            "defaults": {
+            "custom": {
+                "align": null
+            },
+            "mappings": [],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            }
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": {{ .Values.policyReportOverview.failingClusterPolicyRuleTable.height }},
+            "w": 24,
+            "x": 0,
+            "y": 28
+        },
+        "id": 9,
+        "options": {
+            "showHeader": true
+        },
+        "pluginVersion": "7.1.5",
+        "targets": [
+            {
+            "expr": "sum(cluster_policy_report_result{policy=~\"$policy\", category=~\"$category\", severity=~\"$severity\", source=~\"$source\", kind=~\"$kind\", status=~\"fail|error\"}) by (policy,rule,kind,name,status,category,severity,source)",
+            "format": "table",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "{{`{{ kind }}`}}: {{`{{ name }}`}} - {{`{{ policy }}`}}",
+            "refId": "A"
+            }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Failing ClusterPolicyRules",
+        "transformations": [
+            {
+            "id": "organize",
+            "options": {
+                "excludeByName": {
+                "Time": true,
+                "Value": true,
+                "__name__": true,
+                "endpoint": true,
+                "instance": true,
+                "job": true,
+                "namespace": true,
+                "pod": true,
+                "report": true,
+                "service": true,
+                "container": true
+                },
+                "indexByName": {
+                "category": 0,
+                "severity": 1,
+                "kind": 2,
+                "name": 3,
+                "policy": 4,
+                "rule": 5,
+                "status": 6
+                },
+                "renameByName": {}
+            }
+            }
+        ],
+        "type": "table"
+        }
+    ],
+    "schemaVersion": 26,
+    "style": "dark",
+    "tags": [
+        "Policy Reporter"
+    ],
+    "templating": {
+        "list": [
+        {
+            "allValue": ".*",
+            "definition": "label_values({__name__=~ \"policy_report_result|cluster_policy_report_result\", status=~\"fail|error\"}, policy)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Policy",
+            "multi": true,
+            "name": "policy",
+            "options": [],
+            "query": "label_values({__name__=~ \"policy_report_result|cluster_policy_report_result\", status=~\"fail|error\"}, policy)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allValue": ".*",
+            "definition": "label_values({__name__=~ \"policy_report_result|cluster_policy_report_result\", status=~\"fail|error\"}, category)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Category",
+            "multi": true,
+            "name": "category",
+            "options": [],
+            "query": "label_values({__name__=~ \"policy_report_result|cluster_policy_report_result\", status=~\"fail|error\"}, category)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allValue": ".*",
+            "definition": "label_values({__name__=~ \"policy_report_result|cluster_policy_report_result\", status=~\"fail|error\"}, severity)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Severity",
+            "multi": true,
+            "name": "severity",
+            "options": [],
+            "query": "label_values({__name__=~ \"policy_report_result|cluster_policy_report_result\", status=~\"fail|error\"}, severity)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allValue": ".*",
+            "definition": "label_values({__name__= \"policy_report_result\", status=~\"fail|error\"}, exported_namespace)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Namespace",
+            "multi": true,
+            "name": "namespace",
+            "options": [],
+            "query": "label_values({__name__= \"policy_report_result\", status=~\"fail|error\"}, exported_namespace)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allValue": ".*",
+            "definition": "label_values({__name__=~ \"policy_report_result|cluster_policy_report_result\", status=~\"fail|error\"}, kind)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Kind",
+            "multi": true,
+            "name": "kind",
+            "options": [],
+            "query": "label_values({__name__=~ \"policy_report_result|cluster_policy_report_result\", status=~\"fail|error\"}, kind)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allValue": ".*",
+            "definition": "label_values({__name__=~ \"policy_report_result|cluster_policy_report_result\", status=~\"fail|error\"}, source)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Source",
+            "multi": true,
+            "name": "source",
+            "options": [],
+            "query": "label_values({__name__=~ \"policy_report_result|cluster_policy_report_result\", status=~\"fail|error\"}, source)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 5,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        }
+        ]
+    },
+    "time": {
+        "from": "now-30m",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+        ]
+    },
+    "timezone": "",
+    "title": "PolicyReports",
+    "version": 1
+    }


### PR DESCRIPTION
This PR

- adds the kyverno policyreporter overview [dashboard as of version 2.6.1](https://github.com/kyverno/policy-reporter/blob/v2.6.1/charts/policy-reporter/charts/monitoring/templates/overview.dashboard.yaml)

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md in an end-user friendly language.
