### PR TITLE
fix typo in Prometheus dashboard

### DIFF
--- a/helm/dashboards/dashboards/shared/public/prometheus.json
+++ b/helm/dashboards/dashboards/shared/public/prometheus.json
@@ -109,7 +109,7 @@
               "refId": "A"
             }
           ],
-          "title": "Pronmetheus logs",
+          "title": "Prometheus logs",
           "type": "logs"
         }
       ],


### PR DESCRIPTION
Just fixing a typo in the log panel on the Prometheus dashboard

![image](https://github.com/giantswarm/dashboards/assets/6536819/06de2fdd-4cad-48fe-8fa0-29e6222822e1)
