### PR TITLE
remotewrite: add url filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- prometheus remote-writes: filter on URL
+
 ## [3.0.0] - 2023-10-11
 
 ### Changed

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/prometheus-remote-write.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/prometheus-remote-write.json
@@ -79,7 +79,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "(\n  prometheus_remote_storage_highest_timestamp_in_seconds{cluster_id=~\"$cluster\", instance=~\"$instance\"} \n-  \n  ignoring(remote_name, url) group_right(instance) (prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster_id=~\"$cluster\", instance=~\"$instance\"} != 0)\n)\n",
+              "expr": "(\n  prometheus_remote_storage_highest_timestamp_in_seconds{cluster_id=~\"$cluster\", instance=~\"$instance\"} \n-  \n  ignoring(remote_name, url) group_right(instance) (prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"} != 0)\n)\n",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -160,7 +160,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "clamp_min(\n  rate(prometheus_remote_storage_highest_timestamp_in_seconds{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m])  \n- \n  ignoring (remote_name, url) group_right(instance) rate(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m])\n, 0)\n",
+              "expr": "clamp_min(\n  rate(prometheus_remote_storage_highest_timestamp_in_seconds{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m])  \n- \n  ignoring (remote_name, url) group_right(instance) rate(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}[5m])\n, 0)\n",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -254,7 +254,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(\n  prometheus_remote_storage_samples_in_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m])\n- \n  ignoring(remote_name, url) group_right(instance) (rate(prometheus_remote_storage_succeeded_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m]) or rate(prometheus_remote_storage_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m]))\n- \n  (rate(prometheus_remote_storage_dropped_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m]) or rate(prometheus_remote_storage_samples_dropped_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m]))\n",
+              "expr": "rate(\n  prometheus_remote_storage_samples_in_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m])\n- \n  ignoring(remote_name, url) group_right(instance) (rate(prometheus_remote_storage_succeeded_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}[5m]) or rate(prometheus_remote_storage_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}[5m]))\n- \n  (rate(prometheus_remote_storage_dropped_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}[5m]) or rate(prometheus_remote_storage_samples_dropped_total{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}[5m]))\n",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -349,7 +349,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "prometheus_remote_storage_shards{cluster_id=~\"$cluster\", instance=~\"$instance\"}",
+              "expr": "prometheus_remote_storage_shards{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -430,7 +430,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "prometheus_remote_storage_shards_max{cluster_id=~\"$cluster\", instance=~\"$instance\"}",
+              "expr": "prometheus_remote_storage_shards_max{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -511,7 +511,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "prometheus_remote_storage_shards_min{cluster_id=~\"$cluster\", instance=~\"$instance\"}",
+              "expr": "prometheus_remote_storage_shards_min{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -592,7 +592,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "prometheus_remote_storage_shards_desired{cluster_id=~\"$cluster\", instance=~\"$instance\"}",
+              "expr": "prometheus_remote_storage_shards_desired{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -686,7 +686,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "prometheus_remote_storage_shard_capacity{cluster_id=~\"$cluster\", instance=~\"$instance\"}",
+              "expr": "prometheus_remote_storage_shard_capacity{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -767,7 +767,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "prometheus_remote_storage_pending_samples{cluster_id=~\"$cluster\", instance=~\"$instance\"} or prometheus_remote_storage_samples_pending{cluster_id=~\"$cluster\", instance=~\"$instance\"}",
+              "expr": "prometheus_remote_storage_pending_samples{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"} or prometheus_remote_storage_samples_pending{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -1036,7 +1036,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(prometheus_remote_storage_dropped_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m]) or rate(prometheus_remote_storage_samples_dropped_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m])",
+              "expr": "rate(prometheus_remote_storage_dropped_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m]) or rate(prometheus_remote_storage_samples_dropped_total{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -1117,7 +1117,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(prometheus_remote_storage_failed_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m])",
+              "expr": "rate(prometheus_remote_storage_failed_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -1198,7 +1198,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(prometheus_remote_storage_retried_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m]) or rate(prometheus_remote_storage_samples_retried_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m])",
+              "expr": "rate(prometheus_remote_storage_retried_samples_total{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}[5m]) or rate(prometheus_remote_storage_samples_retried_total{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",
@@ -1279,7 +1279,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(prometheus_remote_storage_enqueue_retries_total{cluster_id=~\"$cluster\", instance=~\"$instance\"}[5m])",
+              "expr": "rate(prometheus_remote_storage_enqueue_retries_total{cluster_id=~\"$cluster\", instance=~\"$instance\", url=~\"$url\"}[5m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cluster_id}}:{{instance}} {{remote_name}}:{{url}}",


### PR DESCRIPTION
Add url filtering in remotewrites dashboard.

All URLs:
![image](https://github.com/giantswarm/dashboards/assets/12008875/96ddc6c7-da57-45c0-bcae-78a8b53e2703)
Only prometheus:
![image](https://github.com/giantswarm/dashboards/assets/12008875/613448f3-eb4e-4aa9-95ce-c2598eb60a08)
Only mimir:
![image](https://github.com/giantswarm/dashboards/assets/12008875/b73438e8-8df7-40c1-847c-5ec8369ecbcf)


Not much to see here, but the impact is much bigger on big clusters with lots of WCs, especially if customers have their own remotewrites.


### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
