### PR TITLE
Fix node role label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix all dashboards that were only supporting only role=master to now support role=~control-plane|master.
+
 ## [3.8.4] - 2024-03-11
 
 ### Added

--- a/dashboards/service-level.jsonnet
+++ b/dashboards/service-level.jsonnet
@@ -50,7 +50,7 @@ stdlib.dashboard(
         slo_errors_per_request:ratio_rate6h{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, cluster_id) group_left (cluster_type, class) slo_threshold_low
         and
         slo_errors_per_request:ratio_rate30m{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, cluster_id) group_left (cluster_type, class) slo_threshold_low
-      ) by (service, cluster_id)',
+      ) by (service, customer, installation, cluster_id)',
       format='table',
       instant=true,
     )

--- a/dashboards/service-level.jsonnet
+++ b/dashboards/service-level.jsonnet
@@ -43,13 +43,13 @@ stdlib.dashboard(
   .addTarget(
     grafana.prometheus.target(
       'sum(
-        slo_errors_per_request:ratio_rate1h{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, cluster_id) group_left (cluster_type, class) slo_threshold_high
+        slo_errors_per_request:ratio_rate1h{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, customer, installation, cluster_id) group_left (cluster_type, class) slo_threshold_high
         and
-        slo_errors_per_request:ratio_rate5m{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, cluster_id) group_left (cluster_type, class) slo_threshold_high
+        slo_errors_per_request:ratio_rate5m{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, customer, installation, cluster_id) group_left (cluster_type, class) slo_threshold_high
         or
-        slo_errors_per_request:ratio_rate6h{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, cluster_id) group_left (cluster_type, class) slo_threshold_low
+        slo_errors_per_request:ratio_rate6h{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, customer, installation, cluster_id) group_left (cluster_type, class) slo_threshold_low
         and
-        slo_errors_per_request:ratio_rate30m{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, cluster_id) group_left (cluster_type, class) slo_threshold_low
+        slo_errors_per_request:ratio_rate30m{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, customer, installation, cluster_id) group_left (cluster_type, class) slo_threshold_low
       ) by (service, customer, installation, cluster_id)',
       format='table',
       instant=true,

--- a/dashboards/service-level.jsonnet
+++ b/dashboards/service-level.jsonnet
@@ -43,14 +43,14 @@ stdlib.dashboard(
   .addTarget(
     grafana.prometheus.target(
       'sum(
-        slo_errors_per_request:ratio_rate1h{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, customer, installation, cluster_id) group_left (cluster_type, class) slo_threshold_high
+        slo_errors_per_request:ratio_rate1h{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, cluster_id) group_left (cluster_type, class) slo_threshold_high
         and
-        slo_errors_per_request:ratio_rate5m{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, customer, installation, cluster_id) group_left (cluster_type, class) slo_threshold_high
+        slo_errors_per_request:ratio_rate5m{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, cluster_id) group_left (cluster_type, class) slo_threshold_high
         or
-        slo_errors_per_request:ratio_rate6h{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, customer, installation, cluster_id) group_left (cluster_type, class) slo_threshold_low
+        slo_errors_per_request:ratio_rate6h{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, cluster_id) group_left (cluster_type, class) slo_threshold_low
         and
-        slo_errors_per_request:ratio_rate30m{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, customer, installation, cluster_id) group_left (cluster_type, class) slo_threshold_low
-      ) by (service, customer, installation, cluster_id)',
+        slo_errors_per_request:ratio_rate30m{pipeline=~"$pipeline", service=~"$service", customer=~"$customer", installation=~"$installation", cluster_id=~"$cluster_id"} > on (service, cluster_id) group_left (cluster_type, class) slo_threshold_low
+      ) by (service, cluster_id)',
       format='table',
       instant=true,
     )

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/api-performance.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/api-performance.json
@@ -1432,7 +1432,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "100 * (1 - avg(irate(node_cpu_seconds_total{mode=\"idle\",cluster_id=\"$cluster_id\",node!=\"\"}[$__rate_interval])) by (node)) and on (node) kube_node_role{cluster_id=\"$cluster_id\",role=\"master\"}",
+          "expr": "100 * (1 - avg(irate(node_cpu_seconds_total{mode=\"idle\",cluster_id=\"$cluster_id\",node!=\"\"}[$__rate_interval])) by (node)) and on (node) kube_node_role{cluster_id=\"$cluster_id\",role=~\"control-plane|master\"}",
           "interval": "",
           "legendFormat": "{{ node }}",
           "refId": "A"
@@ -1527,7 +1527,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": true,
-          "expr": "(1 - sum(node_memory_MemAvailable_bytes{cluster_id=\"$cluster_id\",node!=\"\"}) by (node) / sum(node_memory_MemTotal_bytes{cluster_id=\"$cluster_id\",node!=\"\"}) by (node)) and on (node) kube_node_role{cluster_id=\"$cluster_id\",role=\"master\"}",
+          "expr": "(1 - sum(node_memory_MemAvailable_bytes{cluster_id=\"$cluster_id\",node!=\"\"}) by (node) / sum(node_memory_MemTotal_bytes{cluster_id=\"$cluster_id\",node!=\"\"}) by (node)) and on (node) kube_node_role{cluster_id=\"$cluster_id\",role=~\"control-plane|master\"}",
           "interval": "",
           "legendFormat": "{{ node }}",
           "refId": "A"

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-health.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-health.json
@@ -463,7 +463,7 @@
                         "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "code",
-                    "expr": "process_resident_memory_bytes{cluster_id=\"$cluster_id\",role=\"master\", job=\"$cluster_id-prometheus/etcd-$cluster_id/0\"}",
+                    "expr": "process_resident_memory_bytes{cluster_id=\"$cluster_id\",role=~\"control-plane|master\", job=\"$cluster_id-prometheus/etcd-$cluster_id/0\"}",
                     "format": "time_series",
                     "intervalFactor": 2,
                     "legendFormat": "{{instance}} Resident Memory",

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/nodes-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/nodes-overview.json
@@ -169,7 +169,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "count(kube_node_role{cluster_id=\"$cluster\",organization=~\"$organization\",role=\"master\"})",
+          "expr": "count(kube_node_role{cluster_id=\"$cluster\",organization=~\"$organization\",role=~\"control-plane|master\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -268,7 +268,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "count(kube_node_role{cluster_id=\"$cluster\",organization=~\"$organization\",role=\"master\"})",
+          "expr": "count(kube_node_role{cluster_id=\"$cluster\",organization=~\"$organization\",role=~\"control-plane|master\"})",
           "interval": "",
           "legendFormat": "Control plane nodes",
           "refId": "A"

--- a/helm/dashboards/dashboards/kvm/public/kvm-machine-usage.json
+++ b/helm/dashboards/dashboards/kvm/public/kvm-machine-usage.json
@@ -203,7 +203,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(up{app=\"kubelet\", cluster_type=\"management_cluster\",role=\"master\"})",
+          "expr": "sum(up{app=\"kubelet\", cluster_type=\"management_cluster\",role=~\"control-plane|master\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -2442,7 +2442,7 @@
           "pluginVersion": "8.0.3",
           "targets": [
             {
-              "expr": "count(up{app=\"kubelet\", cluster_type=\"workload_cluster\",role=\"master\",cluster_id=\"$cluster\"})",
+              "expr": "count(up{app=\"kubelet\", cluster_type=\"workload_cluster\",role=~\"control-plane|master\",cluster_id=\"$cluster\"})",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 2,


### PR DESCRIPTION
This PR

- fixes node-role label from master to master|control-plane as the master scheme is gone in recent Kubernetes versions
<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
