### PR TITLE
servicemonitors overview - add ram usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- ServiceMonitors Overview dashboard: add RAM usage estimation
+
 ## [3.14.1] - 2024-05-15
 
 ### Changed

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
@@ -19,6 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": 35,
   "links": [
     {
       "asDropdown": true,
@@ -197,7 +198,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "The number of samples discarded by relabeling.",
+      "description": "RAM estimation based on the ratio of series / total Prometheus RAM usage",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -250,7 +251,7 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "decbytes"
         },
         "overrides": []
       },
@@ -260,7 +261,7 @@
         "x": 12,
         "y": 6
       },
-      "id": 8,
+      "id": 9,
       "options": {
         "legend": {
           "calcs": [
@@ -286,14 +287,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(scrape_samples_scraped{cluster_id=~\"$cluster\", job=~\"$job\"} - scrape_samples_post_metric_relabeling{cluster_id=~\"$cluster\", job=~\"$job\"}) by (app, job, cluster_id)",
+          "expr": "giantswarm:observability:monitoring:resource_usage_estimation:memory_usage_bytes{cluster_id=~\"$cluster\", job=~\"$job\"}",
           "instant": false,
-          "legendFormat": "Job: {{job}} / App: {{app}}) / Cluster: {{cluster_id}}",
+          "legendFormat": "Job: {{job}} / Cluster: {{cluster_id}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Samples discarded per servicemonitor",
+      "title": "Prometheus RAM usage estimation per servicemonitor",
       "type": "timeseries"
     },
     {
@@ -405,6 +406,110 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "The number of samples discarded by relabeling.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(scrape_samples_scraped{cluster_id=~\"$cluster\", job=~\"$job\"} - scrape_samples_post_metric_relabeling{cluster_id=~\"$cluster\", job=~\"$job\"}) by (app, job, cluster_id)",
+          "instant": false,
+          "legendFormat": "Job: {{job}} / App: {{app}}) / Cluster: {{cluster_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Samples discarded per servicemonitor",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "Duration of the scrape. Is the sum of all targets for one job/app on a cluster.",
       "fieldConfig": {
         "defaults": {
@@ -465,8 +570,8 @@
       "gridPos": {
         "h": 10,
         "w": 12,
-        "x": 12,
-        "y": 16
+        "x": 0,
+        "y": 26
       },
       "id": 7,
       "options": {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30727

Add Prometheus RAM usage estimation to `ServiceMonitors Overview` dashboard.

Before:
![image](https://github.com/giantswarm/dashboards/assets/12008875/cb142946-6dc1-46b4-831a-e4117b197c6c)


After:
![image](https://github.com/giantswarm/dashboards/assets/12008875/11a42810-acc7-4d2b-a282-bf1653f22f05)


Note: the `Scrape Duration` graph is still there, but just down the page and did not fit in the screenshot. But its contents did not change.

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
