### PR TITLE
add cluster id to cilium metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -Fixed issues from `Loki Cost Estimate` dashboard
+-Fixed cluster id in `Cilium Metrics` dashboard
 
 ### Changed
 

--- a/helm/dashboards/dashboards/shared/public/cilium.json
+++ b/helm/dashboards/dashboards/shared/public/cilium.json
@@ -94,8 +94,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "editorMode": "code",
-          "expr": "sum(rate(cilium_errors_warnings_total{pod=~\"$pod\"}[1m])) by (pod, level) * 60",
+          "expr": "sum(rate(cilium_errors_warnings_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, level) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} ({{level}})",
@@ -204,8 +203,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "editorMode": "code",
-          "expr": "min(irate(cilium_process_cpu_seconds_total{pod=~\"$pod\"}[1m])) by (pod) * 100",
+          "expr": "min(irate(cilium_process_cpu_seconds_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min ({{pod}})",
@@ -217,8 +215,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "editorMode": "code",
-          "expr": "avg(irate(cilium_process_cpu_seconds_total{pod=~\"$pod\"}[1m])) by (pod) * 100",
+          "expr": "avg(irate(cilium_process_cpu_seconds_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg ({{pod}})",
@@ -230,8 +227,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "editorMode": "code",
-          "expr": "max(irate(cilium_process_cpu_seconds_total{pod=~\"$pod\"}[1m])) by (pod) * 100",
+          "expr": "max(irate(cilium_process_cpu_seconds_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max ({{pod}})",
@@ -369,7 +365,8 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_process_virtual_memory_bytes{pod=~\"$pod\"})",
+          "editorMode": "code",
+          "expr": "min(cilium_process_virtual_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Min Virtual Memory",
@@ -380,7 +377,8 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_process_virtual_memory_bytes{pod=~\"$pod\"})",
+          "editorMode": "code",
+          "expr": "avg(cilium_process_virtual_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Average Virtual Memory",
@@ -391,7 +389,8 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_process_virtual_memory_bytes{pod=~\"$pod\"})",
+          "editorMode": "code",
+          "expr": "max(cilium_process_virtual_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Max Virtual Memory",
@@ -489,7 +488,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_process_resident_memory_bytes{pod=~\"$pod\"})",
+          "expr": "avg(cilium_process_resident_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -501,7 +500,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_process_resident_memory_bytes{pod=~\"$pod\"})",
+          "expr": "max(cilium_process_resident_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -513,7 +512,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_process_resident_memory_bytes{pod=~\"$pod\"})",
+          "expr": "min(cilium_process_resident_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "MIN_resident_memory_bytes_min",
@@ -614,7 +613,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(cilium_process_open_fds{pod=~\"$pod\"})",
+          "expr": "sum(cilium_process_open_fds{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "all nodes",
@@ -625,7 +624,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_process_open_fds{pod=~\"$pod\"})",
+          "expr": "min(cilium_process_open_fds{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min/node",
@@ -636,7 +635,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_process_open_fds{pod=~\"$pod\"})",
+          "expr": "avg(cilium_process_open_fds{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg/node",
@@ -647,7 +646,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_process_open_fds{pod=~\"$pod\"})",
+          "expr": "max(cilium_process_open_fds{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max/node",
@@ -746,7 +745,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_bpf_maps_virtual_memory_max_bytes{pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{pod=~\"$pod\"})",
+          "expr": "avg(cilium_bpf_maps_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -759,7 +758,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_bpf_maps_virtual_memory_max_bytes{pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{pod=~\"$pod\"})",
+          "expr": "max(cilium_bpf_maps_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -772,7 +771,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_bpf_maps_virtual_memory_max_bytes{pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{pod=~\"$pod\"})",
+          "expr": "min(cilium_bpf_maps_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -870,7 +869,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "cilium_bpf_map_pressure{pod=~\"$pod\"}",
+          "expr": "cilium_bpf_map_pressure{cluster_id=\"$cluster_id\",pod=~\"$pod\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -996,7 +995,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_agent_api_process_time_seconds_sum{pod=~\"$pod\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{pod=~\"$pod\"}[1m])) by (pod, method, path)",
+          "expr": "avg(rate(cilium_agent_api_process_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}}",
@@ -1094,7 +1093,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(rate(cilium_agent_api_process_time_seconds_sum{pod=~\"$pod\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{pod=~\"$pod\"}[1m])) by (pod, method, path)",
+          "expr": "max(rate(cilium_agent_api_process_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])/rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}}",
@@ -1192,7 +1191,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{pod=~\"$pod\"}[1m])) by (pod, method, path)",
+          "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}} ",
@@ -1290,7 +1289,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(rate(cilium_agent_api_process_time_seconds_count{pod=~\"$pod\"}[1m])) by (pod, method, path)",
+          "expr": "max(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}} ",
@@ -1388,7 +1387,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{pod=~\"$pod\"}[1m])) by (pod, method, path, return_code)",
+          "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, method, path, return_code)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{return_code}} ({{method}} {{path}} )",
@@ -1486,7 +1485,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_agent_api_process_time_seconds_count{pod=~\"$pod\"}[1m])) by (pod, method, path, return_code)",
+          "expr": "sum(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, method, path, return_code)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{return_code}} ({{method}} {{path}} )",
@@ -1640,7 +1639,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, operation)",
+          "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, operation)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{operation}}",
@@ -1739,7 +1738,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(rate(cilium_bpf_syscall_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, operation)",
+          "expr": "max(rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, operation)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{operation}}",
@@ -1838,7 +1837,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_sum{pod=~\"$pod\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, operation)",
+          "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, operation)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{operation}}",
@@ -1934,7 +1933,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(rate(cilium_bpf_syscall_duration_seconds_sum{pod=~\"$pod\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, operation)",
+          "expr": "max(rate(cilium_bpf_syscall_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])/ rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, operation)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{operation}}",
@@ -2032,7 +2031,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{pod=~\"$pod\"}[5m])) by (pod, map_name, operation))",
+          "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, map_name, operation))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{map_name}} {{operation}}",
@@ -2130,7 +2129,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{pod=~\"$pod\"}[5m])) by (pod, map_name, operation))",
+          "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, map_name, operation))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{map_name}} {{operation}}",
@@ -2228,7 +2227,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_bpf_map_ops_total{k8s_app=\"cilium\",outcome=\"fail\", pod=~\"$pod\"}[5m])) by (pod, map_name, operation)",
+          "expr": "sum(rate(cilium_bpf_map_ops_total{cluster_id=\"$cluster_id\",k8s_app=\"cilium\",outcome=\"fail\", pod=~\"$pod\"}[5m])) by (pod, map_name, operation)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{map_name}} {{operation}}",
@@ -2357,7 +2356,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(kvstore_operations_total{pod=~\"$pod\"}[1m])) by (pod, scope, action)",
+          "expr": "sum(rate(kvstore_operations_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}} {{action}}",
@@ -2457,7 +2456,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(rate(kvstore_operations_total{pod=~\"$pod\"}[1m])) by (pod, scope, action)",
+          "expr": "max(rate(kvstore_operations_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}} {{action}}",
@@ -2556,7 +2555,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "topk(5, avg(rate(cilium_kvstore_operations_duration_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, action, scope))",
+          "expr": "topk(5, avg(rate(cilium_kvstore_operations_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, action, scope))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -2654,7 +2653,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "topk(5, max(rate(cilium_kvstore_operations_duration_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, action, scope))",
+          "expr": "topk(5, max(rate(cilium_kvstore_operations_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, action, scope))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -2750,7 +2749,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_kvstore_events_queue_seconds_count{pod=~\"$pod\"}[1m])) by (pod, scope, action)",
+          "expr": "avg(rate(cilium_kvstore_events_queue_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -2874,7 +2873,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_forward_count_total{pod=~\"$pod\"}[1m])) by (pod, direction)",
+          "expr": "sum(rate(cilium_forward_count_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, direction)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{direction}}",
@@ -2973,7 +2972,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_forward_bytes_total{pod=~\"$pod\"}[1m])) by (pod, direction) * 8",
+          "expr": "sum(rate(cilium_forward_bytes_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, direction) * 8",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{direction}}",
@@ -3107,7 +3106,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "min(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3119,7 +3118,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
@@ -3130,7 +3129,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\",status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -3141,7 +3140,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{status=\"deleted\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted",
@@ -3152,7 +3151,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_datapath_conntrack_gc_entries{status=\"deleted\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted max",
@@ -3286,7 +3285,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "min(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3298,7 +3297,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
@@ -3309,7 +3308,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -3320,7 +3319,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{status=\"deleted\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted",
@@ -3331,7 +3330,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_datapath_conntrack_gc_entries{status=\"deleted\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted max",
@@ -3465,7 +3464,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "min(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3477,7 +3476,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
@@ -3488,7 +3487,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -3499,7 +3498,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted",
@@ -3510,7 +3509,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_datapath_conntrack_gc_entries{status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted max",
@@ -3644,7 +3643,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "min(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3656,7 +3655,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
@@ -3667,7 +3666,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_datapath_conntrack_gc_entries{status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -3678,7 +3677,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_datapath_conntrack_gc_entries{status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted",
@@ -3689,7 +3688,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_datapath_conntrack_gc_entries{status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
+          "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "deleted max",
@@ -3792,7 +3791,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(cilium_ip_addresses{pod=~\"$pod\"}) by (pod, family)\n",
+          "expr": "sum(cilium_ip_addresses{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod, family)\n",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{family}}",
@@ -3889,7 +3888,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(cilium_datapath_conntrack_dump_resets_total{pod=~\"$pod\"}) by (pod, area, family, name)",
+          "expr": "sum(cilium_datapath_conntrack_dump_resets_total{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod, area, family, name)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{name}} {{area}} {{family}}",
@@ -3983,7 +3982,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_services_events_total{pod=~\"$pod\"}[1m])) by (pod, action)",
+          "expr": "avg(rate(cilium_services_events_total{cluster_id=\"$cluster_id\", pod=~\"$pod\"}[1m])) by (pod, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -4086,7 +4085,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(cilium_unreachable_nodes{pod=~\"$pod\"}) by (pod)",
+          "expr": "sum(cilium_unreachable_nodes{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unreachable nodes",
@@ -4097,7 +4096,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(cilium_unreachable_health_endpoints{pod=~\"$pod\"}) by (pod)",
+          "expr": "sum(cilium_unreachable_health_endpoints{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unreachable health endpoints",
@@ -4191,7 +4190,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_drop_count_total{direction=\"EGRESS\", pod=~\"$pod\"}[1m])) by (reason)",
+          "expr": "sum(rate(cilium_drop_count_total{cluster_id=\"$cluster_id\", direction=\"EGRESS\", pod=~\"$pod\"}[1m])) by (reason)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{reason}}",
@@ -4314,7 +4313,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_nodes_all_events_received_total{pod=~\"$pod\"}[1m])) by (pod, event_type, source) * 60",
+          "expr": "avg(rate(cilium_nodes_all_events_received_total{cluster_id=\"$cluster_id\", pod=~\"$pod\"}[1m])) by (pod, event_type, source) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{eventType}} {{source}}",
@@ -4408,7 +4407,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_drop_bytes_total{direction=\"EGRESS\", pod=~\"$pod\"}[1m])) by (reason) * 8",
+          "expr": "sum(rate(cilium_drop_bytes_total{cluster_id=\"$cluster_id\", direction=\"EGRESS\", pod=~\"$pod\"}[1m])) by (reason) * 8",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{reason}}",
@@ -4517,7 +4516,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_nodes_all_num{pod=~\"$pod\"}) by (pod)",
+          "expr": "avg(cilium_nodes_all_num{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Average Nodes",
@@ -4528,7 +4527,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_nodes_all_num{pod=~\"$pod\"}) by (pod)",
+          "expr": "min(cilium_nodes_all_num{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Min Nodes",
@@ -4539,7 +4538,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_nodes_all_num{pod=~\"$pod\"}) by (pod)",
+          "expr": "max(cilium_nodes_all_num{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Max Nodes",
@@ -4676,7 +4675,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_policy_l7_denied_total{pod=~\"$pod\"}[1m]))",
+          "expr": "sum(rate(cilium_policy_l7_denied_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "denied",
@@ -4687,7 +4686,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_policy_l7_forwarded_total{pod=~\"$pod\"}[1m]))",
+          "expr": "sum(rate(cilium_policy_l7_forwarded_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "forwarded",
@@ -4698,7 +4697,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_policy_l7_received_total{pod=~\"$pod\"}[1m]))",
+          "expr": "sum(rate(cilium_policy_l7_received_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "received",
@@ -4792,7 +4791,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_drop_count_total{direction=\"INGRESS\", pod=~\"$pod\"}[5m])) by (reason)",
+          "expr": "sum(rate(cilium_drop_count_total{cluster_id=\"$cluster_id\",direction=\"INGRESS\", pod=~\"$pod\"}[5m])) by (reason)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{reason}}",
@@ -4910,7 +4909,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{pod=~\"$pod\"}[1m])) by (pod, scope)",
+          "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -4922,7 +4921,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_policy_l7_parse_errors_total{pod=~\"$pod\"}) by (pod)",
+          "expr": "avg(cilium_policy_l7_parse_errors_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "parse errors",
@@ -5016,7 +5015,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_drop_bytes_total{direction=\"INGRESS\", pod=~\"$pod\"}[1m])) by (reason) * 8",
+          "expr": "sum(rate(cilium_drop_bytes_total{cluster_id=\"$cluster_id\",direction=\"INGRESS\", pod=~\"$pod\"}[1m])) by (reason) * 8",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{reason}}",
@@ -5136,7 +5135,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(rate(cilium_triggers_policy_update_call_duration_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, scope)",
+          "expr": "min(rate(cilium_triggers_policy_update_call_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min",
@@ -5147,7 +5146,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_triggers_policy_update_call_duration_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, scope)",
+          "expr": "avg(rate(cilium_triggers_policy_update_call_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
@@ -5158,7 +5157,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(rate(cilium_triggers_policy_update_call_duration_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, scope)",
+          "expr": "max(rate(cilium_triggers_policy_update_call_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -5263,7 +5262,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(rate(cilium_proxy_upstream_reply_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{pod=~\"$pod\"}[1m])) by (pod, scope)",
+          "expr": "max(rate(cilium_proxy_upstream_reply_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Max {{scope}}",
@@ -5274,7 +5273,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(rate(cilium_policy_l7_parse_errors_total{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "max(rate(cilium_policy_l7_parse_errors_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "parse errors",
@@ -5375,7 +5374,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(cilium_policy_endpoint_enforcement_status{pod=~\"$pod\"}) by (enforcement)",
+          "expr": "sum(cilium_policy_endpoint_enforcement_status{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (enforcement)",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -5488,7 +5487,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_proxy_redirects{pod=~\"$pod\"}) by (pod)",
+          "expr": "min(cilium_proxy_redirects{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min",
@@ -5499,7 +5498,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_proxy_redirects{pod=~\"$pod\"}) by (pod)",
+          "expr": "avg(cilium_proxy_redirects{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
@@ -5510,7 +5509,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_proxy_redirects{pod=~\"$pod\"}) by (pod)",
+          "expr": "max(cilium_proxy_redirects{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -5625,7 +5624,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(rate(cilium_triggers_policy_update_total{pod=~\"$pod\"}[1m])) by (pod) * 60",
+          "expr": "min(rate(cilium_triggers_policy_update_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min trigger",
@@ -5636,7 +5635,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_triggers_policy_update_total{pod=~\"$pod\"}[1m])) by (pod) * 60",
+          "expr": "avg(rate(cilium_triggers_policy_update_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "average trigger",
@@ -5647,7 +5646,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(rate(cilium_triggers_policy_update_total{pod=~\"$pod\"}[1m])) by (pod) * 60",
+          "expr": "max(rate(cilium_triggers_policy_update_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max trigger",
@@ -5776,7 +5775,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_policy{pod=~\"$pod\"}) by(pod)",
+          "expr": "min(cilium_policy{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by(pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min",
@@ -5787,7 +5786,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_policy{pod=~\"$pod\"}) by(pod)",
+          "expr": "avg(cilium_policy{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by(pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
@@ -5798,7 +5797,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_policy{pod=~\"$pod\"}) by(pod)",
+          "expr": "max(cilium_policy{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by(pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -5914,7 +5913,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_count{pod=~\"$pod\"}[1m])) by (pod, scope)",
+          "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}}",
@@ -6022,7 +6021,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "min(cilium_policy_max_revision{pod=~\"$pod\"}) by (pod)",
+          "expr": "min(cilium_policy_max_revision{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min",
@@ -6033,7 +6032,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(cilium_policy_max_revision{pod=~\"$pod\"}) by (pod)",
+          "expr": "avg(cilium_policy_max_revision{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg",
@@ -6044,7 +6043,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(cilium_policy_max_revision{pod=~\"$pod\"}) by (pod)",
+          "expr": "max(cilium_policy_max_revision{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max",
@@ -6170,7 +6169,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
+          "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{cluster_id=\"$cluster_id\",scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}}",
@@ -6266,7 +6265,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
+          "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{cluster_id=\"$cluster_id\",scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{scope}}",
@@ -6373,7 +6372,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_endpoint_regenerations_total{pod=~\"$pod\"}[30s])) by(outcome)",
+          "expr": "sum(rate(cilium_endpoint_regenerations_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[30s])) by(outcome)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -6473,7 +6472,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(cilium_endpoint_state{pod=~\"$pod\"}) by (endpoint_state)",
+          "expr": "sum(cilium_endpoint_state{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (endpoint_state)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{endpoint_state}}",
@@ -6611,7 +6610,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_controllers_runs_total{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(rate(cilium_controllers_runs_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Runs",
@@ -6622,7 +6621,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(cilium_controllers_failing{pod=~\"$pod\"}) by(pod)",
+          "expr": "sum(cilium_controllers_failing{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by(pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Failed",
@@ -6736,7 +6735,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_controllers_runs_duration_seconds_sum{pod=~\"$pod\"}[1m])) by (pod, status) / sum(rate(cilium_controllers_runs_duration_seconds_count{pod=~\"$pod\"}[1m])) by (pod, status)",
+          "expr": "sum(rate(cilium_controllers_runs_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, status) / sum(rate(cilium_controllers_runs_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, status)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{status}}",
@@ -6866,7 +6865,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_k8s_client_api_latency_time_seconds_sum{pod=~\"$pod\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{pod=~\"$pod\"}[1m])) by (pod, method, path)",
+          "expr": "avg(rate(cilium_k8s_client_api_latency_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}}",
@@ -6964,7 +6963,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(rate(cilium_k8s_client_api_latency_time_seconds_sum{pod=~\"$pod\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{pod=~\"$pod\"}[1m])) by (pod, method, path)",
+          "expr": "max(rate(cilium_k8s_client_api_latency_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])/rate(cilium_k8s_client_api_latency_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}}",
@@ -7062,7 +7061,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_k8s_client_api_latency_time_seconds_count{pod=~\"$pod\"}[1m])) by (pod, method, path)",
+          "expr": "sum(rate(cilium_k8s_client_api_latency_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, method, path)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{path}}",
@@ -7160,7 +7159,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_k8s_client_api_calls_total{pod=~\"$pod\"}[1m])) by (pod, method, return_code)",
+          "expr": "sum(rate(cilium_k8s_client_api_calls_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[1m])) by (pod, method, return_code)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{method}} {{return_code}}",
@@ -7257,7 +7256,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{equal=\"true\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"true\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7353,7 +7352,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{equal=\"true\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"true\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7449,7 +7448,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{equal=\"false\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action, valid)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"false\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action, valid)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7545,7 +7544,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "sum(rate(cilium_kubernetes_events_received_total{equal=\"false\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
+          "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"false\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} {{scope}}",
@@ -7641,7 +7640,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_kubernetes_events_total{scope=\"CiliumNetworkPolicy\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"CiliumNetworkPolicy\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -7741,7 +7740,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_kubernetes_events_total{scope=\"NetworkPolicy\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"NetworkPolicy\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -7841,7 +7840,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_kubernetes_events_total{scope=\"Pod\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Pod\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -7941,7 +7940,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_kubernetes_events_total{scope=\"Node\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Node\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}} avg",
@@ -8037,7 +8036,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_kubernetes_events_total{scope=\"Service\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Service\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -8133,7 +8132,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_kubernetes_events_total{scope=\"Endpoint\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Endpoint\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -8229,7 +8228,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(cilium_kubernetes_events_total{scope=\"Namespace\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
+          "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Namespace\", pod=~\"$pod\"}[1m])) by (pod, action) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{action}}",
@@ -8362,6 +8361,6 @@
   "timezone": "utc",
   "title": "Cilium Metrics",
   "uid": "vtuWtdumz",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/helm/dashboards/dashboards/shared/public/cilium.json
+++ b/helm/dashboards/dashboards/shared/public/cilium.json
@@ -365,7 +365,6 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "editorMode": "code",
           "expr": "min(cilium_process_virtual_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
@@ -377,7 +376,6 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "editorMode": "code",
           "expr": "avg(cilium_process_virtual_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,
@@ -389,7 +387,6 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "editorMode": "code",
           "expr": "max(cilium_process_virtual_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 1,


### PR DESCRIPTION
This PR

adds the cluster id to all expressions so you can select data by cluster id.

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md in an end-user friendly language.