### PR TITLE
Update etcd backup dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Better description and small spacing fixes in etcd-backup dashboard
+
 ## [3.5.0] - 2023-11-24
 
 ### Changed

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-backup.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-backup.json
@@ -15,16 +15,12 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1637070444710,
+  "iteration": 1703063641000,
   "links": [],
   "panels": [
     {
       "collapsed": false,
       "datasource": "default",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -33,6 +29,13 @@
       },
       "id": 42,
       "panels": [],
+      "targets": [
+        {
+          "datasource": "default",
+          "refId": "A"
+        }
+      ],
+      "title": "Backup metrics",
       "type": "row"
     },
     {
@@ -41,6 +44,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "default",
+      "description": "Size of the etcd snapshot archive.",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -73,7 +77,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -84,15 +88,14 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "default",
           "expr": "avg by (tenant_cluster_id) (etcd_backup_size_bytes)",
           "legendFormat": "{{tenant_cluster_id}}",
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Backup file size",
       "tooltip": {
         "shared": true,
@@ -101,33 +104,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "decbytes",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -136,6 +131,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "default",
+      "description": "The time it took to take the etcd snapshot.",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -168,7 +164,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -178,15 +174,14 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "default",
           "expr": "avg by (tenant_cluster_id) (etcd_backup_creation_time_ms)",
           "legendFormat": "{{tenant_cluster_id}}",
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Backup Creation Time",
       "tooltip": {
         "shared": true,
@@ -195,33 +190,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "ms",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -230,6 +217,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "default",
+      "description": "The time it took to encrypt the backup, if encryption is enabled.",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -262,7 +250,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -272,15 +260,14 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "default",
           "expr": "avg by (tenant_cluster_id) (etcd_backup_encryption_time_ms)",
           "legendFormat": "{{tenant_cluster_id}}",
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Encryption Time",
       "tooltip": {
         "shared": true,
@@ -289,33 +276,25 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "ms",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -324,6 +303,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "default",
+      "description": "The time it took to upload the backup archive to the S3 bucket. ",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -356,7 +336,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -366,15 +346,14 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "default",
           "expr": "avg by (tenant_cluster_id) (etcd_backup_upload_time_ms)",
           "legendFormat": "{{tenant_cluster_id}}",
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Upload Time",
       "tooltip": {
         "shared": true,
@@ -383,42 +362,30 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "ms",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
       "collapsed": false,
       "datasource": "default",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -427,11 +394,16 @@
       },
       "id": 48,
       "panels": [],
-      "title": "Management cluster",
+      "targets": [
+        {
+          "datasource": "default",
+          "refId": "A"
+        }
+      ],
+      "title": "Management cluster (Vintage only)",
       "type": "row"
     },
     {
-      "cacheTimeout": null,
       "datasource": "default",
       "fieldConfig": {
         "defaults": {
@@ -469,12 +441,11 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
+        "w": 6,
         "x": 0,
         "y": 10
       },
       "id": 44,
-      "interval": null,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -490,23 +461,23 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
+          "datasource": "default",
           "expr": "(count(sum(max_over_time(cluster_service_cluster_info{}[$__range])) by (cluster_id)) OR on() vector(0)) + (count(count(max_over_time(cluster_operator_cluster_status{}[$__range])) by (cluster_id)) OR on() vector(0)) - (count(count(max_over_time(cluster_operator_cluster_status{status=\"Deleting\"}[$__range]) == 1) by (cluster_id)) OR on() vector(0))",
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Number of Workload Clusters",
       "type": "stat"
     },
     {
-      "cacheTimeout": null,
       "datasource": "default",
+      "description": "The count of non-management cluster etcd backups.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -543,8 +514,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 3,
+        "w": 6,
+        "x": 6,
         "y": 10
       },
       "id": 46,
@@ -564,11 +535,13 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
+          "datasource": "default",
           "exemplar": true,
           "expr": "count(count (etcd_backup_latest_success{tenant_cluster_id != \"ManagementCluster\"}) by (tenant_cluster_id))",
           "interval": "",
@@ -576,51 +549,39 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Count of TC ETCD Backups",
       "type": "stat"
     },
     {
       "datasource": "default",
       "gridPos": {
-        "h": 4,
-        "w": 17,
-        "x": 6,
-        "y": 10
-      },
-      "id": 55,
-      "options": {
-        "content": "\n\n\n",
-        "mode": "markdown"
-      },
-      "pluginVersion": "8.0.3",
-      "timeFrom": null,
-      "timeShift": null,
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "datasource": "default",
-      "gridPos": {
         "h": 2,
-        "w": 3,
+        "w": 1,
         "x": 0,
         "y": 14
       },
       "id": 39,
       "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
         "content": "# V2\n\n\n\n",
         "mode": "markdown"
       },
-      "pluginVersion": "8.0.3",
-      "timeFrom": null,
-      "timeShift": null,
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": "default",
+          "refId": "A"
+        }
+      ],
       "type": "text"
     },
     {
-      "cacheTimeout": null,
       "datasource": "default",
+      "description": "The last time a backup was scheduled, whether successful or not.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -656,12 +617,11 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 6,
-        "x": 3,
+        "w": 5,
+        "x": 1,
         "y": 14
       },
       "id": 124,
