### PR TITLE
Update "Ingress NGINX Controller Connection Distribution" dashboard file to schema version 39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update "Ingress NGINX Controller Connection Distribution" dashboard file to schema version 39.
+
 ## [3.11.0] - 2024-04-11
 
 ### Added

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/nginx-connection-distribution.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/nginx-connection-distribution.json
@@ -1,7 +1,301 @@
 {
-  "id": 80,
-  "uid": "Kw0_AuGVk",
-  "title": "Ingress NGINX Controller Connection Distribution",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 6,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "nginx_ingress_controller_nginx_process_connections{cluster_id=\"$cluster\",controller_namespace=~\"$namespace\",app=~\"$app\",controller_class=~\"$controller_class\",controller_pod=~\"$controller\",state=\"active\"}",
+          "refId": "Active Connections by Pod"
+        }
+      ],
+      "title": "Active Connections by Pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum by (node) (nginx_ingress_controller_nginx_process_connections{cluster_id=\"$cluster\",controller_namespace=~\"$namespace\",app=~\"$app\",controller_class=~\"$controller_class\",controller_pod=~\"$controller\",state=\"active\"})",
+          "refId": "Active Connections by Node"
+        }
+      ],
+      "title": "Active Connections by Node",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum by (zone) (nginx_ingress_controller_nginx_process_connections{cluster_id=\"$cluster\",controller_namespace=~\"$namespace\",app=~\"$app\",controller_class=~\"$controller_class\",controller_pod=~\"$controller\",state=\"active\"} * on (node) group_left(zone) kube_node_labels{cluster_id=\"$cluster\"})",
+          "refId": "Active Connections by Zone"
+        }
+      ],
+      "title": "Active Connections by Zone",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
   "tags": [
     "ingress-nginx",
     "topic:management-cluster",
@@ -11,122 +305,154 @@
   "templating": {
     "list": [
       {
-        "name": "cluster",
+        "current": {
+          "selected": true,
+          "text": "golem",
+          "value": "golem"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
         "label": "Cluster",
-        "type": "query",
-        "datasource": "default",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
         "query": {
-          "refId": "StandardVariableQuery",
-          "query": "label_values(kubernetes_build_info, cluster_id)"
-        }
+          "query": "label_values(kubernetes_build_info, cluster_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       },
       {
-        "name": "namespace",
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
         "label": "Namespace",
-        "type": "query",
-        "datasource": "default",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
         "query": {
-          "refId": "StandardVariableQuery",
-          "query": "label_values(nginx_ingress_controller_config_hash{cluster_id=~\"$cluster\"}, controller_namespace)"
+          "query": "label_values(nginx_ingress_controller_config_hash{cluster_id=~\"$cluster\"}, controller_namespace)",
+          "refId": "StandardVariableQuery"
         },
-        "includeAll": true,
-        "allValue": ".*"
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       },
       {
-        "name": "app",
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
         "label": "App",
-        "type": "query",
-        "datasource": "default",
+        "multi": false,
+        "name": "app",
+        "options": [],
         "query": {
-          "refId": "StandardVariableQuery",
-          "query": "label_values(nginx_ingress_controller_config_hash{cluster_id=~\"$cluster\",namespace=~\"$namespace\"}, app)"
+          "query": "label_values(nginx_ingress_controller_config_hash{cluster_id=~\"$cluster\",namespace=~\"$namespace\"}, app)",
+          "refId": "StandardVariableQuery"
         },
-        "includeAll": true,
-        "allValue": ".*"
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       },
       {
-        "name": "controller_class",
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
         "label": "Controller Class",
-        "type": "query",
-        "datasource": "default",
+        "multi": false,
+        "name": "controller_class",
+        "options": [],
         "query": {
-          "refId": "StandardVariableQuery",
-          "query": "label_values(nginx_ingress_controller_config_hash{cluster_id=~\"$cluster\",namespace=~\"$namespace\"}, controller_class)"
+          "query": "label_values(nginx_ingress_controller_config_hash{cluster_id=~\"$cluster\",namespace=~\"$namespace\"}, controller_class)",
+          "refId": "StandardVariableQuery"
         },
-        "includeAll": true,
-        "allValue": ".*"
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       },
       {
-        "name": "controller",
-        "label": "Controller",
-        "type": "query",
-        "datasource": "default",
-        "query": {
-          "refId": "StandardVariableQuery",
-          "query": "label_values(nginx_ingress_controller_config_hash{cluster_id=~\"$cluster\",namespace=~\"$namespace\",app=~\"$app\",controller_class=~\"$controller_class\"}, controller_pod)"
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
         },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "",
+        "hide": 0,
         "includeAll": true,
-        "allValue": ".*"
+        "label": "Controller",
+        "multi": false,
+        "name": "controller",
+        "options": [],
+        "query": {
+          "query": "label_values(nginx_ingress_controller_config_hash{cluster_id=~\"$cluster\",namespace=~\"$namespace\",app=~\"$app\",controller_class=~\"$controller_class\"}, controller_pod)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },
-  "panels": [
-    {
-      "id": 1,
-      "title": "Active Connections by Pod",
-      "type": "timeseries",
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "datasource": "default",
-      "targets": [
-        {
-          "refId": "Active Connections by Pod",
-          "datasource": "default",
-          "expr": "nginx_ingress_controller_nginx_process_connections{cluster_id=\"$cluster\",controller_namespace=~\"$namespace\",app=~\"$app\",controller_class=~\"$controller_class\",controller_pod=~\"$controller\",state=\"active\"}"
-        }
-      ]
-    },
-    {
-      "id": 2,
-      "title": "Active Connections by Node",
-      "type": "timeseries",
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 11
-      },
-      "datasource": "default",
-      "targets": [
-        {
-          "refId": "Active Connections by Node",
-          "datasource": "default",
-          "expr": "sum by (node) (nginx_ingress_controller_nginx_process_connections{cluster_id=\"$cluster\",controller_namespace=~\"$namespace\",app=~\"$app\",controller_class=~\"$controller_class\",controller_pod=~\"$controller\",state=\"active\"})"
-        }
-      ]
-    },
-    {
-      "id": 3,
-      "title": "Active Connections by Zone",
-      "type": "timeseries",
-      "datasource": "default",
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 22
-      },
-      "targets": [
-        {
-          "refId": "Active Connections by Zone",
-          "datasource": "default",
-          "expr": "sum by (zone) (nginx_ingress_controller_nginx_process_connections{cluster_id=\"$cluster\",controller_namespace=~\"$namespace\",app=~\"$app\",controller_class=~\"$controller_class\",controller_pod=~\"$controller\",state=\"active\"} * on (node) group_left(zone) kube_node_labels{cluster_id=\"$cluster\"})"
-        }
-      ]
-    }
-  ]
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "Ingress NGINX Controller Connection Distribution",
+  "uid": "Kw0_AuGVk",
+  "version": 1,
+  "weekStart": ""
 }


### PR DESCRIPTION
This dashboard had an unspecified schema version number. I am updating it to the schema produced by our Grafana installation.