### PR TITLE
Add public dashboard: Container images from docker.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Public dashboard: Container images from docker.io
+
 ## [3.3.0] - 2023-11-09
 
 ### Added

--- a/helm/dashboards/dashboards/mixin/docker-io-images.json
+++ b/helm/dashboards/dashboards/mixin/docker-io-images.json
@@ -135,7 +135,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(kube_pod_container_info{image=~\"docker.io.*\",image!~\".*giantswarm.*\",cluster_type=\"workload_cluster\"})",
+          "expr": "sum(kube_pod_container_info{image=~\"docker.io.*\",image!~\".*/giantswarm/.*\",cluster_type=\"workload_cluster\"} or kube_pod_init_container_info{image=~\"docker.io.*\",image!~\".*/giantswarm/.*\",cluster_type=\"workload_cluster\"})",
           "instant": false,
           "legendFormat": "Total",
           "range": true,
@@ -228,7 +228,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(kube_pod_container_info{image=~\"docker.io.*\",image!~\".*giantswarm.*\",cluster_type=\"workload_cluster\"}) by (organization, cluster_id, namespace, container, image)",
+          "expr": "sum(kube_pod_container_info{image=~\"docker.io.*\",image!~\".*giantswarm.*\",cluster_type=\"workload_cluster\"} or kube_pod_init_container_info{image=~\"docker.io.*\",image!~\".*giantswarm.*\",cluster_type=\"workload_cluster\"}) by (organization, cluster_id, namespace, pod, container, image)",
           "format": "table",
           "instant": true,
           "legendFormat": "Total",
@@ -245,13 +245,14 @@
               "Time": true
             },
             "indexByName": {
-              "Time": 6,
-              "Value": 5,
+              "Time": 7,
+              "Value": 6,
               "cluster_id": 2,
-              "container": 4,
+              "container": 5,
               "image": 0,
               "namespace": 3,
-              "organization": 1
+              "organization": 1,
+              "pod": 4
             },
             "renameByName": {
               "Time": "",
@@ -260,7 +261,8 @@
               "container": "Container name",
               "image": "Image",
               "namespace": "Namespace",
-              "organization": "Organization"
+              "organization": "Organization",
+              "pod": "Pod"
             }
           }
         }
@@ -350,7 +352,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(kube_pod_container_info{image=~\"docker.io.*\",image!~\".*giantswarm.*\",cluster_type=\"workload_cluster\"}) by (image)",
+          "expr": "sum(kube_pod_container_info{image=~\"docker.io.*\",image!~\".*/giantswarm/.*\",cluster_type=\"workload_cluster\"} or kube_pod_init_container_info{image=~\"docker.io.*\",image!~\".*/giantswarm/.*\",cluster_type=\"workload_cluster\"}) by (image)",
           "format": "table",
           "instant": true,
           "legendFormat": "Total",
@@ -407,6 +409,6 @@
   "timezone": "utc",
   "title": "Container images from docker.io",
   "uid": "be4cd321-9c4c-4447-b060-fc875c089f5e",
-  "version": 6,
+  "version": 7,
   "weekStart": ""
 }

--- a/helm/dashboards/dashboards/mixin/docker-io-images.json
+++ b/helm/dashboards/dashboards/mixin/docker-io-images.json
@@ -161,6 +161,7 @@
             "cellOptions": {
               "type": "auto"
             },
+            "filterable": true,
             "inspect": false
           },
           "mappings": [],
@@ -285,6 +286,7 @@
             "cellOptions": {
               "type": "auto"
             },
+            "filterable": true,
             "inspect": false
           },
           "mappings": [],
@@ -409,6 +411,6 @@
   "timezone": "utc",
   "title": "Container images from docker.io",
   "uid": "be4cd321-9c4c-4447-b060-fc875c089f5e",
-  "version": 7,
+  "version": 9,
   "weekStart": ""
 }

