### PR TITLE
Update team label of dashboards related to bigmac components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
 - Update team label of dashboards related to bigmac components.
 
 ## [2.29.0] - 2023-06-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Update team label of dashboards related to bigmac components.
+
 ## [2.29.0] - 2023-06-13
 
 ### Changed

--- a/helm/dashboards/dashboards/shared/private/api-security.json
+++ b/helm/dashboards/dashboards/shared/private/api-security.json
@@ -818,7 +818,7 @@
   "schemaVersion": 30,
   "style": "dark",
   "tags": [
-    "owner:team-rainbow",
+    "owner:team-bigmac",
     "provider:kvm",
     "provider:aws",
     "provider:azure",

--- a/helm/dashboards/dashboards/shared/public/dex.json
+++ b/helm/dashboards/dashboards/shared/public/dex.json
@@ -508,7 +508,7 @@
   "schemaVersion": 33,
   "style": "dark",
   "tags": [
-    "owner:team-rainbow",
+    "owner:team-bigmac",
     "provider:kvm",
     "provider:aws",
     "provider:azure",


### PR DESCRIPTION
This PR

- changes team label of the following dashboards from rainbow to bigmac
  - dex
  - api-security

Towards https://github.com/giantswarm/giantswarm/issues/27090

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
