### PR TITLE
remove 'app' and 'namespace' labels from remotewrite nginx graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `app` and `namespace` labels from the prometheus - remotewrite's nginx graphs.
+
 ## [3.10.2] - 2024-04-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The private Zot dashboard is updated because of a namespace change, and some minor fixes are applied.
-- Remove `app` and `namespace` labels from the prometheus - remotewrite's nginx graphs.
 
 ## [3.10.1] - 2024-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The private Zot dashboard is updated because of a namespace change, and some minor fixes are applied.
+- Remove `app` and `namespace` labels from the prometheus - remotewrite's nginx graphs.
 
 ## [3.10.1] - 2024-04-08
 

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/prometheus-remote-write.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/prometheus-remote-write.json
@@ -162,7 +162,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(rate(nginx_ingress_controller_requests{\n    cluster_type=~\"management_cluster\",\n    namespace=~\"($cluster)-prometheus\",\n    app=~\"nginx-ingress-controller.*\",\n    ingress=~\"prometheus-($cluster)-remote-write\",\n    status!~\"[4-5].*\"}[$__rate_interval]\n)) by (ingress, host, path, method) / \nsum(rate(nginx_ingress_controller_requests{\n    cluster_type=~\"management_cluster\",\n    namespace=~\"($cluster)-prometheus\",\n    app=~\"nginx-ingress-controller.*\",\n    ingress=~\"prometheus-($cluster)-remote-write\"}[$__rate_interval]\n)) by (ingress, host, path, method)",
+          "expr": "sum(rate(nginx_ingress_controller_requests{\n    cluster_type=~\"management_cluster\",\n   ingress=~\"prometheus-($cluster)-remote-write\",\n    status!~\"[4-5].*\"}[$__rate_interval]\n)) by (ingress, host, path, method) / \nsum(rate(nginx_ingress_controller_requests{\n    cluster_type=~\"management_cluster\",\n    ingress=~\"prometheus-($cluster)-remote-write\"}[$__rate_interval]\n)) by (ingress, host, path, method)",
           "hide": false,
           "instant": false,
           "interval": "2m",
@@ -176,7 +176,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(irate(nginx_ingress_controller_requests{\n    cluster_type=~\"management_cluster\",\n    namespace=~\"($cluster)-prometheus\",\n    app=~\"nginx-ingress-controller.*\",\n    ingress=~\"prometheus-($cluster)-remote-write\"}[$__rate_interval]\n)) by (ingress, host, path, method)",
+          "expr": "sum(irate(nginx_ingress_controller_requests{\n    cluster_type=~\"management_cluster\",\n   ingress=~\"prometheus-($cluster)-remote-write\"}[$__rate_interval]\n)) by (ingress, host, path, method)",
           "hide": false,
           "instant": false,
           "interval": "2m",
@@ -276,7 +276,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(irate(nginx_ingress_controller_requests{\n    cluster_type=~\"management_cluster\",\n    namespace=~\"($cluster)-prometheus\",\n    app=~\"nginx-ingress-controller.*\",\n    ingress=~\"prometheus-($cluster)-remote-write\",\n    status!~\"[2].*\"}[$__rate_interval]\n)) by (ingress, host, path, method, status)",
+          "expr": "sum(irate(nginx_ingress_controller_requests{\n    cluster_type=~\"management_cluster\",\n    ingress=~\"prometheus-($cluster)-remote-write\",\n    status!~\"[2].*\"}[$__rate_interval]\n)) by (ingress, host, path, method, status)",
           "instant": false,
           "interval": "2m",
           "legendFormat": "{{ingress}} - {{status}} for {{method}} {{host}}{{path}}",


### PR DESCRIPTION
This PR removes the `app` and `namespace` labels from the prometheus-remotewrite's nginx graphs as they're preventing those graphs from working properly

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
