### PR TITLE
fix: set proper tags for atlas dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Fix storage related panes on zot's dashboards
+### Fixed
+
+- Fix atlas dashboard tags.
+- Fix storage related panes on zot's dashboards.
 
 ## [3.13.0] - 2024-04-24
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This chart is divided in 4 different charts, to get around helm charts size limi
 
 ### Dashboard format
 
-All dashboards should strive to have proper tags to facilitate their discovery.
+All dashboards should have proper tags to facilitate their discovery.
 To that end, we advise the following tags:
 - `owner:team-name`: Team that owns the dashboard
 - `component:component_name`: Name of the component this dashboard is about

--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 This project currently contains Giant Swarm public dashboards.
 
-The goal of this repository is to have both public and Grafana Cloud dashboards defined in one place and in the same format.
+The goal of this repository is to have both public and Grafana Cloud dashboards defined in one place.
 
-## Sub-charts
+## Management cluster's dashboards
+
+The dashboards located under `helm/dashboards` are the dashboards hosted on each management cluster's grafana.
+The "public" ones are accessible by the customer, and the "private" ones are only accessible by Giant Swarm employees.
+
+### Sub-charts
 
 This chart is divided in 4 different charts, to get around helm charts size limitations:
 - `helm/dashboards/charts/public_dashboards/` for public dashboards.
@@ -12,11 +17,13 @@ This chart is divided in 4 different charts, to get around helm charts size limi
 - `helm/dashboards/charts/private_dashboards_mz/` for private dashboards starting with letters M to Z.
 - `helm/dashboards/` for other dashboards.
 
-## Management cluster's dashboards
+### Dashboard format
 
