### PR TITLE
add uid to dashboards when missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add official kong ingress controller dashboard rev 2 from https://grafana.com/grafana/dashboards/15662-kong-ingress-controller/
 
+### Changed
+
+- Added uid for some dashboards when missing (etcd, managed-apps-efk-stack-app, management-cluster-kubernetes, microstorage, prometheus-remote-write, workload-cluster-kubernetes)
+
 ## [2.18.0] - 2022-11-22
 
 ### Changed

--- a/helm/dashboards/dashboards/shared/private/etcd.json
+++ b/helm/dashboards/dashboards/shared/private/etcd.json
@@ -1626,5 +1626,6 @@
   },
   "timezone": "UTC",
   "title": "Management cluster etcd",
+  "uid": "etcd00001",
   "version": 1
 }

--- a/helm/dashboards/dashboards/shared/private/managed-apps-efk-stack-app.json
+++ b/helm/dashboards/dashboards/shared/private/managed-apps-efk-stack-app.json
@@ -7205,5 +7205,6 @@
   },
   "timezone": "UTC",
   "title": "Managed Apps: efk-stack-app",
+  "uid": "managedefk001",
   "version": 0
 }

--- a/helm/dashboards/dashboards/shared/private/management-cluster-kubernetes.json
+++ b/helm/dashboards/dashboards/shared/private/management-cluster-kubernetes.json
@@ -351,5 +351,6 @@
   },
   "timezone": "UTC",
   "title": "Management cluster Kubernetes",
+  "uid": "mckube001",
   "version": 1
 }

--- a/helm/dashboards/dashboards/shared/private/microstorage.json
+++ b/helm/dashboards/dashboards/shared/private/microstorage.json
@@ -237,5 +237,6 @@
   },
   "timezone": "UTC",
   "title": "Microstorage",
+  "uid": "microstorage001",
   "version": 2
 }

--- a/helm/dashboards/dashboards/shared/private/prometheus-remote-write.json
+++ b/helm/dashboards/dashboards/shared/private/prometheus-remote-write.json
@@ -1417,5 +1417,6 @@
   },
   "timezone": "UTC",
   "title": "Prometheus / Remote Write",
+  "uid": "promRW001",
   "version": 0
 }

--- a/helm/dashboards/dashboards/shared/private/workload-cluster-kubernetes.json
+++ b/helm/dashboards/dashboards/shared/private/workload-cluster-kubernetes.json
@@ -669,5 +669,6 @@
   },
   "timezone": "UTC",
   "title": "Kubernetes workload cluster core components",
+  "uid": "wckube001",
   "version": 1
 }


### PR DESCRIPTION
This PR adds UIDs to dashboards when missing

List of impacted dashboards:
* etcd, managed-apps-efk-stack-app
* management-cluster-kubernetes
* microstorage
* prometheus-remote-write
* workload-cluster-kubernetes

Towards https://github.com/giantswarm/prometheus-rules/pull/584

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
