### PR TITLE
fix prometheus-availability dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- prometheus availability over period
+
 ## [2.28.0] - 2023-04-20
 
 ### Added

--- a/helm/dashboards/dashboards/shared/public/prometheus-availability.json
+++ b/helm/dashboards/dashboards/shared/public/prometheus-availability.json
@@ -25,7 +25,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 92,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -95,7 +94,7 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "9.3.8",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -103,7 +102,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "max by (pod)\n(avg_over_time(kube_pod_status_ready{namespace=~\"(${cluster})-prometheus\", condition=\"true\"}[$__range]))",
+          "expr": "avg(avg_over_time(kube_pod_status_ready{namespace=~\"(${cluster})-prometheus\", condition=\"true\"}[$__range])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -306,7 +305,8 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 37,
+  "revision": 1,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [
     "owner:team-atlas",
@@ -355,6 +355,6 @@
   "timezone": "",
   "title": "Prometheus / Availability",
   "uid": "promavailability",
-  "version": 4,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR fixes prometheus-availability dashboard (https://github.com/giantswarm/roadmap/issues/1959)
Availability bar computation was broken.

- screenshots before:
![image](https://user-images.githubusercontent.com/12008875/235455214-177eafbe-ef7f-4e94-956a-bd8bcb8240c9.png)


- screenshots after:
![image](https://user-images.githubusercontent.com/12008875/235455240-eb4866d7-1c7c-4a12-8ad2-f81b8866e152.png)


<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
