### PR TITLE
Fix name of public API server dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix name and query for API server dashboard
+
 ## [3.6.1] - 2024-01-18
 
 ### Changed

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/apiserver.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/apiserver.json
@@ -1619,7 +1619,7 @@
    },
    "timezone": "UTC",
    "title": "Kubernetes / API server",
-   "uid": "09ec8aa1e996d6ffcd6817bbaff4db1basd",
+   "uid": "k8s-apiserver",
    "version": 2,
    "weekStart": ""
  }

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/apiserver.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/apiserver.json
@@ -1244,7 +1244,6 @@
              "axisBorderShow": false,
              "axisCenteredZero": false,
              "axisColorMode": "text",
-             "axisLabel": "Gigabytes of RAM",
              "axisPlacement": "auto",
              "barAlignment": 0,
              "drawStyle": "line",
@@ -1285,12 +1284,13 @@
                  "value": 80
                }
              ]
-           }
-         },
-         "overrides": []
-       },
+           },
+           "unit": "bytes"
+        },
+        "overrides": []
+      },
        "gridPos": {
-         "h": 8,
+         "h": 7,
          "w": 8,
          "x": 0,
          "y": 37
@@ -1315,7 +1315,7 @@
              "uid": "PBFA97CFB590B2093"
            },
            "editorMode": "code",
-           "expr": "avg(container_memory_usage_bytes{cluster_id=\"$cluster\", container=\"k8s-api-server\", namespace=\"kube-system\", pod=~\"k8s-api-server.*\"} / 1024 / 1024 / 1024) by (instance)",
+           "expr": "avg(container_memory_usage_bytes{cluster_id=\"$cluster\", container=\"k8s-api-server\", namespace=\"kube-system\", pod=~\"k8s-api-server.*\"}) by (instance)",
            "instant": false,
            "legendFormat": "__auto",
            "range": true,
@@ -1618,8 +1618,8 @@
      ]
    },
    "timezone": "UTC",
-   "title": "Loreno api server test",
+   "title": "Kubernetes / API server",
    "uid": "09ec8aa1e996d6ffcd6817bbaff4db1basd",
-   "version": 1,
+   "version": 2,
    "weekStart": ""
  }


### PR DESCRIPTION
This PR

- fixes the name for the public API server dashboard
- slightly tune the memory consumption query (leave the bytes -> GB conversion to grafana)

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
