### PR TITLE
Add three stat panels to "Container images from docker.io" dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add three stat panels to "Container images from docker.io" dashboard
+
 ## [3.4.1] - 2023-11-20
 
 ### Fixed

--- a/helm/dashboards/dashboards/mixin/docker-io-images.json
+++ b/helm/dashboards/dashboards/mixin/docker-io-images.json
@@ -29,8 +29,8 @@
         "uid": "PBFA97CFB590B2093"
       },
       "gridPos": {
-        "h": 4,
-        "w": 24,
+        "h": 5,
+        "w": 12,
         "x": 0,
         "y": 0
       },
@@ -47,6 +47,201 @@
       "pluginVersion": "10.1.5",
       "title": "About this dashboard",
       "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Number of all containers running in workload clusters",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(kube_pod_container_info or kube_pod_init_container_info)",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Containers total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Number of containers in workload clusters with image from docker.io",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(kube_pod_container_info{image_spec=~\"docker.io.*\",image_spec!~\".*/giantswarm/.*\",cluster_type=\"workload_cluster\"} or kube_pod_init_container_info{image_spec=~\"docker.io.*\",image_spec!~\".*/giantswarm/.*\",cluster_type=\"workload_cluster\"})",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Containers from docker.io",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Percentage of containers in workload clusters with image from docker.io",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(kube_pod_container_info{image_spec=~\"docker.io.*\",image_spec!~\".*/giantswarm/.*\",cluster_type=\"workload_cluster\"} or kube_pod_init_container_info{image_spec=~\"docker.io.*\",image_spec!~\".*/giantswarm/.*\",cluster_type=\"workload_cluster\"}) / sum(kube_pod_container_info or kube_pod_init_container_info)",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Share of containers from docker.io",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -112,7 +307,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 5
       },
       "id": 6,
       "interval": "1m",
@@ -198,7 +393,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 14
       },
       "id": 7,
       "interval": "1m",
@@ -323,7 +518,7 @@
         "h": 13,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 26
       },
       "id": 8,
       "interval": "1m",
@@ -404,13 +599,13 @@
     "list": []
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "utc",
   "title": "Container images from docker.io",
   "uid": "docker-io-images",
-  "version": 9,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28933

This PR enhances the dashboard by adding these stat panels:

![image](https://github.com/giantswarm/dashboards/assets/273727/23e907f0-4bd4-487a-b84b-a42d805230bd)


### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
