### PR TITLE
Fix duplicate series in match group in cost estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add missing data source to atlas dashboards.
 - Fix missing provider specific dashboards.
+- Fix prometheus-cost-estimation dashboard.
 
 ### Removed
 

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-cost-estimation.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/prometheus-cost-estimation.json
@@ -569,7 +569,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "max (node_memory_MemTotal_bytes{node=~\".+\"} * on (node) group_right(pod) (kube_pod_info{pod=~\"prometheus-.*-0\",cluster_type=\"management_cluster\", namespace=~\"($cluster)-prometheus\"})) by (namespace)",
+          "expr": "max (sum(node_memory_MemTotal_bytes{node=~\".+\"}) by (cluster_id, node) * on (cluster_id, node) group_right(pod) (kube_pod_info{pod=~\"prometheus-.*-0\",cluster_type=\"management_cluster\", namespace=~\"($cluster)-prometheus\"})) by (namespace)",
           "hide": false,
           "legendFormat": "node memory - {{ namespace }}",
           "range": true,


### PR DESCRIPTION
This PR

- fixes a panel in the prometehus cost estimation dashboard
- screenshots before:
![image](https://github.com/giantswarm/dashboards/assets/2787548/6020d7fa-adac-436c-9011-46cae5163d9e)

- screenshots after:
![image](https://github.com/giantswarm/dashboards/assets/2787548/432124c9-0479-4ee1-8c4b-853aaecbc603)

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
