### PR TITLE
added links between prometheus dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- added link from prometheus to prometheus/availability dashboard
+- added link from prometheus/availability to prometheus dashboard
+
 ## [2.28.1] - 2023-05-02
 
 ### Fixed

--- a/helm/dashboards/dashboards/shared/public/prometheus-availability.json
+++ b/helm/dashboards/dashboards/shared/public/prometheus-availability.json
@@ -25,7 +25,20 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Prometheus",
+      "tooltip": "Open Prometheus dashboard",
+      "type": "link",
+      "url": "/d/iWowmlSmk/prometheus"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {

--- a/helm/dashboards/dashboards/shared/public/prometheus.json
+++ b/helm/dashboards/dashboards/shared/public/prometheus.json
@@ -35,7 +35,20 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Availability",
+      "tooltip": "Open Prometheus/Availability dashboard",
+      "type": "link",
+      "url": "/d/promavailability/prometheus-availability"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {
@@ -221,7 +234,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.8",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -293,7 +306,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.8",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -362,7 +375,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "9.3.8",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -1088,8 +1101,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1248,8 +1260,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1611,7 +1622,7 @@
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [
     "owner:team-atlas",
@@ -1624,10 +1635,10 @@
         "current": {
           "selected": true,
           "text": [
-            "prod"
+            "All"
           ],
           "value": [
-            "prod"
+            "$__all"
           ]
         },
         "datasource": {


### PR DESCRIPTION
This PR

- adds link from prometheus to prometheus/availability dashboard
- adds link from prometheus/availability to prometheus dashboard


- screenshots before:
![image](https://user-images.githubusercontent.com/12008875/235954390-f00b680b-e232-4a7b-a84c-ba4dfe7b6a11.png)

- screenshots after:
![image](https://user-images.githubusercontent.com/12008875/235954457-c267d6b7-4412-493f-bbe0-69a6ed6a2154.png)

Notice the small "prometheus" link top-right? Clicking on it opens the main "prometheus" dashboard in a new tab, with the same parameters (selected cluster, timerange).

And the "prometheus" dashboard has the same to open the "availability" dashboard:
![image](https://user-images.githubusercontent.com/12008875/235955539-8e34590b-e0dc-472b-ad2c-91cb7a715f48.png)


<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
