### PR TITLE
add promxy cpu and memory graphs to prometheus cost dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Migrate panels from graph to timeseries in DNS dashboard.
+- Add promxy cpu and memory graphs to prometheus cost dashboard.
 
 ## [3.8.5] - 2024-03-26
 

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-cost-estimation.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-cost-estimation.json
@@ -18,7 +18,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 97,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -29,6 +28,158 @@
         "w": 24,
         "x": 0,
         "y": 0
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Promxy",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Total cpu used by all promxy pods",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(sum(rate(container_cpu_usage_seconds_total{container=\"promxy-app\", pod=~\"promxy-app-.*\", cluster_type=\"management_cluster\"}[3m])) by (pod))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total cpu used ",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Total memory used by all promxy pods",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(sum(max_over_time(\n    container_memory_usage_bytes{container=\"promxy-app\", pod=~\"promxy-app-.*\", cluster_type=\"management_cluster\"}[$__range]\n)) by (container, pod, cluster_type))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total memory used ",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
       },
       "id": 12,
       "panels": [],
@@ -47,6 +198,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -60,6 +212,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -122,7 +275,7 @@
         "h": 8,
         "w": 21,
         "x": 0,
-        "y": 1
+        "y": 10
       },
       "id": 1,
       "options": {
@@ -211,7 +364,7 @@
         "h": 8,
         "w": 3,
         "x": 21,
-        "y": 1
+        "y": 10
       },
       "id": 14,
       "options": {
@@ -226,9 +379,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "datasource": {
@@ -257,6 +412,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -270,6 +426,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -350,7 +507,7 @@
         "h": 7,
         "w": 21,
         "x": 0,
-        "y": 9
+        "y": 18
       },
       "id": 2,
       "options": {
@@ -456,7 +613,7 @@
         "h": 7,
         "w": 3,
         "x": 21,
-        "y": 9
+        "y": 18
       },
       "id": 13,
       "options": {
@@ -471,9 +628,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "datasource": {
@@ -496,7 +655,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 25
       },
       "id": 7,
       "panels": [],
@@ -515,6 +674,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -528,6 +688,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -567,7 +728,7 @@
         "h": 8,
         "w": 19,
         "x": 0,
-        "y": 17
+        "y": 26
       },
       "id": 3,
       "options": {
@@ -644,7 +805,7 @@
         "h": 8,
         "w": 5,
         "x": 19,
-        "y": 17
+        "y": 26
       },
       "id": 4,
       "options": {
@@ -657,9 +818,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "datasource": {
@@ -681,7 +844,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 34
       },
       "id": 6,
       "title": "Network transfer usage",
@@ -698,6 +861,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -711,6 +875,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -750,7 +915,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 35
       },
       "id": 9,
       "options": {
@@ -792,6 +957,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -805,6 +971,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -844,7 +1011,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 35
       },
       "id": 10,
       "options": {
@@ -881,7 +1048,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 43
       },
       "id": 5,
       "panels": [],
@@ -935,7 +1102,7 @@
         "h": 7,
         "w": 7,
         "x": 0,
-        "y": 35
+        "y": 44
       },
       "id": 11,
       "maxDataPoints": 100,
@@ -951,9 +1118,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.4.0",
       "targets": [
         {
           "datasource": {
@@ -974,8 +1143,7 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": [
@@ -1021,6 +1189,6 @@
   "timezone": "",
   "title": "Prometheus Cost Estimate",
   "uid": "d37ffc71-9200-4f0b-8f9a-9e2af9f6b277",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30353

This PR adds a promxy section wih the pods' total CPU and memory usage to the prometheus cost dashboard

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
