### PR TITLE
servicemonitor dashboards: add links and small fixes

### DIFF
--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-details.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-details.json
@@ -19,8 +19,23 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 135,
-  "links": [],
+  "id": 53,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": false,
+      "tags": [
+        "servicemonitor"
+      ],
+      "targetBlank": true,
+      "title": "ServiceMonitors",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
   "panels": [
     {
       "collapsed": false,
@@ -406,7 +421,14 @@
     }
   ],
   "schemaVersion": 39,
-  "tags": [],
+  "tags": [
+    "topic:observability",
+    "owner:team-atlas",
+    "component:prometheus-agent",
+    "servicemonitor",
+    "podmonitor",
+    "scraping"
+  ],
   "templating": {
     "list": [
       {
@@ -522,6 +544,10 @@
           "text": "app_operator_app_info",
           "value": "app_operator_app_info"
         },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
         "definition": "query_result(topk(50, (count by (__name__) ({cluster_id=\"$cluster\", job=\"$job\"}))))",
         "hide": 0,
         "includeAll": false,
@@ -560,6 +586,6 @@
   "timezone": "browser",
   "title": "ServiceMonitors Details",
   "uid": "servicemonitors-details",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "ServiceMonitors overview: rank servicemonitors by number of metrics, churn...",
+  "description": "ServiceMonitors Overview: rank servicemonitors by number of metrics, churn...",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -639,7 +639,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "ServiceMonitors overview",
+  "title": "ServiceMonitors Overview",
   "uid": "servicemonitors-overview",
   "version": 1,
   "weekStart": ""

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
@@ -19,7 +19,22 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": false,
+      "tags": [
+        "servicemonitor"
+      ],
+      "targetBlank": true,
+      "title": "ServiceMonitors",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
   "panels": [
     {
       "collapsed": false,
@@ -492,9 +507,9 @@
   ],
   "schemaVersion": 39,
   "tags": [
-    "\"topic:observability\"",
-    "\"owner:team-atlas\"",
-    "\"component:prometheus-agent\"",
+    "topic:observability",
+    "owner:team-atlas",
+    "component:prometheus-agent",
     "servicemonitor",
     "podmonitor",
     "scraping"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30727

This PR improves the `servicemonitors` dashboards:
- tags fixes
- link between them

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md in an end-user friendly language.
