### PR TITLE
Move ownership of dashboards from Celestial and Firecracker to Phoenix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move ownership of dashboards from Celestial and Firecracker to Phoenix.
+
 ## [2.12.1] - 2022-06-29
 
 ### Fixed

--- a/helm/dashboards/dashboards/aws/private/autoscaling-groups.json
+++ b/helm/dashboards/dashboards/aws/private/autoscaling-groups.json
@@ -716,7 +716,7 @@
     "provider:aws",
     "topic:workload-cluster",
     "topic:management-cluster",
-    "owner:team-firecracker"
+    "owner:team-phoenix"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/dashboards/aws/private/aws-cni.json
+++ b/helm/dashboards/dashboards/aws/private/aws-cni.json
@@ -1900,7 +1900,7 @@
   "tags": [
     "provider:aws",
     "topic:workload-cluster",
-    "owner:team-firecracker"
+    "owner:team-phoenix"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/dashboards/aws/private/aws-service-limits.json
+++ b/helm/dashboards/dashboards/aws/private/aws-service-limits.json
@@ -534,7 +534,7 @@
   "style": "dark",
   "tags": [
     "provider:aws",
-    "owner:team-firecracker"
+    "owner:team-phoenix"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/dashboards/aws/private/cluster-autoscaler.json
+++ b/helm/dashboards/dashboards/aws/private/cluster-autoscaler.json
@@ -942,8 +942,7 @@
   "tags": [
     "topic:workload-cluster",
     "provider:aws",
-    "owner:team-celestial",
-    "owner:team-firecracker"
+    "owner:team-phoenix"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/dashboards/aws/private/instances.json
+++ b/helm/dashboards/dashboards/aws/private/instances.json
@@ -979,7 +979,7 @@
     "provider:aws",
     "topic:management-cluster",
     "topic:workload-cluster",
-    "owner:team-firecracker"
+    "owner:team-phoenix"
   ],
   "templating": {
     "list": []

--- a/helm/dashboards/dashboards/aws/private/kiam.json
+++ b/helm/dashboards/dashboards/aws/private/kiam.json
@@ -2714,7 +2714,7 @@
   "style": "dark",
   "tags": [
     "kiam",
-    "owner:team-firecracker",
+    "owner:team-phoenix",
     "topic:workload-cluster"
   ],
   "templating": {

--- a/helm/dashboards/dashboards/aws/public/aws-cluster-info.json
+++ b/helm/dashboards/dashboards/aws/public/aws-cluster-info.json
@@ -1239,7 +1239,7 @@
   "tags": [
     "provider:aws",
     "topic:workload-cluster",
-    "owner:team-firecracker"
+    "owner:team-phoenix"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/dashboards/azure/private/azure-service-principal.json
+++ b/helm/dashboards/dashboards/azure/private/azure-service-principal.json
@@ -175,7 +175,7 @@
   "schemaVersion": 26,
   "style": "dark",
   "tags": [
-    "owner:team-celestial"
+    "owner:team-phoenix"
   ],
   "templating": {
     "list": []

--- a/helm/dashboards/dashboards/azure/private/vmss-rate-limits.json
+++ b/helm/dashboards/dashboards/azure/private/vmss-rate-limits.json
@@ -526,7 +526,7 @@
   "style": "dark",
   "tags": [
     "provider:azure",
-    "owner:team-celestial"
+    "owner:team-phoenix"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/dashboards/shared/private/team-firecracker.json
+++ b/helm/dashboards/dashboards/shared/private/team-firecracker.json
@@ -117,7 +117,7 @@
   "schemaVersion": 20,
   "style": "dark",
   "tags": [
-    "owner:team-firecracker"
+    "owner:team-phoenix"
   ],
   "templating": {
     "list": []
@@ -141,7 +141,7 @@
     ]
   },
   "timezone": "UTC",
-  "title": "Team Firecracker",
+  "title": "Team Phoenix",
   "uid": "bVMqoUkMk",
   "version": 1
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/19944



### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
