### PR TITLE
Add missing datasource to certificate dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Add missing datasource to api-performance dashboard and fix tags.
+- Add missing datasource to `api-performance` dashboard and fix tags.
+- Add missing datasource to `certificate` dashboard and fix tags.
 - Lint the capi and capa aggregated-error-logs dashboards to have proper datasource variables.
 
 ### Removed

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/certificate-requests.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/certificate-requests.json
@@ -32,7 +32,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -103,7 +103,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(etcd_kubernetes_resources_count{cluster_id=~\"$cluster_id\", kind=\"certificates.cert-manager.io\"}) by (cluster_id)",
@@ -119,7 +119,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -190,7 +190,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(etcd_kubernetes_resources_count{cluster_id=~\"$cluster_id\", kind=\"certificaterequests.cert-manager.io\"}) by (cluster_id)",
@@ -207,10 +207,24 @@
   "schemaVersion": 36,
   "style": "dark",
   "tags": [
-    "owner:team-cabbage"
+    "owner:team-bigmac"
   ],
   "templating": {
     "list": [
+      {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allValue": ".*",
         "current": {
@@ -220,7 +234,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "${datasource}"
         },
         "definition": "label_values(etcd_kubernetes_resources_count, cluster_id)",
         "hide": 0,
@@ -233,7 +247,7 @@
           "query": "label_values(etcd_kubernetes_resources_count, cluster_id)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/certificates-details.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/certificates-details.json
@@ -32,9 +32,9 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
-      "description": "Show the clusters with certificate expiry in less than  month.\n\nUpgrade should be planned ",
+      "description": "Show the clusters with certificate expiry in less than month.\n\nUpgrade should be planned ",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -145,7 +145,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "cert_exporter_not_after{path!=\"/etc/kubernetes/ssl/service-account-crt.pem\", cluster_id=\"$cluster\"} - time()",
@@ -177,10 +177,24 @@
   "schemaVersion": 36,
   "style": "dark",
   "tags": [
-    "owner:team-honeybadger"
+    "owner:team-bigmac"
   ],
   "templating": {
     "list": [
+      {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allValue": ".*",
         "current": {
@@ -190,7 +204,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "${datasource}"
         },
         "definition": "label_values(kubernetes_build_info, organization)",
         "hide": 0,
@@ -203,7 +217,7 @@
           "query": "label_values(kubernetes_build_info, organization)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -217,7 +231,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "${datasource}"
         },
         "definition": "label_values(kubernetes_build_info{organization=~\"$organization\"}, cluster_id)",
         "hide": 0,
@@ -230,7 +244,7 @@
           "query": "label_values(kubernetes_build_info{organization=~\"$organization\"}, cluster_id)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/certificates.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/certificates.json
@@ -20,6 +20,7 @@
   "panels": [
     {
       "columns": [],
+      "datasource": "$datasource",
       "description": "Show the clusters with certificate expiry in less than  month.\n\nUpgrade should be planned ",
       "fontSize": "100%",
       "gridPos": {
@@ -96,6 +97,7 @@
     },
     {
       "columns": [],
+      "datasource": "$datasource",
       "description": "Show the clusters closest certificates expiry",
       "fontSize": "100%",
       "gridPos": {
@@ -175,10 +177,25 @@
   "schemaVersion": 18,
   "style": "dark",
   "tags": [
-    "owner:team-honeybadger"
+    "owner:team-bigmac"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",


### PR DESCRIPTION
This PR adds the missing datasource so the dashboard can be checked on mimir and also fixes the tag ownership because certificate related dashboards should not belong to honeybadger.

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
