### PR TITLE
update team labels for team-rockets dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated team labels for team-rocket
+
 ## [2.25.0] - 2023-03-24
 
 ### Added

--- a/helm/dashboards/dashboards/kvm/private/flannel-operator.json
+++ b/helm/dashboards/dashboards/kvm/private/flannel-operator.json
@@ -612,7 +612,9 @@
   "style": "dark",
   "tags": [
     "owner:team-rocket",
-    "provider:kvm"
+    "provider:kvm",
+    "topic:management-cluster"
+
   ],
   "templating": {
     "list": []

--- a/helm/dashboards/dashboards/kvm/private/kvm-operator.json
+++ b/helm/dashboards/dashboards/kvm/private/kvm-operator.json
@@ -616,7 +616,8 @@
   "style": "dark",
   "tags": [
     "owner:team-rocket",
-    "provider:kvm"
+    "provider:kvm",
+    "topic:management-cluster"
   ],
   "templating": {
     "list": []

--- a/helm/dashboards/dashboards/kvm/public/ceph-cluster-usage.json
+++ b/helm/dashboards/dashboards/kvm/public/ceph-cluster-usage.json
@@ -4929,7 +4929,10 @@
   "style": "dark",
   "tags": [
     "ceph",
-    "cluster"
+    "cluster",
+    "owner:team-rocket",
+    "topic:management-cluster",
+    "provider:kvm"
   ],
   "templating": {
     "list": [


### PR DESCRIPTION
This PR

updates the labels for dashboards owned by team rocket
See https://github.com/giantswarm/giantswarm/issues/19944

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
