### PR TITLE
Fix query in API server dashboard for CAPI clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix query in API server dashboard for CAPI clusters
+
 ## [3.6.2] - 2024-01-18
 
 ### Fixed

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/apiserver.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/apiserver.json
@@ -1315,7 +1315,7 @@
              "uid": "PBFA97CFB590B2093"
            },
            "editorMode": "code",
-           "expr": "avg(container_memory_usage_bytes{cluster_id=\"$cluster\", container=\"k8s-api-server\", namespace=\"kube-system\", pod=~\"k8s-api-server.*\"}) by (instance)",
+           "expr": "avg(container_memory_usage_bytes{cluster_id=\"$cluster\", container=~\"(k8s-api-server|kube-apiserver)\", namespace=\"kube-system\", pod=~\"(k8s-api-server|kube-apiserver).*\"}) by (instance)",
            "instant": false,
            "legendFormat": "__auto",
            "range": true,


### PR DESCRIPTION
This PR fixes the query used to compute apiserver ram usage in CAPI clusters (having different pod name & container name from vintage).

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
