### PR TITLE
update kube-mixins to 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated team labels for team-rocket
 - Add graph in Node Overview to identify emptydir growth
+- Update kube-mixins to 0.12
 
 ## [2.25.0] - 2023-03-24
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To upload a dashboard while editing, run:
 * To Update the `kubernetes-mixin` dashboards:
 
   * Follow the instructions in [giantswarm-kubernetes-mixin](https://github.com/giantswarm/giantswarm-kubernetes-mixin)
-  * Run `./scripts/sync-mixins.sh (?my-fancy-branch-or-tag)` to update the `helm/dashboards/dashboards/mixin` folder.
+  * Run `./scripts/sync-kube-mixin.sh (?my-fancy-branch-or-tag)` to update the `helm/dashboards/dashboards/mixin` folder.
 
 * To Update the `alertmanager-monitoring-mixins` dashboards:
 

--- a/helm/dashboards/dashboards/mixin/apiserver.json
+++ b/helm/dashboards/dashboards/mixin/apiserver.json
@@ -28,7 +28,7 @@
          "type": "text"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -988,7 +988,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(workqueue_adds_total{app=\"kubernetes\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name)",
+                     "expr": "sum(rate(workqueue_adds_total{app=\"kube-apiserver\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}} {{name}}",
@@ -1070,7 +1070,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(workqueue_depth{app=\"kubernetes\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name)",
+                     "expr": "sum(rate(workqueue_depth{app=\"kube-apiserver\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}} {{name}}",
@@ -1152,7 +1152,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{app=\"kubernetes\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name, le))",
+                     "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{app=\"kube-apiserver\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}} {{name}}",
@@ -1247,7 +1247,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "process_resident_memory_bytes{app=\"kubernetes\",instance=~\"$instance\", cluster_id=\"$cluster\"}",
+                     "expr": "process_resident_memory_bytes{app=\"kube-apiserver\",instance=~\"$instance\", cluster_id=\"$cluster\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}}",
@@ -1329,7 +1329,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(process_cpu_seconds_total{app=\"kubernetes\",instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])",
+                     "expr": "rate(process_cpu_seconds_total{app=\"kube-apiserver\",instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}}",
@@ -1411,7 +1411,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "go_goroutines{app=\"kubernetes\",instance=~\"$instance\", cluster_id=\"$cluster\"}",
+                     "expr": "go_goroutines{app=\"kube-apiserver\",instance=~\"$instance\", cluster_id=\"$cluster\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}}",
@@ -1467,7 +1467,8 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -1489,13 +1490,13 @@
             "allValue": null,
             "current": { },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": "cluster",
             "multi": false,
             "name": "cluster",
             "options": [ ],
-            "query": "label_values(up{app=\"kubernetes\"}, cluster_id)",
+            "query": "label_values(up{app=\"kube-apiserver\"}, cluster_id)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -1515,7 +1516,7 @@
             "multi": false,
             "name": "instance",
             "options": [ ],
-            "query": "label_values(up{app=\"kubernetes\", cluster_id=\"$cluster\"}, instance)",
+            "query": "label_values(up{app=\"kube-apiserver\", cluster_id=\"$cluster\"}, instance)",
             "refresh": 2,
             "regex": "",
             "sort": 1,

--- a/helm/dashboards/dashboards/mixin/apiserver.json
+++ b/helm/dashboards/dashboards/mixin/apiserver.json
@@ -988,7 +988,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(workqueue_adds_total{app=\"kube-apiserver\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name)",
+                     "expr": "sum(rate(workqueue_adds_total{app=\"kubernetes\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}} {{name}}",
@@ -1070,7 +1070,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(workqueue_depth{app=\"kube-apiserver\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name)",
+                     "expr": "sum(rate(workqueue_depth{app=\"kubernetes\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}} {{name}}",
@@ -1152,7 +1152,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{app=\"kube-apiserver\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name, le))",
+                     "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{app=\"kubernetes\", instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])) by (instance, name, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}} {{name}}",
@@ -1247,7 +1247,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "process_resident_memory_bytes{app=\"kube-apiserver\",instance=~\"$instance\", cluster_id=\"$cluster\"}",
+                     "expr": "process_resident_memory_bytes{app=\"kubernetes\",instance=~\"$instance\", cluster_id=\"$cluster\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}}",
@@ -1329,7 +1329,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(process_cpu_seconds_total{app=\"kube-apiserver\",instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])",
+                     "expr": "rate(process_cpu_seconds_total{app=\"kubernetes\",instance=~\"$instance\", cluster_id=\"$cluster\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}}",
@@ -1411,7 +1411,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "go_goroutines{app=\"kube-apiserver\",instance=~\"$instance\", cluster_id=\"$cluster\"}",
+                     "expr": "go_goroutines{app=\"kubernetes\",instance=~\"$instance\", cluster_id=\"$cluster\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}}",
@@ -1496,7 +1496,7 @@
             "multi": false,
             "name": "cluster",
             "options": [ ],
-            "query": "label_values(up{app=\"kube-apiserver\"}, cluster_id)",
+            "query": "label_values(up{app=\"kubernetes\"}, cluster_id)",
             "refresh": 2,
             "regex": "",
             "sort": 1,
@@ -1516,7 +1516,7 @@
             "multi": false,
             "name": "instance",
             "options": [ ],
-            "query": "label_values(up{app=\"kube-apiserver\", cluster_id=\"$cluster\"}, instance)",
+            "query": "label_values(up{app=\"kubernetes\", cluster_id=\"$cluster\"}, instance)",
             "refresh": 2,
             "regex": "",
             "sort": 1,

--- a/helm/dashboards/dashboards/mixin/cluster-total.json
+++ b/helm/dashboards/dashboards/mixin/cluster-total.json
@@ -1528,12 +1528,13 @@
          "type": "row"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [ ],
    "schemaVersion": 18,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -1631,7 +1632,7 @@
             "allValue": null,
             "current": { },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": null,
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/controller-manager.json
+++ b/helm/dashboards/dashboards/mixin/controller-manager.json
@@ -10,7 +10,7 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -139,10 +139,10 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(workqueue_adds_total{cluster_id=\"$cluster\", app=\"kube-controller-manager\", instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance, name)",
+                     "expr": "sum(rate(workqueue_adds_total{cluster_id=\"$cluster\", app=\"kube-controller-manager\", instance=~\"$instance\"}[$__rate_interval])) by (cluster_id, instance, name)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} {{name}}",
+                     "legendFormat": "{{cluster_id}} {{instance}} {{name}}",
                      "refId": "A"
                   }
                ],
@@ -234,10 +234,10 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(workqueue_depth{cluster_id=\"$cluster\", app=\"kube-controller-manager\", instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance, name)",
+                     "expr": "sum(rate(workqueue_depth{cluster_id=\"$cluster\", app=\"kube-controller-manager\", instance=~\"$instance\"}[$__rate_interval])) by (cluster_id, instance, name)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} {{name}}",
+                     "legendFormat": "{{cluster_id}} {{instance}} {{name}}",
                      "refId": "A"
                   }
                ],
@@ -329,10 +329,10 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster_id=\"$cluster\", app=\"kube-controller-manager\", instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance, name, le))",
+                     "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster_id=\"$cluster\", app=\"kube-controller-manager\", instance=~\"$instance\"}[$__rate_interval])) by (cluster_id, instance, name, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} {{name}}",
+                     "legendFormat": "{{cluster_id}} {{instance}} {{name}}",
                      "refId": "A"
                   }
                ],
@@ -937,7 +937,8 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -959,7 +960,7 @@
             "allValue": null,
             "current": { },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": "cluster",
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/k8s-resources-cluster.json
+++ b/helm/dashboards/dashboards/mixin/k8s-resources-cluster.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -49,7 +49,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "1 - sum(avg by (mode) (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=~\"idle|iowait|steal\", cluster_id=\"$cluster\"}[$__rate_interval])))",
+                     "expr": "cluster:node_cpu:ratio_rate5m{cluster_id=\"$cluster\"}",
                      "format": "time_series",
                      "instant": true,
                      "intervalFactor": 2,
@@ -639,7 +639,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$__cell_1",
+                     "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
                      "pattern": "Value #A",
                      "thresholds": [ ],
                      "type": "number",
@@ -654,7 +654,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down to workloads",
-                     "linkUrl": "/d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$__cell_1",
+                     "linkUrl": "./d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
                      "pattern": "Value #B",
                      "thresholds": [ ],
                      "type": "number",
@@ -744,7 +744,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$__cell",
+                     "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
                      "pattern": "namespace",
                      "thresholds": [ ],
                      "type": "number",
@@ -1016,7 +1016,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$__cell_1",
+                     "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
                      "pattern": "Value #A",
                      "thresholds": [ ],
                      "type": "number",
@@ -1031,7 +1031,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down to workloads",
-                     "linkUrl": "/d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$__cell_1",
+                     "linkUrl": "./d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
                      "pattern": "Value #B",
                      "thresholds": [ ],
                      "type": "number",
@@ -1121,7 +1121,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$__cell",
+                     "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
                      "pattern": "namespace",
                      "thresholds": [ ],
                      "type": "number",
@@ -1392,7 +1392,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$__cell",
+                     "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
                      "pattern": "namespace",
                      "thresholds": [ ],
                      "type": "number",
@@ -2231,7 +2231,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "ceil(sum by(namespace) (rate(container_fs_reads_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval]) + rate(container_fs_writes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval])))",
+                     "expr": "ceil(sum by(namespace) (rate(container_fs_reads_total{app=\"cadvisor\", container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval])))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
@@ -2310,7 +2310,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval]))",
+                     "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
@@ -2509,7 +2509,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$__cell",
+                     "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
                      "pattern": "namespace",
                      "thresholds": [ ],
                      "type": "number",
@@ -2529,7 +2529,7 @@
                ],
                "targets": [
                   {
-                     "expr": "sum by(namespace) (rate(container_fs_reads_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval]))",
+                     "expr": "sum by(namespace) (rate(container_fs_reads_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2538,7 +2538,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(namespace) (rate(container_fs_writes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval]))",
+                     "expr": "sum by(namespace) (rate(container_fs_writes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2547,7 +2547,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(namespace) (rate(container_fs_reads_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval]) + rate(container_fs_writes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval]))",
+                     "expr": "sum by(namespace) (rate(container_fs_reads_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2556,7 +2556,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval]))",
+                     "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2565,7 +2565,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(namespace) (rate(container_fs_writes_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval]))",
+                     "expr": "sum by(namespace) (rate(container_fs_writes_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2574,7 +2574,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\"}[$__rate_interval]))",
+                     "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2632,7 +2632,8 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -2657,7 +2658,7 @@
                "value": ""
             },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": null,
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/k8s-resources-multicluster.json
+++ b/helm/dashboards/dashboards/mixin/k8s-resources-multicluster.json
@@ -22,11 +22,14 @@
                "fill": 1,
                "format": "percentunit",
                "id": 1,
+               "interval": "1m",
                "legend": {
+                  "alignAsTable": true,
                   "avg": false,
                   "current": false,
                   "max": false,
                   "min": false,
+                  "rightSide": true,
                   "show": true,
                   "total": false,
                   "values": false
@@ -46,7 +49,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))",
+                     "expr": "cluster:node_cpu:ratio_rate5m",
                      "format": "time_series",
                      "instant": true,
                      "intervalFactor": 2,
@@ -59,7 +62,7 @@
                "title": "CPU Utilisation",
                "tooltip": {
                   "shared": false,
-                  "sort": 0,
+                  "sort": 2,
                   "value_type": "individual"
                },
                "type": "singlestat",
@@ -98,11 +101,14 @@
                "fill": 1,
                "format": "percentunit",
                "id": 2,
+               "interval": "1m",
                "legend": {
+                  "alignAsTable": true,
                   "avg": false,
                   "current": false,
                   "max": false,
                   "min": false,
+                  "rightSide": true,
                   "show": true,
                   "total": false,
                   "values": false
@@ -122,7 +128,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"}) / sum(kube_node_status_allocatable{resource=\"cpu\"})",
+                     "expr": "sum(kube_pod_container_resource_requests{app=\"kube-state-metrics\", resource=\"cpu\"}) / sum(kube_node_status_allocatable{app=\"kube-state-metrics\", resource=\"cpu\"})",
                      "format": "time_series",
                      "instant": true,
                      "intervalFactor": 2,
@@ -135,7 +141,7 @@
                "title": "CPU Requests Commitment",
                "tooltip": {
                   "shared": false,
-                  "sort": 0,
+                  "sort": 2,
                   "value_type": "individual"
                },
                "type": "singlestat",
@@ -174,11 +180,14 @@
                "fill": 1,
                "format": "percentunit",
                "id": 3,
+               "interval": "1m",
                "legend": {
+                  "alignAsTable": true,
                   "avg": false,
                   "current": false,
                   "max": false,
                   "min": false,
+                  "rightSide": true,
                   "show": true,
                   "total": false,
                   "values": false
@@ -198,7 +207,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"}) / sum(kube_node_status_allocatable{resource=\"cpu\"})",
+                     "expr": "sum(kube_pod_container_resource_limits{app=\"kube-state-metrics\", resource=\"cpu\"}) / sum(kube_node_status_allocatable{app=\"kube-state-metrics\", resource=\"cpu\"})",
                      "format": "time_series",
                      "instant": true,
                      "intervalFactor": 2,
@@ -211,7 +220,7 @@
                "title": "CPU Limits Commitment",
                "tooltip": {
                   "shared": false,
-                  "sort": 0,
+                  "sort": 2,
                   "value_type": "individual"
                },
                "type": "singlestat",
@@ -250,11 +259,14 @@
                "fill": 1,
                "format": "percentunit",
                "id": 4,
+               "interval": "1m",
                "legend": {
+                  "alignAsTable": true,
                   "avg": false,
                   "current": false,
                   "max": false,
                   "min": false,
+                  "rightSide": true,
                   "show": true,
                   "total": false,
                   "values": false
@@ -274,7 +286,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(kube_node_status_allocatable{resource=\"memory\"})",
+                     "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(node_memory_MemTotal_bytes{app=\"node-exporter\"})",
                      "format": "time_series",
                      "instant": true,
                      "intervalFactor": 2,
@@ -287,7 +299,7 @@
                "title": "Memory Utilisation",
                "tooltip": {
                   "shared": false,
-                  "sort": 0,
+                  "sort": 2,
                   "value_type": "individual"
                },
                "type": "singlestat",
@@ -326,11 +338,14 @@
                "fill": 1,
                "format": "percentunit",
                "id": 5,
+               "interval": "1m",
                "legend": {
+                  "alignAsTable": true,
                   "avg": false,
                   "current": false,
                   "max": false,
                   "min": false,
+                  "rightSide": true,
                   "show": true,
                   "total": false,
                   "values": false
@@ -350,7 +365,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"}) / sum(kube_node_status_allocatable{resource=\"memory\"})",
+                     "expr": "sum(kube_pod_container_resource_requests{app=\"kube-state-metrics\", resource=\"memory\"}) / sum(kube_node_status_allocatable{app=\"kube-state-metrics\", resource=\"memory\"})",
                      "format": "time_series",
                      "instant": true,
                      "intervalFactor": 2,
@@ -363,7 +378,7 @@
                "title": "Memory Requests Commitment",
                "tooltip": {
                   "shared": false,
-                  "sort": 0,
+                  "sort": 2,
                   "value_type": "individual"
                },
                "type": "singlestat",
@@ -402,11 +417,14 @@
                "fill": 1,
                "format": "percentunit",
                "id": 6,
+               "interval": "1m",
                "legend": {
+                  "alignAsTable": true,
                   "avg": false,
                   "current": false,
                   "max": false,
                   "min": false,
+                  "rightSide": true,
                   "show": true,
                   "total": false,
                   "values": false
@@ -426,7 +444,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"}) / sum(kube_node_status_allocatable{resource=\"memory\"})",
+                     "expr": "sum(kube_pod_container_resource_limits{app=\"kube-state-metrics\", resource=\"memory\"}) / sum(kube_node_status_allocatable{app=\"kube-state-metrics\", resource=\"memory\"})",
                      "format": "time_series",
                      "instant": true,
                      "intervalFactor": 2,
@@ -439,7 +457,7 @@
                "title": "Memory Limits Commitment",
                "tooltip": {
                   "shared": false,
-                  "sort": 0,
+                  "sort": 2,
                   "value_type": "individual"
                },
                "type": "singlestat",
@@ -489,11 +507,14 @@
                "datasource": "$datasource",
                "fill": 0,
                "id": 7,
+               "interval": "1m",
                "legend": {
+                  "alignAsTable": true,
                   "avg": false,
                   "current": false,
                   "max": false,
                   "min": false,
+                  "rightSide": true,
                   "show": true,
                   "total": false,
                   "values": false
@@ -513,7 +534,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate) by (cluster_id)",
+                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (cluster_id)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{cluster_id}}",
@@ -527,7 +548,7 @@
                "title": "CPU Usage",
                "tooltip": {
                   "shared": false,
-                  "sort": 0,
+                  "sort": 2,
                   "value_type": "individual"
                },
                "type": "graph",
@@ -577,11 +598,14 @@
                "datasource": "$datasource",
                "fill": 1,
                "id": 8,
+               "interval": "1m",
                "legend": {
+                  "alignAsTable": true,
                   "avg": false,
                   "current": false,
                   "max": false,
                   "min": false,
+                  "rightSide": true,
                   "show": true,
                   "total": false,
                   "values": false
@@ -710,7 +734,7 @@
                ],
                "targets": [
                   {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate) by (cluster_id)",
+                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (cluster_id)",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -719,7 +743,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"}) by (cluster_id)",
+                     "expr": "sum(kube_pod_container_resource_requests{app=\"kube-state-metrics\", resource=\"cpu\"}) by (cluster_id)",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -728,7 +752,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate) by (cluster_id) / sum(kube_pod_container_resource_requests{resource=\"cpu\"}) by (cluster_id)",
+                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (cluster_id) / sum(kube_pod_container_resource_requests{app=\"kube-state-metrics\", resource=\"cpu\"}) by (cluster_id)",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -737,7 +761,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"}) by (cluster_id)",
+                     "expr": "sum(kube_pod_container_resource_limits{app=\"kube-state-metrics\", resource=\"cpu\"}) by (cluster_id)",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -746,7 +770,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate) by (cluster_id) / sum(kube_pod_container_resource_limits{resource=\"cpu\"}) by (cluster_id)",
+                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (cluster_id) / sum(kube_pod_container_resource_limits{app=\"kube-state-metrics\", resource=\"cpu\"}) by (cluster_id)",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -761,7 +785,7 @@
                "title": "CPU Quota",
                "tooltip": {
                   "shared": false,
-                  "sort": 0,
+                  "sort": 2,
                   "value_type": "individual"
                },
                "transform": "table",
@@ -812,11 +836,14 @@
                "datasource": "$datasource",
                "fill": 0,
                "id": 9,
+               "interval": "1m",
                "legend": {
+                  "alignAsTable": true,
                   "avg": false,
                   "current": false,
                   "max": false,
                   "min": false,
+                  "rightSide": true,
                   "show": true,
                   "total": false,
                   "values": false
@@ -836,7 +863,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(container_memory_rss{container!=\"\"}) by (cluster_id)",
+                     "expr": "sum(container_memory_rss{app=\"cadvisor\", container!=\"\"}) by (cluster_id)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{cluster_id}}",
@@ -850,7 +877,7 @@
                "title": "Memory Usage (w/o cache)",
                "tooltip": {
                   "shared": false,
-                  "sort": 0,
+                  "sort": 2,
                   "value_type": "individual"
                },
                "type": "graph",
@@ -900,11 +927,14 @@
                "datasource": "$datasource",
                "fill": 1,
                "id": 10,
+               "interval": "1m",
                "legend": {
+                  "alignAsTable": true,
                   "avg": false,
                   "current": false,
                   "max": false,
                   "min": false,
+                  "rightSide": true,
                   "show": true,
                   "total": false,
                   "values": false
@@ -1033,7 +1063,7 @@
                ],
                "targets": [
                   {
-                     "expr": "sum(container_memory_rss{container!=\"\"}) by (cluster_id)",
+                     "expr": "sum(container_memory_rss{app=\"cadvisor\", container!=\"\"}) by (cluster_id)",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -1042,7 +1072,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"}) by (cluster_id)",
+                     "expr": "sum(kube_pod_container_resource_requests{app=\"kube-state-metrics\", resource=\"memory\"}) by (cluster_id)",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -1051,7 +1081,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum(container_memory_rss{container!=\"\"}) by (cluster_id) / sum(kube_pod_container_resource_requests{resource=\"memory\"}) by (cluster_id)",
+                     "expr": "sum(container_memory_rss{app=\"cadvisor\", container!=\"\"}) by (cluster_id) / sum(kube_pod_container_resource_requests{app=\"kube-state-metrics\", resource=\"memory\"}) by (cluster_id)",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -1060,7 +1090,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"}) by (cluster_id)",
+                     "expr": "sum(kube_pod_container_resource_limits{app=\"kube-state-metrics\", resource=\"memory\"}) by (cluster_id)",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -1069,7 +1099,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum(container_memory_rss{container!=\"\"}) by (cluster_id) / sum(kube_pod_container_resource_limits{resource=\"memory\"}) by (cluster_id)",
+                     "expr": "sum(container_memory_rss{app=\"cadvisor\", container!=\"\"}) by (cluster_id) / sum(kube_pod_container_resource_limits{app=\"kube-state-metrics\", resource=\"memory\"}) by (cluster_id)",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -1084,7 +1114,7 @@
                "title": "Requests by Cluster",
                "tooltip": {
                   "shared": false,
-                  "sort": 0,
+                  "sort": 2,
                   "value_type": "individual"
                },
                "transform": "table",
@@ -1138,7 +1168,7 @@
                "value": "default"
             },
             "hide": 0,
-            "label": null,
+            "label": "Data Source",
             "name": "datasource",
             "options": [ ],
             "query": "prometheus",

--- a/helm/dashboards/dashboards/mixin/k8s-resources-namespace.json
+++ b/helm/dashboards/dashboards/mixin/k8s-resources-namespace.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -595,7 +595,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                     "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
                      "pattern": "pod",
                      "thresholds": [ ],
                      "type": "number",
@@ -1008,7 +1008,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                     "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
                      "pattern": "pod",
                      "thresholds": [ ],
                      "type": "number",
@@ -1288,7 +1288,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                     "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
                      "pattern": "pod",
                      "thresholds": [ ],
                      "type": "number",
@@ -1957,7 +1957,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_total{container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval])))",
+                     "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
@@ -2036,7 +2036,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval]))",
+                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
@@ -2235,7 +2235,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                     "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
                      "pattern": "pod",
                      "thresholds": [ ],
                      "type": "number",
@@ -2255,7 +2255,7 @@
                ],
                "targets": [
                   {
-                     "expr": "sum by(pod) (rate(container_fs_reads_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval]))",
+                     "expr": "sum by(pod) (rate(container_fs_reads_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2264,7 +2264,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(pod) (rate(container_fs_writes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval]))",
+                     "expr": "sum by(pod) (rate(container_fs_writes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2273,7 +2273,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(pod) (rate(container_fs_reads_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval]))",
+                     "expr": "sum by(pod) (rate(container_fs_reads_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2282,7 +2282,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval]))",
+                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2291,7 +2291,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval]))",
+                     "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2300,7 +2300,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval]))",
+                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2358,7 +2358,8 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -2383,7 +2384,7 @@
                "value": ""
             },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": null,
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/k8s-resources-node.json
+++ b/helm/dashboards/dashboards/mixin/k8s-resources-node.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -783,7 +783,8 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -808,7 +809,7 @@
                "value": ""
             },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": null,
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/k8s-resources-pod.json
+++ b/helm/dashboards/dashboards/mixin/k8s-resources-pod.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -1461,7 +1461,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
+                     "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "Reads",
@@ -1469,7 +1469,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "ceil(sum by(pod) (rate(container_fs_writes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
+                     "expr": "ceil(sum by(pod) (rate(container_fs_writes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "Writes",
@@ -1548,7 +1548,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "Reads",
@@ -1556,7 +1556,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+                     "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "Writes",
@@ -1648,7 +1648,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "ceil(sum by(container) (rate(container_fs_reads_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval])))",
+                     "expr": "ceil(sum by(container) (rate(container_fs_reads_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval])))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{container}}",
@@ -1727,7 +1727,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by(container) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                     "expr": "sum by(container) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{container}}",
@@ -1946,7 +1946,7 @@
                ],
                "targets": [
                   {
-                     "expr": "sum by(container) (rate(container_fs_reads_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                     "expr": "sum by(container) (rate(container_fs_reads_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -1955,7 +1955,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(container) (rate(container_fs_writes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                     "expr": "sum by(container) (rate(container_fs_writes_total{app=\"cadvisor\",device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -1964,7 +1964,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(container) (rate(container_fs_reads_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                     "expr": "sum by(container) (rate(container_fs_reads_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -1973,7 +1973,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(container) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                     "expr": "sum by(container) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -1982,7 +1982,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(container) (rate(container_fs_writes_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                     "expr": "sum by(container) (rate(container_fs_writes_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -1991,7 +1991,7 @@
                      "step": 10
                   },
                   {
-                     "expr": "sum by(container) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{app=\"cadvisor\", container!=\"\", cluster_id=\"$cluster\",namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
+                     "expr": "sum by(container) (rate(container_fs_reads_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{app=\"cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster_id=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -2049,7 +2049,8 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -2074,7 +2075,7 @@
                "value": ""
             },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": null,
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/k8s-resources-workload.json
+++ b/helm/dashboards/dashboards/mixin/k8s-resources-workload.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -228,7 +228,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                     "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
                      "pattern": "pod",
                      "thresholds": [ ],
                      "type": "number",
@@ -557,7 +557,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                     "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
                      "pattern": "pod",
                      "thresholds": [ ],
                      "type": "number",
@@ -810,7 +810,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                     "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
                      "pattern": "pod",
                      "thresholds": [ ],
                      "type": "number",
@@ -1613,7 +1613,8 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -1638,7 +1639,7 @@
                "value": ""
             },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": null,
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/k8s-resources-workloads-namespace.json
+++ b/helm/dashboards/dashboards/mixin/k8s-resources-workloads-namespace.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -282,7 +282,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down",
-                     "linkUrl": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
+                     "linkUrl": "./d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
                      "pattern": "workload",
                      "thresholds": [ ],
                      "type": "number",
@@ -689,7 +689,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down",
-                     "linkUrl": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
+                     "linkUrl": "./d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
                      "pattern": "workload",
                      "thresholds": [ ],
                      "type": "number",
@@ -966,7 +966,7 @@
                      "link": true,
                      "linkTargetBlank": false,
                      "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster_id=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type",
+                     "linkUrl": "./d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type",
                      "pattern": "workload",
                      "thresholds": [ ],
                      "type": "number",
@@ -1784,7 +1784,8 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -1809,7 +1810,7 @@
                "value": ""
             },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": null,
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/kubelet.json
+++ b/helm/dashboards/dashboards/mixin/kubelet.json
@@ -694,7 +694,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_count{cluster_id=\"$cluster\",app=\"kubelet\",instance=~\"$instance\"}[$__rate_interval])) by (instance, le))",
+               "expr": "histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_bucket{cluster_id=\"$cluster\",app=\"kubelet\",instance=~\"$instance\"}[$__rate_interval])) by (instance, le))",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "{{instance}} pod",
@@ -1878,12 +1878,13 @@
          ]
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [ ],
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -1905,7 +1906,7 @@
             "allValue": null,
             "current": { },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": "cluster",
             "multi": false,
@@ -1927,7 +1928,7 @@
             "datasource": "$datasource",
             "hide": 0,
             "includeAll": true,
-            "label": "Data Source",
+            "label": "instance",
             "multi": false,
             "name": "instance",
             "options": [ ],

--- a/helm/dashboards/dashboards/mixin/namespace-by-pod.json
+++ b/helm/dashboards/dashboards/mixin/namespace-by-pod.json
@@ -1122,12 +1122,13 @@
          "type": "row"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [ ],
    "schemaVersion": 18,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -1149,7 +1150,7 @@
             "allValue": null,
             "current": { },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": null,
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/namespace-by-workload.json
+++ b/helm/dashboards/dashboards/mixin/namespace-by-workload.json
@@ -1334,12 +1334,13 @@
          "type": "row"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [ ],
    "schemaVersion": 18,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -1361,7 +1362,7 @@
             "allValue": null,
             "current": { },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": null,
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/persistentvolumesusage.json
+++ b/helm/dashboards/dashboards/mixin/persistentvolumesusage.json
@@ -10,7 +10,7 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -388,7 +388,8 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -410,7 +411,7 @@
             "allValue": null,
             "current": { },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": "cluster",
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/pod-total.json
+++ b/helm/dashboards/dashboards/mixin/pod-total.json
@@ -888,12 +888,13 @@
          "type": "row"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [ ],
    "schemaVersion": 18,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -915,7 +916,7 @@
             "allValue": null,
             "current": { },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": null,
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/proxy.json
+++ b/helm/dashboards/dashboards/mixin/proxy.json
@@ -10,7 +10,7 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -1006,7 +1006,8 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -1028,7 +1029,7 @@
             "allValue": null,
             "current": { },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": "cluster",
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/scheduler.json
+++ b/helm/dashboards/dashboards/mixin/scheduler.json
@@ -10,7 +10,7 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -139,31 +139,31 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(scheduler_e2e_scheduling_duration_seconds_count{cluster_id=\"$cluster\", app=\"kube-scheduler\", instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance)",
+                     "expr": "sum(rate(scheduler_e2e_scheduling_duration_seconds_count{cluster_id=\"$cluster\", app=\"kube-scheduler\", instance=~\"$instance\"}[$__rate_interval])) by (cluster_id, instance)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} e2e",
+                     "legendFormat": "{{cluster_id}} {{instance}} e2e",
                      "refId": "A"
                   },
                   {
-                     "expr": "sum(rate(scheduler_binding_duration_seconds_count{cluster_id=\"$cluster\", app=\"kube-scheduler\", instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance)",
+                     "expr": "sum(rate(scheduler_binding_duration_seconds_count{cluster_id=\"$cluster\", app=\"kube-scheduler\", instance=~\"$instance\"}[$__rate_interval])) by (cluster_id, instance)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} binding",
+                     "legendFormat": "{{cluster_id}} {{instance}} binding",
                      "refId": "B"
                   },
                   {
-                     "expr": "sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{cluster_id=\"$cluster\", app=\"kube-scheduler\", instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance)",
+                     "expr": "sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{cluster_id=\"$cluster\", app=\"kube-scheduler\", instance=~\"$instance\"}[$__rate_interval])) by (cluster_id, instance)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} scheduling algorithm",
+                     "legendFormat": "{{cluster_id}} {{instance}} scheduling algorithm",
                      "refId": "C"
                   },
                   {
-                     "expr": "sum(rate(scheduler_volume_scheduling_duration_seconds_count{cluster_id=\"$cluster\", app=\"kube-scheduler\", instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance)",
+                     "expr": "sum(rate(scheduler_volume_scheduling_duration_seconds_count{cluster_id=\"$cluster\", app=\"kube-scheduler\", instance=~\"$instance\"}[$__rate_interval])) by (cluster_id, instance)",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} volume",
+                     "legendFormat": "{{cluster_id}} {{instance}} volume",
                      "refId": "D"
                   }
                ],
@@ -242,31 +242,31 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{cluster_id=\"$cluster\", app=\"kube-scheduler\",instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance, le))",
+                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{cluster_id=\"$cluster\", app=\"kube-scheduler\",instance=~\"$instance\"}[$__rate_interval])) by (cluster_id, instance, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} e2e",
+                     "legendFormat": "{{cluster_id}} {{instance}} e2e",
                      "refId": "A"
                   },
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{cluster_id=\"$cluster\", app=\"kube-scheduler\",instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance, le))",
+                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{cluster_id=\"$cluster\", app=\"kube-scheduler\",instance=~\"$instance\"}[$__rate_interval])) by (cluster_id, instance, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} binding",
+                     "legendFormat": "{{cluster_id}} {{instance}} binding",
                      "refId": "B"
                   },
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{cluster_id=\"$cluster\", app=\"kube-scheduler\",instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance, le))",
+                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{cluster_id=\"$cluster\", app=\"kube-scheduler\",instance=~\"$instance\"}[$__rate_interval])) by (cluster_id, instance, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} scheduling algorithm",
+                     "legendFormat": "{{cluster_id}} {{instance}} scheduling algorithm",
                      "refId": "C"
                   },
                   {
-                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{cluster_id=\"$cluster\", app=\"kube-scheduler\",instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance, le))",
+                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{cluster_id=\"$cluster\", app=\"kube-scheduler\",instance=~\"$instance\"}[$__rate_interval])) by (cluster_id, instance, le))",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} volume",
+                     "legendFormat": "{{cluster_id}} {{instance}} volume",
                      "refId": "D"
                   }
                ],
@@ -871,7 +871,8 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -893,7 +894,7 @@
             "allValue": null,
             "current": { },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": "cluster",
             "multi": false,

--- a/helm/dashboards/dashboards/mixin/workload-total.json
+++ b/helm/dashboards/dashboards/mixin/workload-total.json
@@ -1046,12 +1046,13 @@
          "type": "row"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [ ],
    "schemaVersion": 18,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin",
+      "owner:team-ludacris"
    ],
    "templating": {
       "list": [
@@ -1073,7 +1074,7 @@
             "allValue": null,
             "current": { },
             "datasource": "$datasource",
-            "hide": 2,
+            "hide": 0,
             "includeAll": false,
             "label": null,
             "multi": false,


### PR DESCRIPTION
This PR updates kube-mixins to 0.12.

Related:
- https://github.com/giantswarm/giantswarm-kubernetes-mixin/pull/49
- https://github.com/giantswarm/prometheus-rules/pull/684

Updated dashboards:
- apiserver.json
- cluster-total.json
- controller-manager.json
- k8s-resources-cluster.json
- k8s-resources-multicluster.json
- k8s-resources-namespace.json
- k8s-resources-node.json
- k8s-resources-pod.json
- k8s-resources-workload.json
- k8s-resources-workloads-namespace.json
- kubelet.json
- namespace-by-pod.json
- namespace-by-workload.json
- persistentvolumesusage.json
- pod-total.json
- proxy.json
- scheduler.json
- workload-total.json

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
