### PR TITLE
add panes for cache in DNS dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `External DNS` dashboard.
+- Add Cache panes to DNS dashboard.
 
 ## [2.35.0] - 2023-07-13
 

--- a/helm/dashboards/dashboards/shared/public/dns.json
+++ b/helm/dashboards/dashboards/shared/public/dns.json
@@ -2198,6 +2198,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
+      "description": "Number of items per second that the cache has prefetched.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2282,7 +2283,7 @@
           "refId": "A"
         }
       ],
-      "title": "Prefetch",
+      "title": "Prefetchs per second",
       "type": "timeseries"
     }
   ],

--- a/helm/dashboards/dashboards/shared/public/dns.json
+++ b/helm/dashboards/dashboards/shared/public/dns.json
@@ -2223,7 +2223,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2276,8 +2276,8 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "irate(coredns_cache_prefetch_total{cluster_id=\"$cluster\", organization=\"$organization\", zones=\"$zone\"}[5m])",
-          "legendFormat": "__auto",
+          "expr": "sum by (app) (rate(coredns_cache_prefetch_total{cluster_id=\"$cluster\", organization=\"$organization\", zones=\"$zone\"}[5m]))",
+          "legendFormat": "{{ app }}",
           "range": true,
           "refId": "A"
         }

--- a/helm/dashboards/dashboards/shared/public/dns.json
+++ b/helm/dashboards/dashboards/shared/public/dns.json
@@ -1920,6 +1920,370 @@
       ],
       "title": "99th percentile DNS resolution time by node - node-local DNS cache (logarithmic) zone ${zone}",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 93
+      },
+      "id": 40,
+      "panels": [],
+      "title": "Cache",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 94
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\", type=\"success\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[5m]))",
+          "instant": false,
+          "legendFormat": "hits ratio: success",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\", type=\"denial\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[5m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "hits ratio: denial",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "1 - (sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[5m])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "miss",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "CoreDNS hits and miss ratios",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 94
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\", type=\"success\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[5m]))",
+          "instant": false,
+          "legendFormat": "hits ratio: success",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\", type=\"denial\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[5m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "hits ratio: denial",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "1 - (sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[5m])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "miss",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "NodeLocal hits and miss ratios",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 102
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "irate(coredns_cache_prefetch_total{cluster_id=\"$cluster\", organization=\"$organization\", zones=\"$zone\"}[5m])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Prefetch",
+      "type": "timeseries"
     }
   ],
   "refresh": "",


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

This PR adds 3 panes in the DNS dashboard:
- Hits and misses ratio (CoreDNS and NodeLocal)
- Prefetch rate


![image](https://github.com/giantswarm/dashboards/assets/11235884/42c88f80-e99b-469f-b3b2-16d6d149fad7)

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
