### PR TITLE
use app label instead of service label in dex dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `app` label instead of `service` label to identify metrics in `dex` dashboard.
+
 ### Added
 
 - Add new dashboard for CertificateRequests

--- a/helm/dashboards/dashboards/shared/public/dex.json
+++ b/helm/dashboards/dashboards/shared/public/dex.json
@@ -93,7 +93,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum (increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",service=\"dex\", code=~\"^[1]..$|[2]..$|^[3]..$\"}[5m]))/sum (increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",service=\"dex\"}[5m]))",
+          "expr": "sum (increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",app=\"dex\", code=~\"^[1]..$|[2]..$|^[3]..$\"}[5m]))/sum (increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",app=\"dex\"}[5m]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -212,7 +212,7 @@
         {
           "datasource": "default",
           "exemplar": true,
-          "expr": "sum (increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",service=\"dex\", code=~\"^[1]..$|[2]..$|^[3]..$\",handler!=\"/healthz\"}[5m]))by (code)",
+          "expr": "sum (increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",app=\"dex\", code=~\"^[1]..$|[2]..$|^[3]..$\",handler!=\"/healthz\"}[5m]))by (code)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -276,7 +276,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum (increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",service=\"dex\", code=~\"^[4]..$|[5]..$\"}[5m]))",
+          "expr": "sum (increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",app=\"dex\", code=~\"^[4]..$|[5]..$\"}[5m]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -395,7 +395,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum (increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",service=\"dex\", code=~\"^[4]..$|^[5]..$\"}[5m]))by (code)",
+          "expr": "sum (increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",app=\"dex\", code=~\"^[4]..$|^[5]..$\"}[5m]))by (code)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -492,7 +492,7 @@
         {
           "datasource": "default",
           "exemplar": true,
-          "expr": "sum(increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",service=\"dex\",handler!=\"/healthz\"}[1m])) by (handler, method, code)",
+          "expr": "sum(increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",app=\"dex\",handler!=\"/healthz\"}[1m])) by (handler, method, code)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -541,7 +541,7 @@
           "value": "$__all"
         },
         "datasource": "$datasource",
-        "definition": "label_values(http_requests_total{service=\"dex\"}, organization)",
+        "definition": "label_values(http_requests_total{app=\"dex\"}, organization)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -551,7 +551,7 @@
         "name": "organization",
         "options": [],
         "query": {
-          "query": "label_values(http_requests_total{service=\"dex\"}, organization)",
+          "query": "label_values(http_requests_total{app=\"dex\"}, organization)",
           "refId": "Organization-query"
         },
         "refresh": 2,
@@ -569,7 +569,7 @@
           "text": "talos",
           "value": "talos"
         },
-        "definition": "label_values(http_requests_total{service=\"dex\", organization=\"$organization\"}, cluster_id)",
+        "definition": "label_values(http_requests_total{app=\"dex\", organization=\"$organization\"}, cluster_id)",
         "hide": 0,
         "includeAll": false,
         "label": "Cluster",
@@ -577,7 +577,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(http_requests_total{service=\"dex\", organization=\"$organization\"}, cluster_id)",
+          "query": "label_values(http_requests_total{app=\"dex\", organization=\"$organization\"}, cluster_id)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
The `service` label is not on the metrics we currently scrape for WCs due to them not coming from the service monitor. Changing it to `app` so we see the WC metrics again.

Towards https://github.com/giantswarm/giantswarm/issues/22817

This PR

- adds/changes/removes etc

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md in an end-user friendly language.