-The dashboards located under `helm/dashboards` are the dashboards hosted on each management cluster's grafana.
-The "public" ones are accessible by the customer, and the "private" ones are only accessible by Giant Swarm employees.
-Those dashboards are currently in JSON and will eventually be replaced to jsonnet format.
+All dashboards should strive to have proper tags to facilitate their discovery.
+To that end, we advise the following tags:
+- `owner:team-name`: Team that owns the dashboard
+- `component:component_name`: Name of the component this dashboard is about
+- `topic:topic`: The topic that this dashboard is about (observability, security, networking, kubernetes, ...)
 
 ## Grafana Cloud dashboards
 

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/fluentbit.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/fluentbit.json
@@ -1323,7 +1323,9 @@
   "schemaVersion": 35,
   "style": "dark",
   "tags": [
-    "fluentbit"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:fluentbit"
   ],
   "templating": {
     "list": []

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/grafana.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/grafana.json
@@ -1251,7 +1251,8 @@
   "style": "dark",
   "tags": [
     "owner:team-atlas",
-    "topic:meta"
+    "topic:observability",
+    "component:grafana"
   ],
   "templating": {
     "list": []

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-canary.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-canary.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -1699,7 +1701,9 @@
   "schemaVersion": 27,
   "style": "dark",
   "tags": [
-    "loki"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-chunks.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-chunks.json
@@ -13,7 +13,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -1234,7 +1236,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "loki"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-cost-estimation.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-cost-estimation.json
@@ -31,7 +31,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -1038,7 +1040,11 @@
   "revision": 1,
   "schemaVersion": 38,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
+  ],
   "templating": {
     "list": [
       {

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-deletion.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-deletion.json
@@ -13,7 +13,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -872,7 +874,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "loki"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-logs.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-logs.json
@@ -14,7 +14,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -851,7 +853,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "loki"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-mixin-recording-rules.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-mixin-recording-rules.json
@@ -15,7 +15,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -590,7 +592,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "loki"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-operational.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-operational.json
@@ -25,7 +25,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -7064,7 +7066,9 @@
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
-    "loki"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-reads-resources.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-reads-resources.json
@@ -13,7 +13,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -837,7 +839,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "loki"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-reads.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-reads.json
@@ -13,7 +13,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -572,7 +574,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "loki"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-retention.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-retention.json
@@ -13,7 +13,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -1451,7 +1453,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "loki"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-writes-resources.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-writes-resources.json
@@ -13,7 +13,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -624,7 +626,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "loki"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-writes.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-writes.json
@@ -13,7 +13,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "loki"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:loki"
       ],
       "targetBlank": false,
       "title": "Loki Dashboards",
@@ -402,7 +404,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "loki"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:loki"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-compactor-resources.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-compactor-resources.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -706,7 +708,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-compactor.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-compactor.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -2008,7 +2010,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-overview-networking.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-overview-networking.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -718,7 +720,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-overview-resources.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-overview-resources.json
@@ -25,7 +25,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -1515,7 +1517,9 @@
   "refresh": "1m",
   "schemaVersion": 39,
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-overview.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-overview.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -1367,7 +1369,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-reads-networking.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-reads-networking.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -1402,7 +1404,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-reads-resources.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-reads-resources.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -2347,7 +2349,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-reads.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-reads.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -3600,7 +3602,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-ruler.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-ruler.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -2513,7 +2515,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-writes-networking.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-writes-networking.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -718,7 +720,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-writes-resources.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-writes-resources.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -1084,7 +1086,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-writes.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-writes.json
@@ -21,7 +21,9 @@
       "includeVars": true,
       "keepTime": true,
       "tags": [
-        "mimir"
+        "owner:team-atlas",
+        "topic:observability",
+        "component:mimir"
       ],
       "targetBlank": false,
       "title": "Mimir dashboards",
@@ -2605,7 +2607,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "mimir"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/operatorkit.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/operatorkit.json
@@ -745,7 +745,11 @@
   "refresh": "5m",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "owner:team-atlas",
+    "topic:operators",
+    "component:operatorkit"
+  ],
   "templating": {
     "list": [
       {

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-benchmark.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-benchmark.json
@@ -3128,7 +3128,9 @@
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
-    "owner:team-atlas"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:prometheus"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-cost-estimation.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-cost-estimation.json
@@ -1144,7 +1144,11 @@
   ],
   "refresh": "",
   "schemaVersion": 39,
-  "tags": [],
+  "tags": [
+    "owner:team-atlas",
+    "topic:observability",
+    "component:prometheus"
+  ],
   "templating": {
     "list": [
       {
@@ -1187,7 +1191,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Prometheus Cost Estimate",
+  "title": "Prometheus / Cost Estimatation",
   "uid": "d37ffc71-9200-4f0b-8f9a-9e2af9f6b277",
   "version": 1,
   "weekStart": ""

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-mimir-comparative.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-mimir-comparative.json
@@ -702,14 +702,19 @@
   "refresh": "",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "owner:team-atlas",
+    "topic:observability",
+    "component:prometheus",
+    "component:mimir"
+  ],
   "time": {
     "from": "now-7d",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Prometheus - Mimir comparative",
+  "title": "Prometheus / Mimir comparative",
   "uid": "dc39e0c1-d4f1-4c8e-b0ab-e1455621f64c",
   "version": 5,
   "weekStart": ""

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-opsrecipe.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-opsrecipe.json
@@ -178,8 +178,8 @@
   "style": "dark",
   "tags": [
     "owner:team-atlas",
-    "topic:workload-cluster",
-    "topic:management-cluster"
+    "topic:observability",
+    "component:prometheus"
   ],
   "templating": {
     "list": []
@@ -190,7 +190,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Prometheus - opsrecipe",
+  "title": "Prometheus / opsrecipe",
   "uid": "prometheusrecipe",
   "version": 2,
   "weekStart": ""

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-overview.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-overview.json
@@ -1221,7 +1221,9 @@
   "schemaVersion": 37,
   "style": "dark",
   "tags": [
-    "prometheus-mixin"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:prometheus"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/slos-reporting.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/slos-reporting.json
@@ -1224,8 +1224,9 @@
   "revision": 1,
   "schemaVersion": 39,
   "tags": [
-    "topic:sla",
-    "owner:atlas"
+    "owner:team-atlas",
+    "topic:observability",
+    "topic:sla"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/alertmanager-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/alertmanager-overview.json
@@ -396,7 +396,9 @@
   "schemaVersion": 14,
   "style": "dark",
   "tags": [
-    "alertmanager-mixin"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:alertmanager"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/alerts.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/alerts.json
@@ -476,7 +476,9 @@
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
-    "owner:team-atlas"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:alertmanager"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/pod-request-vs-usage.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/pod-request-vs-usage.json
@@ -399,7 +399,8 @@
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
-    "owner:team-atlas"
+    "owner:team-atlas",
+    "topic:resource-usage"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/prometheus-availability.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/prometheus-availability.json
@@ -335,8 +335,8 @@
   "style": "dark",
   "tags": [
     "owner:team-atlas",
-    "topic:management-cluster",
-    "topic:workload-cluster"
+    "topic:observability",
+    "component:prometheus"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/prometheus-remote-write.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/prometheus-remote-write.json
@@ -1784,8 +1784,9 @@
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
-    "prometheus-mixin",
-    "owner:team-atlas"
+    "owner:team-atlas",
+    "topic:observability",
+    "component:prometheus"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/prometheus.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/prometheus.json
@@ -1704,8 +1704,8 @@
   "style": "dark",
   "tags": [
     "owner:team-atlas",
-    "topic:management-cluster",
-    "topic:workload-cluster"
+    "topic:observability",
+    "component:prometheus"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/dashboards/home.json
+++ b/helm/dashboards/dashboards/home.json
@@ -117,7 +117,11 @@
   ],
   "schemaVersion": 30,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "owner:team-atlas",
+    "topic:observability",
+    "component:grafana"
+  ],
   "templating": {
     "list": []
   },


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3318, this PR sets proper tags on our dashboards to make it clear that we own those dashboards.

Once this is merged then I will add the missing datasources to our dashboards


<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
