### PR TITLE
Fixes "All Dex requests" panel showing "No data" by increasing query interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixes "All Dex requests" panel showing "No data" by increasing query interval to 2m.
+
 ## [3.10.3] - 2024-04-10
 
 ### Changed

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/dex.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/dex.json
@@ -492,7 +492,7 @@
         {
           "datasource": "default",
           "exemplar": true,
-          "expr": "sum(increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",app=\"dex\",handler!=\"/healthz\"}[1m])) by (handler, method, code)",
+          "expr": "sum(increase(http_requests_total{cluster_id=\"$cluster\",organization=~\"$organization\",app=\"dex\",handler!=\"/healthz\"}[2m])) by (handler, method, code)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30517


This PR:
- Fixes "All Dex requests" panel showing "No data" by increasing query interval to 2m.

### Before:
![image](https://github.com/giantswarm/dashboards/assets/5674762/dd64f14e-7bca-494e-863a-4189b7e80719)

### After:
![image](https://github.com/giantswarm/dashboards/assets/5674762/9a01c1f4-be1d-42d5-bbf9-7298cf093ac3)


<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