-      "interval": null,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -677,11 +637,13 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
+          "datasource": "default",
           "exemplar": true,
           "expr": "max(etcd_backup_latest_attempt{tenant_cluster_id=\"ManagementCluster\",etcd_version=\"V2\"}*1000)",
           "hide": false,
@@ -690,14 +652,12 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Latest backup attempt",
+      "title": "Latest backup schedule",
       "type": "stat"
     },
     {
-      "cacheTimeout": null,
       "datasource": "default",
+      "description": "Date of the latest backup completed successfully. This is the time the backup was taken, not when it finished uploading.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -734,11 +694,10 @@
       "gridPos": {
         "h": 2,
         "w": 6,
-        "x": 9,
+        "x": 6,
         "y": 14
       },
       "id": 33,
-      "interval": null,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -754,11 +713,13 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
+          "datasource": "default",
           "exemplar": true,
           "expr": "max(etcd_backup_latest_success{tenant_cluster_id=\"ManagementCluster\",etcd_version=\"V2\"}*1000)",
           "hide": false,
@@ -767,8 +728,6 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Latest successful backup",
       "type": "stat"
     },
@@ -776,23 +735,32 @@
       "datasource": "default",
       "gridPos": {
         "h": 2,
-        "w": 3,
+        "w": 1,
         "x": 0,
         "y": 16
       },
       "id": 40,
       "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
         "content": "# V3\n\n\n\n",
         "mode": "markdown"
       },
-      "pluginVersion": "8.0.3",
-      "timeFrom": null,
-      "timeShift": null,
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": "default",
+          "refId": "A"
+        }
+      ],
       "type": "text"
     },
     {
-      "cacheTimeout": null,
       "datasource": "default",
+      "description": "The last time a backup was scheduled, whether successful or not.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -828,12 +796,11 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 6,
-        "x": 3,
+        "w": 5,
+        "x": 1,
         "y": 16
       },
       "id": 125,
-      "interval": null,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -849,11 +816,13 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
+          "datasource": "default",
           "exemplar": true,
           "expr": "max(etcd_backup_latest_attempt{tenant_cluster_id=\"ManagementCluster\",etcd_version=\"V3\"}*1000)",
           "hide": false,
@@ -862,14 +831,12 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Latest backup attempt",
+      "title": "Latest backup schedule",
       "type": "stat"
     },
     {
-      "cacheTimeout": null,
       "datasource": "default",
+      "description": "Date of the latest backup completed successfully. This is the time the backup was taken, not when it finished uploading.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -906,11 +873,10 @@
       "gridPos": {
         "h": 2,
         "w": 6,
-        "x": 9,
+        "x": 6,
         "y": 16
       },
       "id": 32,
-      "interval": null,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -926,11 +892,13 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
+          "datasource": "default",
           "exemplar": true,
           "expr": "max(etcd_backup_latest_success{tenant_cluster_id=\"ManagementCluster\",etcd_version=\"V3\"}*1000)",
           "hide": false,
@@ -939,37 +907,41 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Latest successful backup",
       "type": "stat"
     },
     {
       "datasource": "default",
+      "description": "These include the Management Cluster in CAPI clusters.",
       "gridPos": {
         "h": 2,
-        "w": 14,
+        "w": 12,
         "x": 0,
         "y": 18
       },
       "id": 57,
       "options": {
-        "content": "\n# Workload Clusters\n\n\n\n",
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# Workload Clusters",
         "mode": "markdown"
       },
-      "pluginVersion": "8.0.3",
-      "timeFrom": null,
-      "timeShift": null,
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": "default",
+          "refId": "A"
+        }
+      ],
       "transparent": true,
       "type": "text"
     },
     {
       "collapsed": false,
       "datasource": "default",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -979,12 +951,18 @@
       "id": 13,
       "panels": [],
       "repeat": "cluster",
+      "targets": [
+        {
+          "datasource": "default",
+          "refId": "A"
+        }
+      ],
       "title": "$cluster",
       "type": "row"
     },
     {
-      "cacheTimeout": null,
       "datasource": "default",
+      "description": "The last time a backup was scheduled, whether successful or not.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1025,7 +1003,6 @@
         "y": 21
       },
       "id": 53,
-      "interval": null,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1041,24 +1018,24 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
+          "datasource": "default",
           "expr": "max(etcd_backup_latest_attempt{tenant_cluster_id=\"$cluster\",etcd_version=\"V3\"}*1000)",
           "hide": false,
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Latest backup attempt",
+      "title": "Latest backup schedule",
       "type": "stat"
     },
     {
-      "cacheTimeout": null,
       "datasource": "default",
+      "description": "Date of the latest backup completed successfully. This is the time the backup was taken, not when it finished uploading.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1115,24 +1092,24 @@
           "values": false
         },
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "8.0.3",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
+          "datasource": "default",
           "expr": "max(etcd_backup_latest_success{tenant_cluster_id=\"$cluster\",etcd_version=\"V3\"}*1000)",
           "hide": false,
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Latest successful backup",
       "type": "stat"
     }
   ],
   "refresh": false,
-  "schemaVersion": 30,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [
     "owner:team-phoenix"
@@ -1196,5 +1173,5 @@
   "timezone": "UTC",
   "title": "ETCD Backup",
   "uid": "1wEtsXfWz",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
This PR

- adds descriptions to etcd-backup dashboard panels, changes "attempt" to "schedule" so it's clear what the metrics mean.

Towards: https://github.com/giantswarm/giantswarm/issues/28791

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
