### PR TITLE
Add basic linting to dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix atlas dashboard tags.
 - Fix storage related panes on zot's dashboards
 - prometheus: scraping info can now be filtered by cluster
+- add some basic linting configuration so we can track down issues in dashboards.
 
 ## [3.13.0] - 2024-04-24
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ To that end, we advise the following tags:
 - `component:component_name`: Name of the component this dashboard is about
 - `topic:topic`: The topic that this dashboard is about (observability, security, networking, kubernetes, ...)
 
+### Linting
+
+Atlas introduced a dashboard linter to ensure some basic dashboard rules are followed (e.g. always have a datasource present) to help with the migration to Mimir. 
+This will most likely be moved to CI later but until it is you can run it like this:
+
+```sh
+# Install the tool
+go install github.com/grafana/dashboard-linter@latest
+### Run on a specific dashboard
+dashboard-linter lint -c linter/config.yaml <dashboard_location>
+```
+
+If you need help with the tool or its output, please contact @team-atlas.
+
 ## Grafana Cloud dashboards
 
 The dashboards located under `dashboards` are the dashboards hosted on Giant Swarm's Grafana Cloud.

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/fluentbit.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/fluentbit.json
@@ -1,18 +1,8 @@
 {
   "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": "PBFA97CFB590B2093",
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
+    "list": []
   },
-  "description": "Inspired by https://grafana.com/grafana/dashboards/7752",
+  "description": "Fluent-bit monitoring dashboard used to display the status of the fluent-bit pods and the processing rates of the input and output data.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "gnetId": 7752,
@@ -85,10 +75,7 @@
       "pluginVersion": "8.4.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum(kube_pod_info{pod=~\".*fluent-logshipping.*\"})",
           "format": "time_series",
@@ -166,10 +153,7 @@
       "pluginVersion": "8.4.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(kube_node_status_condition{condition=\"Ready\",status=\"true\"})",
           "format": "time_series",
@@ -248,10 +232,7 @@
       "pluginVersion": "8.4.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum(kube_node_status_condition{condition!=\"Ready\",status=\"true\"})",
           "format": "time_series",
@@ -267,10 +248,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -331,7 +309,7 @@
       "pluginVersion": "8.4.2",
       "targets": [
         {
-          "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[1m]))",
+          "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))",
           "instant": false,
           "refId": "A"
         }
@@ -401,10 +379,7 @@
       "pluginVersion": "8.4.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(kube_node_status_allocatable{resource=\"memory\"})",
           "instant": false,
@@ -478,10 +453,7 @@
       "pluginVersion": "8.4.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\"}) / sum(kube_node_status_allocatable{resource=\"cpu\"})",
           "instant": false,
@@ -555,10 +527,7 @@
       "pluginVersion": "8.4.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\"}) / sum(kube_node_status_allocatable{resource=\"memory\"})",
           "instant": false,
@@ -632,10 +601,7 @@
       "pluginVersion": "8.4.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\"}) / sum(kube_node_status_allocatable{resource=\"cpu\"})",
           "instant": false,
@@ -709,10 +675,7 @@
       "pluginVersion": "8.4.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\"}) / sum(kube_node_status_allocatable{resource=\"memory\"})",
           "instant": false,
@@ -730,6 +693,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -779,10 +743,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
           "exemplar": true,
           "expr": "sum(rate(fluentbit_input_bytes_total[5m])) by (instance, name)",
           "format": "time_series",
@@ -828,10 +788,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -924,10 +881,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1019,10 +973,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1117,10 +1068,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1170,7 +1118,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_output_retries_total[1m])) by (instance, name)",
+          "expr": "sum(rate(fluentbit_output_retries_total[$__rate_interval])) by (instance, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1179,7 +1127,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(fluentbit_output_retries_failed_total[1m])) by (instance, name)",
+          "expr": "sum(rate(fluentbit_output_retries_failed_total[$__rate_interval])) by (instance, name)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1225,10 +1173,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1278,7 +1223,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_output_errors_total[1m])) by (instance, name)",
+          "expr": "sum(rate(fluentbit_output_errors_total[$__rate_interval])) by (instance, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1328,7 +1273,20 @@
     "component:fluentbit"
   ],
   "templating": {
-    "list": []
+    "list": [{
+      "current": {
+        "text": "default",
+        "value": "default"
+      },
+      "hide": 0,
+      "label": "Data source",
+      "name": "datasource",
+      "options": [],
+      "query": "prometheus",
+      "refresh": 1,
+      "regex": "",
+      "type": "datasource"
+    }]
   },
   "time": {
     "from": "now-3h",

--- a/linter/config.yaml
+++ b/linter/config.yaml
@@ -1,0 +1,13 @@
+exclusions:
+  target-instance-rule:
+    reason: We are not using it.
+  target-job-rule:
+    reason: We are not using it.
+  template-instance-rule:
+    reason: We are not using it.
+  template-job-rule:
+    reason: We are not using it.
+  panel-units-rule:
+    reason: We are not using it even though we should.
+  panel-title-description-rule:
+    reason: We are not using it even though we should.


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3318

This PR adds a basic linter configuration (used by https://github.com/grafana/dashboard-linter) to be able to find issues in our dashboards prior to the migration to mimir. This is especially useful to track down dashboards that do not have a datasource which is mandatory for the migration (to be able to test dashboards on both Mimir and Prometheus).

The list of exclusions is based on our use cases (we do not use the job and instance label that much) and the fluent-bit dashboards is the first I've tested it on.

Once I'm more confident or if someone else has the time, this should be added to a make file and most likely added to CI

@giantswarm/team-atlas what do you think?

To run, use:

```sh
go install github.com/grafana/dashboard-linter@latest
dashboard-linter lint -c linter/config.yaml helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/fluentbit.json
```

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
