### PR TITLE
dashboards: Add Kong Connection Distribution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Kong Connection Distribution dashboard.
+
 ## [2.15.0] - 2022-09-06
 
 ### Changed

--- a/helm/dashboards/dashboards/shared/private/kong-connection-distribution.json
+++ b/helm/dashboards/dashboards/shared/private/kong-connection-distribution.json
@@ -1,0 +1,119 @@
+{
+  "id": 80,
+  "uid": "Kw0_AuGOs",
+  "title": "Kong Connection Distribution",
+  "tags": [
+    "kong",
+    "topic:workload-cluster",
+    "owner:team-cabbage"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": "default",
+        "query": {
+          "refId": "StandardVariableQuery",
+          "query": "label_values(kubernetes_build_info, cluster_id)"
+        }
+      },
+      {
+        "name": "namespace",
+        "label": "Namespace",
+        "type": "query",
+        "datasource": "default",
+        "query": {
+          "refId": "StandardVariableQuery",
+          "query": "label_values(kong_nginx_http_current_connections{cluster_id=~\"$cluster\"}, namespace)"
+        },
+        "includeAll": true,
+        "allValue": ".*"
+      },
+      {
+        "name": "app",
+        "label": "App",
+        "type": "query",
+        "datasource": "default",
+        "query": {
+          "refId": "StandardVariableQuery",
+          "query": "label_values(kong_nginx_http_current_connections{cluster_id=~\"$cluster\",namespace=~\"$namespace\"}, app)"
+        },
+        "includeAll": true,
+        "allValue": ".*"
+      },
+      {
+        "name": "pod",
+        "label": "Pod",
+        "type": "query",
+        "datasource": "default",
+        "query": {
+          "refId": "StandardVariableQuery",
+          "query": "label_values(kong_nginx_http_current_connections{cluster_id=~\"$cluster\",namespace=~\"$namespace\",app=~\"$app\"}, pod)"
+        },
+        "includeAll": true,
+        "allValue": ".*"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Active Connections by Pod",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": "default",
+      "targets": [
+        {
+          "refId": "Active Connections by Pod",
+          "datasource": "default",
+          "expr": "kong_nginx_http_current_connections{cluster_id=\"$cluster\",namespace=~\"$namespace\",app=~\"$app\",pod=~\"$pod\",state=\"active\"}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Active Connections by Node",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "datasource": "default",
+      "targets": [
+        {
+          "refId": "Active Connections by Node",
+          "datasource": "default",
+          "expr": "sum by (node) (kong_nginx_http_current_connections{cluster_id=\"$cluster\",namespace=~\"$namespace\",app=~\"$app\",pod=~\"$pod\",state=\"active\"})"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Active Connections by Zone",
+      "type": "timeseries",
+      "datasource": "default",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "targets": [
+        {
+          "refId": "Active Connections by Zone",
+          "datasource": "default",
+          "expr": "sum by (zone) (kong_nginx_http_current_connections{cluster_id=\"$cluster\",namespace=~\"$namespace\",app=~\"$app\",pod=~\"$pod\",state=\"active\"} * on (node) group_left(zone) kube_node_labels{cluster_id=\"$cluster\"})"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a dashboard which shows the distribution of active Kong connections across pods, nodes and zones.

Towards https://github.com/giantswarm/giantswarm/issues/21426.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
