### PR TITLE
Update dashboards owned by Shield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Move ownership of dashboards from Celestial and Firecracker to Phoenix.
+- Set Team Shield as owner of Falco and Starboard dashboards.
 
 ## [2.12.1] - 2022-06-29
 

--- a/helm/dashboards/dashboards/shared/private/management-cluster-falco.json
+++ b/helm/dashboards/dashboards/shared/private/management-cluster-falco.json
@@ -268,6 +268,7 @@
   "schemaVersion": 26,
   "style": "dark",
   "tags": [
+    "owner:team-shield",
     "topic:security",
     "topic:management-cluster"
   ],

--- a/helm/dashboards/dashboards/shared/private/management-cluster-starboard.json
+++ b/helm/dashboards/dashboards/shared/private/management-cluster-starboard.json
@@ -681,6 +681,11 @@
   "refresh": "",
   "schemaVersion": 33,
   "style": "dark",
+  "tags": [
+    "owner:team-shield",
+    "topic:security",
+    "topic:management-cluster"
+  ],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19944

This PR

- sets team Shield as the owner of the Falco and Starboard dashboards

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