--- a/helm/dashboards/dashboards/mixin/docker-io-images.json
+++ b/helm/dashboards/dashboards/mixin/docker-io-images.json
@@ -410,7 +410,7 @@
   "timepicker": {},
   "timezone": "utc",
   "title": "Container images from docker.io",
-  "uid": "be4cd321-9c4c-4447-b060-fc875c089f5e",
+  "uid": "docker-io-images",
   "version": 9,
   "weekStart": ""
 }

--- a/helm/dashboards/dashboards/mixin/docker-io-images.json
+++ b/helm/dashboards/dashboards/mixin/docker-io-images.json
@@ -1,0 +1,412 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Helps to identify workloads using images from Docker Hub (docker.io)",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 118,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# Images from docker.io\n\nThis dashboard should help you identify containers using images from `docker.io`. Images from the `giantswarm` registry namespace (`docker.io/giantswarm/*`) are filtered out. If there is no data shown, this means that none of the containers in this installation is using a docker.io image.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.1.5",
+      "title": "About this dashboard",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Count of all containers in workload clusters using images from docker.io, excluding those with prefix \"docker.io/giantswarm\".",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 6,
+      "interval": "1m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_container_info{image=~\"docker.io.*\",image!~\".*giantswarm.*\",cluster_type=\"workload_cluster\"})",
+          "instant": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Containers over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Details of all containers in workload clusters using images from docker.io, excluding those with prefix \"docker.io/giantswarm\".",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Image"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 314
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 7,
+      "interval": "1m",
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Namespace"
+          }
+        ]
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(kube_pod_container_info{image=~\"docker.io.*\",image!~\".*giantswarm.*\",cluster_type=\"workload_cluster\"}) by (organization, cluster_id, namespace, container, image)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "Total",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Container details",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Time": 6,
+              "Value": 5,
+              "cluster_id": 2,
+              "container": 4,
+              "image": 0,
+              "namespace": 3,
+              "organization": 1
+            },
+            "renameByName": {
+              "Time": "",
+              "Value": "Count",
+              "cluster_id": "Cluster",
+              "container": "Container name",
+              "image": "Image",
+              "namespace": "Namespace",
+              "organization": "Organization"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "A flat list of the images used and the number of containers using the image",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Image"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 314
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 8,
+      "interval": "1m",
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Image"
+          }
+        ]
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(kube_pod_container_info{image=~\"docker.io.*\",image!~\".*giantswarm.*\",cluster_type=\"workload_cluster\"}) by (image)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "Total",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Image list",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Time": 6,
+              "Value": 5,
+              "cluster_id": 2,
+              "container": 4,
+              "image": 0,
+              "namespace": 3,
+              "organization": 1
+            },
+            "renameByName": {
+              "Time": "",
+              "Value": "Container count",
+              "cluster_id": "Cluster",
+              "container": "Container name",
+              "image": "Image",
+              "namespace": "Namespace",
+              "organization": "Organization"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "owner:team-honeybadger"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "Container images from docker.io",
+  "uid": "be4cd321-9c4c-4447-b060-fc875c089f5e",
+  "version": 6,
+  "weekStart": ""
+}


### PR DESCRIPTION
This PR adds a public dashboard "Container images from docker.io" for customers to track their use of images hosted on `docker.io`.

Context: https://github.com/giantswarm/giantswarm/issues/28933

<details>
<summary>Screenshots</summary>

From gorilla

<img width="1423" alt="image" src="https://github.com/giantswarm/dashboards/assets/273727/8333e7c8-f4b8-46a5-85b6-26afba980a90">

<img width="1419" alt="image" src="https://github.com/giantswarm/dashboards/assets/273727/26789359-e0d9-4a10-b6e7-09a00d7ea7c2">

<img width="1423" alt="image" src="https://github.com/giantswarm/dashboards/assets/273727/1e25c7c4-7e72-484b-be34-81592e4da395">

</details>

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
