### PR TITLE
Align owner tags in Grafana cloud dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Align owner tags in Grafana cloud dashboards to format `owner:TEAM-NAME`.
+
 ## [2.37.0] - 2023-08-18
 
 ### Fixed
 
--Fixed issues from `Loki Cost Estimate` dashboard
--Fixed cluster id in `Cilium Metrics` dashboard
+- Fixed issues from `Loki Cost Estimate` dashboard
+- Fixed cluster id in `Cilium Metrics` dashboard
 
 ### Changed
 

--- a/dashboards/docker-actions.jsonnet
+++ b/dashboards/docker-actions.jsonnet
@@ -4,7 +4,7 @@ local stdlib = import 'stdlib.jsonnet';
 stdlib.dashboard(
   'Docker Actions',
   'docker-actions',
-  ['honeybadger'],
+  ['owner:team-honeybadger'],
   time_from='now-7d',
 )
 

--- a/dashboards/grafana-analytics.jsonnet
+++ b/dashboards/grafana-analytics.jsonnet
@@ -4,7 +4,7 @@ local stdlib = import 'stdlib.jsonnet';
 stdlib.dashboard(
   'Grafana Analytics',
   'grafana-analytics',
-  ['atlas'],
+  ['owner:team-atlas'],
   time_from='now-7d',
 )
 

--- a/dashboards/metrics.jsonnet
+++ b/dashboards/metrics.jsonnet
@@ -4,7 +4,7 @@ local stdlib = import 'stdlib.jsonnet';
 stdlib.dashboard(
   'Metrics',
   'metrics',
-  ['atlas'],
+  ['owner:team-atlas'],
   time_from='now-7d',
 )
 

--- a/dashboards/service-level.jsonnet
+++ b/dashboards/service-level.jsonnet
@@ -24,7 +24,7 @@ local burnRateChart(title, queries) =
 stdlib.dashboard(
   'Service Level',
   'service-level',
-  ['atlas'],
+  ['owner:team-atlas'],
 )
 
 .addTemplates([


### PR DESCRIPTION
This PR brings all owner tags into the format `owner:TEAM-NAME`, so that dashboards can be discovered by owner team name in a robust way.

Towards https://github.com/giantswarm/giantswarm/issues/27935

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
