### PR TITLE
Update Kyverno webhooks rejection count panel

### DIFF
--- a/helm/dashboards/dashboards/shared/private/kyverno-health.json
+++ b/helm/dashboards/dashboards/shared/private/kyverno-health.json
@@ -1169,13 +1169,14 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "avg(apiserver_admission_webhook_rejection_count{cluster_id=\"$cluster\", name=~\".*.kyverno.svc.*\"}) by (name)",
-          "legendFormat": "__auto",
+          "expr": "avg(apiserver_admission_webhook_rejection_count{cluster_id=\"$cluster\", name=~\".*.kyverno.*\"}) by (error_type, name)",
+          "instant": false,
+          "legendFormat": "{{name}} - {{error_type}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Webhooks Rejection Count by name",
+      "title": "Webhooks Rejection Count by name and error type",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
Updates the Kyverno webhook rejection count panel and adds the error type next to the webhook to be able to tell if a request is being blocked due to admission or a webhook error. 