### PR TITLE
Lint capi/a aggregated error logs dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Lint the capi and capa aggregated-error-logs dashboards to have proper datasource variables.
+
 ## [3.16.1] - 2024-06-04
 
 ### Changed

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/capa-aggregated-error-logs.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/capa-aggregated-error-logs.json
@@ -57,7 +57,7 @@
           "refId": "A"
         }
       ],
-      "title": "Agregated error logs for all CAPA controllers - capa-controller-manager, capa-iam-operator,aws-resolver-rules-operator,irsa-operator",
+      "title": "Aggregated error logs for all CAPA controllers - capa-controller-manager, capa-iam-operator,aws-resolver-rules-operator,irsa-operator",
       "transparent": true,
       "type": "logs"
     }
@@ -72,10 +72,39 @@
     "list": [
       {
         "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Prometheus data source",
+        "name": "prometheus_datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Loki data source",
+        "multi": false,
+        "name": "loki_datasource",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "${datasource}"
+          "uid": "${prometheus_datasource}"
         },
         "definition": "label_values(up{app=\"kubernetes\"},cluster_id)",
         "hide": 0,
@@ -89,43 +118,11 @@
           "query": "label_values(up{app=\"kubernetes\"},cluster_id)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
-      },
-      {
-        "current": {
-        },
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "loki_datasource",
-        "options": [],
-        "query": "loki",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "type": "datasource"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "Mimir",
-          "value": "mimir"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "datasource",
-        "options": [],
-        "query": "prometheus",
-        "queryValue": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "type": "datasource"
       }
     ]
   },
@@ -135,7 +132,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "CAPA - agregated error logs for capa controllers",
+  "title": "CAPA - aggregated error logs for capa controllers",
   "uid": "bdiako8tt1b7kc",
   "version": 2,
   "weekStart": ""

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/capi-aggregated-error-logs.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/capi-aggregated-error-logs.json
@@ -57,7 +57,7 @@
           "refId": "A"
         }
       ],
-      "title": "Agregated error logs for all CAPI controllers",
+      "title": "Aggregated error logs for all CAPI controllers",
       "transparent": true,
       "type": "logs"
     }
@@ -72,10 +72,39 @@
     "list": [
       {
         "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Prometheus data source",
+        "name": "prometheus_datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Loki data source",
+        "multi": false,
+        "name": "loki_datasource",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "${datasource}"
+          "uid": "${prometheus_datasource}"
         },
         "definition": "label_values(up{app=\"kubernetes\"},cluster_id)",
         "hide": 0,
@@ -89,43 +118,11 @@
           "query": "label_values(up{app=\"kubernetes\"},cluster_id)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
-      },
-      {
-        "current": {
-        },
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "loki_datasource",
-        "options": [],
-        "query": "loki",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "type": "datasource"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "Mimir",
-          "value": "mimir"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "datasource",
-        "options": [],
-        "query": "prometheus",
-        "queryValue": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "type": "datasource"
       }
     ]
   },
@@ -135,7 +132,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "CAPI - agregated error logs for capi controllers",
+  "title": "CAPI - aggregated error logs for capi controllers",
   "uid": "bdi7iswg81czkcasd",
   "version": 9,
   "weekStart": ""


### PR DESCRIPTION
This PR fixes linting warning on the new capi/a dashboards

This PR also fixes typos on the word aggregated.

@giantswarm/team-phoenix should the capi-aggregated-dashboard not belong to turtles instead of phoenix?

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
