### PR TITLE
Prometheus dashboard: logs panel and restart logs annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Prometheus dashboard: logs panel and restart logs annotation
+
 ## [2.40.0] - 2023-08-24
 
 ### Added

--- a/helm/dashboards/dashboards/shared/public/prometheus.json
+++ b/helm/dashboards/dashboards/shared/public/prometheus.json
@@ -29,12 +29,26 @@
         "iconColor": "red",
         "name": "prometheus restarts",
         "titleFormat": "{{pod}} restarted"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "enable": true,
+        "expr": "{app=\"prometheus\", instance=~\"$cluster\"} |= `Starting Prometheus Server`",
+        "iconColor": "green",
+        "instant": false,
+        "name": "Prometheus Start logs",
+        "textFormat": "{{instance}}",
+        "titleFormat": "Prometheus Start log"
       }
     ]
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": 67,
   "links": [
     {
       "asDropdown": false,
@@ -52,12 +66,63 @@
   "liveNow": false,
   "panels": [
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 0
+      },
+      "id": 33,
+      "panels": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 34,
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": false,
+            "sortOrder": "Descending",
+            "wrapLogMessage": false
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "P8E80F9AEF21F6940"
+              },
+              "editorMode": "code",
+              "expr": "{app=\"prometheus\", instance=~\"$cluster\"}",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Pronmetheus logs",
+          "type": "logs"
+        }
+      ],
+      "title": "Logs",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
       },
       "id": 19,
       "panels": [],
@@ -128,7 +193,7 @@
         "h": 7,
         "w": 13,
         "x": 0,
-        "y": 1
+        "y": 2
       },
       "id": 4,
       "links": [],
@@ -215,7 +280,7 @@
         "h": 7,
         "w": 4,
         "x": 13,
-        "y": 1
+        "y": 2
       },
       "id": 13,
       "links": [],
@@ -234,7 +299,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
@@ -288,7 +353,7 @@
         "h": 7,
         "w": 3,
         "x": 17,
-        "y": 1
+        "y": 2
       },
       "id": 21,
       "options": {
@@ -306,7 +371,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
@@ -358,7 +423,7 @@
         "h": 7,
         "w": 4,
         "x": 20,
-        "y": 1
+        "y": 2
       },
       "id": 31,
       "options": {
@@ -375,7 +440,7 @@
         },
         "textMode": "value_and_name"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
@@ -457,7 +522,7 @@
         "h": 7,
         "w": 13,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "id": 5,
       "links": [],
@@ -589,7 +654,7 @@
         "h": 7,
         "w": 11,
         "x": 13,
-        "y": 8
+        "y": 9
       },
       "id": 6,
       "links": [],
@@ -663,7 +728,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 16
       },
       "id": 17,
       "panels": [],
@@ -787,7 +852,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 17
       },
       "id": 8,
       "links": [],
@@ -986,7 +1051,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 24
       },
       "id": 9,
       "links": [],
@@ -1101,7 +1166,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1170,7 +1236,7 @@
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 31
       },
       "id": 32,
       "links": [],
@@ -1260,7 +1326,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1276,7 +1343,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 35
       },
       "id": 15,
       "options": {
@@ -1314,7 +1381,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 41
       },
       "id": 25,
       "panels": [
@@ -1349,7 +1416,7 @@
             "h": 12,
             "w": 8,
             "x": 0,
-            "y": 37
+            "y": 45
           },
           "id": 23,
           "options": {
@@ -1420,7 +1487,7 @@
             "h": 12,
             "w": 8,
             "x": 8,
-            "y": 37
+            "y": 45
           },
           "id": 26,
           "options": {
@@ -1491,7 +1558,7 @@
             "h": 12,
             "w": 8,
             "x": 16,
-            "y": 37
+            "y": 45
           },
           "id": 27,
           "options": {
@@ -1541,7 +1608,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 42
       },
       "id": 29,
       "panels": [
@@ -1576,7 +1643,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 50
+            "y": 58
           },
           "id": 30,
           "options": {


### PR DESCRIPTION
This PR updates prometheus dashboard with:
- annotation for "starting" logs - more precise than annotation based on metrics
- a (folded) panel for logs

Screenshot before:
![image](https://github.com/giantswarm/dashboards/assets/12008875/fe59a2d4-7ad5-467c-9cb1-db9fcb02f87f)

Screenshot after:
![image](https://github.com/giantswarm/dashboards/assets/12008875/5ffa0618-c77e-42c6-a680-ec3039a2ae59)

Screenshot with logs panel unfolded, and filtered on one cluster:
![image](https://github.com/giantswarm/dashboards/assets/12008875/54083bbc-0fcb-4bd0-b59e-1d68c3fc9b11)


Notes:
- annotations and logs are filtered according to the "cluster" dropdown.
- previous annotation is kept because not all installs have Loki
- Number of restarts is still based on metrics computation because not all installs have logs

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.