### PR TITLE
Add datasource in a few phoenix dashboards

### DIFF
--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/capa-aggregated-error-logs.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/capa-aggregated-error-logs.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "aggregate error logs for specific cluster ID for CAPA controllers",
+  "description": "aggregate error logs for specific cluster for CAPA controllers",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/capi-aggregated-error-logs.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/capi-aggregated-error-logs.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "aggregate error logs for specific cluster ID from all 3 CAPI controllers",
+  "description": "aggregate error logs for specific cluster from all 3 CAPI controllers",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/conntrack.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/conntrack.json
@@ -27,6 +27,7 @@
   "liveNow": false,
   "panels": [
     {
+      "datasource": "${datasource}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -96,7 +97,6 @@
       },
       "targets": [
         {
-          "datasource": "default",
           "exemplar": true,
           "expr": "avg by (node) (node_nf_conntrack_entries{cluster_id=\"$cluster\"})",
           "interval": "",
@@ -104,7 +104,6 @@
           "refId": "A"
         },
         {
-          "datasource": "default",
           "exemplar": true,
           "expr": "max by (node) (node_nf_conntrack_entries_limit{cluster_id=\"$cluster\"})",
           "hide": false,
@@ -128,14 +127,29 @@
     "list": [
       {
         "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
           "selected": true,
           "text": "5jka7",
           "value": "5jka7"
         },
+        "datasource": "$datasource",
         "definition": "label_values(node_nf_conntrack_entries,cluster_id)",
         "hide": 0,
         "includeAll": false,
-        "label": "Cluster ID",
+        "label": "Cluster",
         "multi": false,
         "name": "cluster",
         "options": [],
@@ -143,7 +157,7 @@
           "query": "label_values(node_nf_conntrack_entries,cluster_id)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-backup.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-backup.json
@@ -20,7 +20,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": "default",
+      "datasource": "${datasource}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -31,7 +31,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "refId": "A"
         }
       ],
@@ -43,7 +43,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "Size of the etcd snapshot archive.",
       "fieldConfig": {
         "defaults": {
@@ -88,7 +88,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "expr": "avg by (tenant_cluster_id) (etcd_backup_size_bytes)",
           "legendFormat": "{{tenant_cluster_id}}",
           "refId": "A"
@@ -130,7 +130,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "The time it took to take the etcd snapshot.",
       "fieldConfig": {
         "defaults": {
@@ -174,7 +174,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "expr": "avg by (tenant_cluster_id) (etcd_backup_creation_time_ms)",
           "legendFormat": "{{tenant_cluster_id}}",
           "refId": "A"
@@ -216,7 +216,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "The time it took to encrypt the backup, if encryption is enabled.",
       "fieldConfig": {
         "defaults": {
@@ -260,7 +260,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "expr": "avg by (tenant_cluster_id) (etcd_backup_encryption_time_ms)",
           "legendFormat": "{{tenant_cluster_id}}",
           "refId": "A"
@@ -302,7 +302,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "The time it took to upload the backup archive to the S3 bucket. ",
       "fieldConfig": {
         "defaults": {
@@ -346,7 +346,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "expr": "avg by (tenant_cluster_id) (etcd_backup_upload_time_ms)",
           "legendFormat": "{{tenant_cluster_id}}",
           "refId": "A"
@@ -385,7 +385,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "default",
+      "datasource": "${datasource}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -396,7 +396,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "refId": "A"
         }
       ],
@@ -404,7 +404,7 @@
       "type": "row"
     },
     {
-      "datasource": "default",
+      "datasource": "${datasource}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -467,7 +467,7 @@
       "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "expr": "(count(sum(max_over_time(cluster_service_cluster_info{}[$__range])) by (cluster_id)) OR on() vector(0)) + (count(count(max_over_time(cluster_operator_cluster_status{}[$__range])) by (cluster_id)) OR on() vector(0)) - (count(count(max_over_time(cluster_operator_cluster_status{status=\"Deleting\"}[$__range]) == 1) by (cluster_id)) OR on() vector(0))",
           "refId": "A"
         }
@@ -476,7 +476,7 @@
       "type": "stat"
     },
     {
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "The count of non-management cluster etcd backups.",
       "fieldConfig": {
         "defaults": {
@@ -541,7 +541,7 @@
       "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "exemplar": true,
           "expr": "count(count (etcd_backup_latest_success{tenant_cluster_id != \"ManagementCluster\"}) by (tenant_cluster_id))",
           "interval": "",
@@ -553,7 +553,7 @@
       "type": "stat"
     },
     {
-      "datasource": "default",
+      "datasource": "${datasource}",
       "gridPos": {
         "h": 2,
         "w": 1,
@@ -573,14 +573,14 @@
       "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "refId": "A"
         }
       ],
       "type": "text"
     },
     {
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "The last time a backup was scheduled, whether successful or not.",
       "fieldConfig": {
         "defaults": {
@@ -643,7 +643,7 @@
       "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "exemplar": true,
           "expr": "max(etcd_backup_latest_attempt{tenant_cluster_id=\"ManagementCluster\",etcd_version=\"V2\"}*1000)",
           "hide": false,
@@ -656,7 +656,7 @@
       "type": "stat"
     },
     {
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "Date of the latest backup completed successfully. This is the time the backup was taken, not when it finished uploading.",
       "fieldConfig": {
         "defaults": {
@@ -719,7 +719,7 @@
       "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "exemplar": true,
           "expr": "max(etcd_backup_latest_success{tenant_cluster_id=\"ManagementCluster\",etcd_version=\"V2\"}*1000)",
           "hide": false,
@@ -732,7 +732,7 @@
       "type": "stat"
     },
     {
-      "datasource": "default",
+      "datasource": "${datasource}",
       "gridPos": {
         "h": 2,
         "w": 1,
@@ -752,14 +752,14 @@
       "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "refId": "A"
         }
       ],
       "type": "text"
     },
     {
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "The last time a backup was scheduled, whether successful or not.",
       "fieldConfig": {
         "defaults": {
@@ -822,7 +822,7 @@
       "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "exemplar": true,
           "expr": "max(etcd_backup_latest_attempt{tenant_cluster_id=\"ManagementCluster\",etcd_version=\"V3\"}*1000)",
           "hide": false,
@@ -835,7 +835,7 @@
       "type": "stat"
     },
     {
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "Date of the latest backup completed successfully. This is the time the backup was taken, not when it finished uploading.",
       "fieldConfig": {
         "defaults": {
@@ -898,7 +898,7 @@
       "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "exemplar": true,
           "expr": "max(etcd_backup_latest_success{tenant_cluster_id=\"ManagementCluster\",etcd_version=\"V3\"}*1000)",
           "hide": false,
@@ -911,7 +911,7 @@
       "type": "stat"
     },
     {
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "These include the Management Cluster in CAPI clusters.",
       "gridPos": {
         "h": 2,
@@ -932,7 +932,7 @@
       "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "refId": "A"
         }
       ],
@@ -941,7 +941,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "default",
+      "datasource": "${datasource}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -953,7 +953,7 @@
       "repeat": "cluster",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "refId": "A"
         }
       ],
@@ -961,7 +961,7 @@
       "type": "row"
     },
     {
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "The last time a backup was scheduled, whether successful or not.",
       "fieldConfig": {
         "defaults": {
@@ -1024,7 +1024,7 @@
       "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "expr": "max(etcd_backup_latest_attempt{tenant_cluster_id=\"$cluster\",etcd_version=\"V3\"}*1000)",
           "hide": false,
           "refId": "A"
@@ -1034,7 +1034,7 @@
       "type": "stat"
     },
     {
-      "datasource": "default",
+      "datasource": "${datasource}",
       "description": "Date of the latest backup completed successfully. This is the time the backup was taken, not when it finished uploading.",
       "fieldConfig": {
         "defaults": {
@@ -1098,7 +1098,7 @@
       "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": "default",
+          "datasource": "${datasource}",
           "expr": "max(etcd_backup_latest_success{tenant_cluster_id=\"$cluster\",etcd_version=\"V3\"}*1000)",
           "hide": false,
           "refId": "A"
@@ -1112,10 +1112,25 @@
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
-    "owner:team-phoenix"
+    "owner:team-phoenix",
+    "component:etcd"
   ],
   "templating": {
     "list": [
+      {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "allValue": null,
         "current": {
@@ -1127,7 +1142,7 @@
             "$__all"
           ]
         },
-        "datasource": "default",
+        "datasource": "${datasource}",
         "definition": "label_values(etcd_backup_latest_attempt, tenant_cluster_id)",
         "description": null,
         "error": null,
@@ -1141,7 +1156,7 @@
           "query": "label_values(etcd_backup_latest_attempt, tenant_cluster_id)",
           "refId": "Promxy-cluster-Variable-Query"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "/^[^M]+$/",
         "skipUrlSync": false,
         "sort": 1,

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-k8s-events-and-resources-count.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-k8s-events-and-resources-count.json
@@ -43,7 +43,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -120,7 +120,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -137,7 +137,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -215,7 +215,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -245,7 +245,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -309,7 +309,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -326,7 +326,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -403,7 +403,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(rate(etcd_kubernetes_events_count{cluster_id=\"$cluster\", namespace=~\"$namespace\"}[1h])) by (namespace)",
@@ -420,7 +420,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -498,7 +498,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(etcd_kubernetes_events_count{cluster_id=\"$cluster\",namespace=~\"$namespace\"}) by (kind)",
@@ -516,7 +516,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -594,7 +594,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(etcd_kubernetes_events_count{cluster_id=\"$cluster\",namespace=~\"$namespace\"}) by (reason)",
@@ -612,7 +612,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -690,7 +690,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(etcd_kubernetes_events_count{cluster_id=\"$cluster\",namespace=~\"$namespace\"}) by (namespace)",
@@ -710,10 +710,25 @@
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
-    "owner:team-phoenix"
+    "owner:team-phoenix",
+    "component:etcd"
   ],
   "templating": {
     "list": [
+      {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
       {
         "current": {
           "selected": true,
@@ -722,12 +737,12 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "${datasource}"
         },
         "definition": "label_values(etcd_kubernetes_resources_count, cluster_id)",
         "hide": 0,
         "includeAll": false,
-        "label": "Cluster ID",
+        "label": "Cluster",
         "multi": false,
         "name": "cluster",
         "options": [],
@@ -735,7 +750,7 @@
           "query": "label_values(etcd_kubernetes_resources_count, cluster_id)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -754,7 +769,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "${datasource}"
         },
         "definition": "label_values(etcd_kubernetes_resources_count, namespace)",
         "hide": 0,
@@ -767,7 +782,7 @@
           "query": "label_values(etcd_kubernetes_resources_count, namespace)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/team-firecracker.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/team-firecracker.json
@@ -23,7 +23,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "default",
+      "datasource": "$datasource",
       "decimals": 5,
       "description": "The graph shows when the API of a certain Workload Cluster is up or down. The table shows the average uptime percentage over the amount of time selected for the Grafana Dashboard. Selecting a 7 day time range and having a result of 0.99 means that the Workload Cluster has an average uptime of 99% over the past 7 days. ",
       "fill": 0,
@@ -120,7 +120,22 @@
     "owner:team-phoenix"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-7d",

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/cilium.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/cilium.json
@@ -32,7 +32,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -144,9 +144,9 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
-          "expr": "sum(rate(cilium_errors_warnings_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, level) * 60",
+          "expr": "sum(rate(cilium_errors_warnings_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, level) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} ({{level}})",
@@ -160,7 +160,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -285,9 +285,9 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
-          "expr": "min(irate(cilium_process_cpu_seconds_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod) * 100",
+          "expr": "min(irate(cilium_process_cpu_seconds_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min ({{pod}})",
@@ -297,9 +297,9 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
-          "expr": "avg(irate(cilium_process_cpu_seconds_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod) * 100",
+          "expr": "avg(irate(cilium_process_cpu_seconds_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg ({{pod}})",
@@ -309,9 +309,9 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
-          "expr": "max(irate(cilium_process_cpu_seconds_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod) * 100",
+          "expr": "max(irate(cilium_process_cpu_seconds_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max ({{pod}})",
@@ -326,7 +326,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -339,7 +339,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -509,7 +509,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_process_virtual_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -520,7 +520,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_process_virtual_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -531,7 +531,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_process_virtual_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -546,7 +546,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -643,7 +643,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_process_resident_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -655,7 +655,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_process_resident_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -667,7 +667,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_process_resident_memory_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -682,7 +682,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -779,7 +779,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "sum(cilium_process_open_fds{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -790,7 +790,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_process_open_fds{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -801,7 +801,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_process_open_fds{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -812,7 +812,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_process_open_fds{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -827,7 +827,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "BPF memory usage in the entire system including components not managed by Cilium.",
           "fieldConfig": {
@@ -925,7 +925,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_bpf_maps_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -938,7 +938,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_bpf_maps_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -951,7 +951,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_bpf_maps_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"} + cilium_bpf_progs_virtual_memory_max_bytes{cluster_id=\"$cluster_id\",pod=~\"$pod\"})",
               "format": "time_series",
@@ -969,7 +969,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Fill percentage of BPF maps, tagged by map name",
           "fieldConfig": {
@@ -1051,7 +1051,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "cilium_bpf_map_pressure{cluster_id=\"$cluster_id\",pod=~\"$pod\"}",
               "interval": "",
@@ -1067,7 +1067,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -1079,7 +1079,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -1092,7 +1092,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1216,9 +1216,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_agent_api_process_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])/rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, method, path)",
+              "expr": "avg(rate(cilium_agent_api_process_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])/rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}}",
@@ -1231,7 +1231,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1355,9 +1355,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "max(rate(cilium_agent_api_process_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])/rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, method, path)",
+              "expr": "max(rate(cilium_agent_api_process_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])/rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}}",
@@ -1370,7 +1370,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1494,9 +1494,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, method, path)",
+              "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}} ",
@@ -1509,7 +1509,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1633,9 +1633,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "max(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, method, path)",
+              "expr": "max(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}} ",
@@ -1648,7 +1648,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1772,9 +1772,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, method, path, return_code)",
+              "expr": "avg(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, method, path, return_code)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{return_code}} ({{method}} {{path}} )",
@@ -1787,7 +1787,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1911,9 +1911,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, method, path, return_code)",
+              "expr": "sum(rate(cilium_agent_api_process_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, method, path, return_code)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{return_code}} ({{method}} {{path}} )",
@@ -1928,7 +1928,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -1940,7 +1940,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -1953,7 +1953,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -1977,7 +1977,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "refId": "A"
             }
@@ -1988,7 +1988,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2113,9 +2113,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, operation)",
+              "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, operation)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{operation}}",
@@ -2128,7 +2128,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2254,9 +2254,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "max(rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, operation)",
+              "expr": "max(rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, operation)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{operation}}",
@@ -2269,7 +2269,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2394,9 +2394,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])/ rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, operation)",
+              "expr": "avg(rate(cilium_bpf_syscall_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])/ rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, operation)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{operation}}",
@@ -2409,7 +2409,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2493,9 +2493,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "max(rate(cilium_bpf_syscall_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])/ rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, operation)",
+              "expr": "max(rate(cilium_bpf_syscall_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])/ rate(cilium_bpf_syscall_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, operation)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{operation}}",
@@ -2508,7 +2508,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2610,9 +2610,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, map_name, operation))",
+              "expr": "topk(5, avg(rate(cilium_bpf_map_ops_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, map_name, operation))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{map_name}} {{operation}}",
@@ -2625,7 +2625,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2727,9 +2727,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, map_name, operation))",
+              "expr": "topk(5, max(rate(cilium_bpf_map_ops_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, map_name, operation))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{map_name}} {{operation}}",
@@ -2742,7 +2742,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -2864,9 +2864,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_bpf_map_ops_total{cluster_id=\"$cluster_id\",k8s_app=\"cilium\",outcome=\"fail\", pod=~\"$pod\"}[5m])) by (pod, map_name, operation)",
+              "expr": "sum(rate(cilium_bpf_map_ops_total{cluster_id=\"$cluster_id\",k8s_app=\"cilium\",outcome=\"fail\", pod=~\"$pod\"}[$__rate_interval])) by (pod, map_name, operation)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{map_name}} {{operation}}",
@@ -2879,7 +2879,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -2903,7 +2903,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "refId": "A"
             }
@@ -2914,7 +2914,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3040,9 +3040,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(kvstore_operations_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope, action)",
+              "expr": "sum(rate(kvstore_operations_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}} {{action}}",
@@ -3055,7 +3055,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3181,9 +3181,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "max(rate(kvstore_operations_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope, action)",
+              "expr": "max(rate(kvstore_operations_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}} {{action}}",
@@ -3196,7 +3196,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3321,9 +3321,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "topk(5, avg(rate(cilium_kvstore_operations_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, action, scope))",
+              "expr": "topk(5, avg(rate(cilium_kvstore_operations_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, action, scope))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -3336,7 +3336,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3461,9 +3461,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "topk(5, max(rate(cilium_kvstore_operations_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, action, scope))",
+              "expr": "topk(5, max(rate(cilium_kvstore_operations_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, action, scope) / avg(rate(cilium_kvstore_operations_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, action, scope))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -3476,7 +3476,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3598,9 +3598,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_kvstore_events_queue_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope, action)",
+              "expr": "avg(rate(cilium_kvstore_events_queue_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -3613,7 +3613,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -3637,7 +3637,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "refId": "A"
             }
@@ -3648,7 +3648,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3729,9 +3729,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_forward_count_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, direction)",
+              "expr": "sum(rate(cilium_forward_count_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, direction)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{direction}}",
@@ -3744,7 +3744,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3825,9 +3825,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_forward_bytes_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, direction) * 8",
+              "expr": "sum(rate(cilium_forward_bytes_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, direction) * 8",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{direction}}",
@@ -3840,7 +3840,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4205,7 +4205,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -4217,7 +4217,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -4228,7 +4228,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\",status=\"alive\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -4239,7 +4239,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -4250,7 +4250,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv4\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -4265,7 +4265,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -4630,7 +4630,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -4642,7 +4642,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -4653,7 +4653,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -4664,7 +4664,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -4675,7 +4675,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv6\", protocol=\"TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -4690,7 +4690,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5055,7 +5055,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -5067,7 +5067,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -5078,7 +5078,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -5089,7 +5089,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -5100,7 +5100,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv4\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -5115,7 +5115,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5480,7 +5480,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -5492,7 +5492,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -5503,7 +5503,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"alive\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -5514,7 +5514,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -5525,7 +5525,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_datapath_conntrack_gc_entries{cluster_id=\"$cluster_id\", status=\"deleted\", family=\"ipv6\", protocol=\"non-TCP\", pod=~\"$pod\"}) by (family,status)",
               "format": "time_series",
@@ -5540,7 +5540,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5657,7 +5657,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "sum(cilium_ip_addresses{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod, family)\n",
               "format": "time_series",
@@ -5672,7 +5672,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5784,7 +5784,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "sum(cilium_datapath_conntrack_dump_resets_total{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod, area, family, name)",
               "format": "time_series",
@@ -5799,7 +5799,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5880,9 +5880,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_services_events_total{cluster_id=\"$cluster_id\", pod=~\"$pod\"}[5m])) by (pod, action)",
+              "expr": "avg(rate(cilium_services_events_total{cluster_id=\"$cluster_id\", pod=~\"$pod\"}[$__rate_interval])) by (pod, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}}",
@@ -5895,7 +5895,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -5976,7 +5976,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "sum(cilium_unreachable_nodes{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -5987,7 +5987,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "sum(cilium_unreachable_health_endpoints{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -6002,7 +6002,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -6083,9 +6083,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_drop_count_total{cluster_id=\"$cluster_id\", direction=\"EGRESS\", pod=~\"$pod\"}[5m])) by (reason)",
+              "expr": "sum(rate(cilium_drop_count_total{cluster_id=\"$cluster_id\", direction=\"EGRESS\", pod=~\"$pod\"}[$__rate_interval])) by (reason)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{reason}}",
@@ -6098,7 +6098,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -6286,9 +6286,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_nodes_all_events_received_total{cluster_id=\"$cluster_id\", pod=~\"$pod\"}[5m])) by (pod, event_type, source) * 60",
+              "expr": "avg(rate(cilium_nodes_all_events_received_total{cluster_id=\"$cluster_id\", pod=~\"$pod\"}[$__rate_interval])) by (pod, event_type, source) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{eventType}} {{source}}",
@@ -6301,7 +6301,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -6382,9 +6382,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_drop_bytes_total{cluster_id=\"$cluster_id\", direction=\"EGRESS\", pod=~\"$pod\"}[5m])) by (reason) * 8",
+              "expr": "sum(rate(cilium_drop_bytes_total{cluster_id=\"$cluster_id\", direction=\"EGRESS\", pod=~\"$pod\"}[$__rate_interval])) by (reason) * 8",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{reason}}",
@@ -6397,7 +6397,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -6537,7 +6537,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_nodes_all_num{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -6548,7 +6548,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_nodes_all_num{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -6559,7 +6559,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_nodes_all_num{cluster_id=\"$cluster_id\", pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -6574,7 +6574,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -6598,7 +6598,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "refId": "A"
             }
@@ -6609,7 +6609,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -6736,9 +6736,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_policy_l7_denied_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m]))",
+              "expr": "sum(rate(cilium_policy_l7_denied_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "denied",
@@ -6747,9 +6747,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_policy_l7_forwarded_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m]))",
+              "expr": "sum(rate(cilium_policy_l7_forwarded_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "forwarded",
@@ -6758,9 +6758,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_policy_l7_received_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m]))",
+              "expr": "sum(rate(cilium_policy_l7_received_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "received",
@@ -6773,7 +6773,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -6854,9 +6854,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_drop_count_total{cluster_id=\"$cluster_id\",direction=\"INGRESS\", pod=~\"$pod\"}[5m])) by (reason)",
+              "expr": "sum(rate(cilium_drop_count_total{cluster_id=\"$cluster_id\",direction=\"INGRESS\", pod=~\"$pod\"}[$__rate_interval])) by (reason)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{reason}}",
@@ -6869,7 +6869,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -7061,9 +7061,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope)",
+              "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7073,7 +7073,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_policy_l7_parse_errors_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -7088,7 +7088,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -7169,9 +7169,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_drop_bytes_total{cluster_id=\"$cluster_id\",direction=\"INGRESS\", pod=~\"$pod\"}[5m])) by (reason) * 8",
+              "expr": "sum(rate(cilium_drop_bytes_total{cluster_id=\"$cluster_id\",direction=\"INGRESS\", pod=~\"$pod\"}[$__rate_interval])) by (reason) * 8",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{reason}}",
@@ -7184,7 +7184,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -7378,9 +7378,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "min(rate(cilium_triggers_policy_update_call_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope)",
+              "expr": "min(rate(cilium_triggers_policy_update_call_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "min",
@@ -7389,9 +7389,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_triggers_policy_update_call_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope)",
+              "expr": "avg(rate(cilium_triggers_policy_update_call_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "avg",
@@ -7400,9 +7400,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "max(rate(cilium_triggers_policy_update_call_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope)",
+              "expr": "max(rate(cilium_triggers_policy_update_call_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope) / sum(rate(cilium_triggers_policy_update_call_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max",
@@ -7415,7 +7415,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -7556,9 +7556,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "max(rate(cilium_proxy_upstream_reply_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope)",
+              "expr": "max(rate(cilium_proxy_upstream_reply_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope) / sum(rate(cilium_proxy_upstream_reply_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Max {{scope}}",
@@ -7567,9 +7567,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "max(rate(cilium_policy_l7_parse_errors_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod)",
+              "expr": "max(rate(cilium_policy_l7_parse_errors_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "parse errors",
@@ -7582,7 +7582,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -7726,7 +7726,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "sum(cilium_policy_endpoint_enforcement_status{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (enforcement)",
               "format": "time_series",
@@ -7744,7 +7744,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -7899,7 +7899,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_proxy_redirects{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -7910,7 +7910,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_proxy_redirects{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -7921,7 +7921,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_proxy_redirects{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -7936,7 +7936,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -8148,9 +8148,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "min(rate(cilium_triggers_policy_update_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod) * 60",
+              "expr": "min(rate(cilium_triggers_policy_update_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "min trigger",
@@ -8159,9 +8159,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_triggers_policy_update_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod) * 60",
+              "expr": "avg(rate(cilium_triggers_policy_update_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "average trigger",
@@ -8170,9 +8170,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "max(rate(cilium_triggers_policy_update_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod) * 60",
+              "expr": "max(rate(cilium_triggers_policy_update_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "max trigger",
@@ -8181,9 +8181,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "max(rate(cilium_triggers_policy_update_folds{pod=~\"$pod\"}[5m])) by (pod) * 60",
+              "expr": "max(rate(cilium_triggers_policy_update_folds{pod=~\"$pod\"}[$__rate_interval])) by (pod) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "folds",
@@ -8196,7 +8196,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -8353,7 +8353,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_policy{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by(pod)",
               "format": "time_series",
@@ -8364,7 +8364,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_policy{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by(pod)",
               "format": "time_series",
@@ -8375,7 +8375,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_policy{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by(pod)",
               "format": "time_series",
@@ -8386,7 +8386,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "sum(cilium_policy_import_errors_total{pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -8401,7 +8401,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -8546,9 +8546,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, scope)",
+              "expr": "avg(rate(cilium_proxy_upstream_reply_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}}",
@@ -8561,7 +8561,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -8716,7 +8716,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "min(cilium_policy_max_revision{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -8727,7 +8727,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "avg(cilium_policy_max_revision{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -8738,7 +8738,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "max(cilium_policy_max_revision{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod)",
               "format": "time_series",
@@ -8753,7 +8753,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -8777,7 +8777,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "refId": "A"
             }
@@ -8788,7 +8788,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -8871,9 +8871,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{cluster_id=\"$cluster_id\",scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
+              "expr": "avg(histogram_quantile(0.90, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{cluster_id=\"$cluster_id\",scope!=\"total\", pod=~\"$pod\"}[$__rate_interval]))) by (scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}}",
@@ -8886,7 +8886,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -8969,9 +8969,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{cluster_id=\"$cluster_id\",scope!=\"total\", pod=~\"$pod\"}[5m]))) by (scope)",
+              "expr": "avg(histogram_quantile(0.99, rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{cluster_id=\"$cluster_id\",scope!=\"total\", pod=~\"$pod\"}[$__rate_interval]))) by (scope)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{scope}}",
@@ -8984,7 +8984,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9129,9 +9129,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_endpoint_regenerations_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[30s])) by(outcome)",
+              "expr": "sum(rate(cilium_endpoint_regenerations_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by(outcome)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -9145,7 +9145,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9274,7 +9274,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "sum(cilium_endpoint_state{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (endpoint_state)",
               "format": "time_series",
@@ -9289,7 +9289,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -9313,7 +9313,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "refId": "A"
             }
@@ -9324,7 +9324,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9454,9 +9454,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_controllers_runs_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod)",
+              "expr": "sum(rate(cilium_controllers_runs_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Runs",
@@ -9465,7 +9465,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "expr": "sum(cilium_controllers_failing{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by(pod)",
               "format": "time_series",
@@ -9480,7 +9480,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9657,9 +9657,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_controllers_runs_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, status) / sum(rate(cilium_controllers_runs_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, status)",
+              "expr": "sum(rate(cilium_controllers_runs_duration_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, status) / sum(rate(cilium_controllers_runs_duration_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, status)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{status}}",
@@ -9672,7 +9672,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "gridPos": {
             "h": 1,
@@ -9696,7 +9696,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "refId": "A"
             }
@@ -9707,7 +9707,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9829,9 +9829,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_k8s_client_api_latency_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])/rate(cilium_k8s_client_api_latency_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, method, path)",
+              "expr": "avg(rate(cilium_k8s_client_api_latency_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])/rate(cilium_k8s_client_api_latency_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}}",
@@ -9844,7 +9844,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -9966,9 +9966,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "max(rate(cilium_k8s_client_api_latency_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])/rate(cilium_k8s_client_api_latency_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, method, path)",
+              "expr": "max(rate(cilium_k8s_client_api_latency_time_seconds_sum{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])/rate(cilium_k8s_client_api_latency_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}}",
@@ -9981,7 +9981,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -10106,9 +10106,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_k8s_client_api_latency_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, method, path)",
+              "expr": "sum(rate(cilium_k8s_client_api_latency_time_seconds_count{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, method, path)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{path}}",
@@ -10121,7 +10121,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -10245,9 +10245,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_k8s_client_api_calls_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, method, return_code)",
+              "expr": "sum(rate(cilium_k8s_client_api_calls_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, method, return_code)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{method}} {{return_code}}",
@@ -10260,7 +10260,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -10384,9 +10384,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"true\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
+              "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"true\", valid=\"true\", pod=~\"$pod\"}[$__rate_interval])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -10399,7 +10399,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -10523,9 +10523,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"true\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
+              "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"true\", valid=\"false\", pod=~\"$pod\"}[$__rate_interval])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -10542,7 +10542,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -10592,9 +10592,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"false\", valid=\"true\", pod=~\"$pod\"}[5m])) by (pod, scope, action, valid)",
+              "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"false\", valid=\"true\", pod=~\"$pod\"}[$__rate_interval])) by (pod, scope, action, valid)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -10638,7 +10638,7 @@
           "dashes": false,
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -10688,9 +10688,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"false\", valid=\"false\", pod=~\"$pod\"}[5m])) by (pod, scope, action)",
+              "expr": "sum(rate(cilium_kubernetes_events_received_total{cluster_id=\"$cluster_id\",equal=\"false\", valid=\"false\", pod=~\"$pod\"}[$__rate_interval])) by (pod, scope, action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} {{scope}}",
@@ -10730,7 +10730,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -10811,9 +10811,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"CiliumNetworkPolicy\", pod=~\"$pod\"}[5m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"CiliumNetworkPolicy\", pod=~\"$pod\"}[$__rate_interval])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} avg",
@@ -10826,7 +10826,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -10953,9 +10953,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"NetworkPolicy\", pod=~\"$pod\"}[5m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"NetworkPolicy\", pod=~\"$pod\"}[$__rate_interval])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} avg",
@@ -10968,7 +10968,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -11095,9 +11095,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Pod\", pod=~\"$pod\"}[5m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Pod\", pod=~\"$pod\"}[$__rate_interval])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} avg",
@@ -11110,7 +11110,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -11237,9 +11237,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Node\", pod=~\"$pod\"}[5m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Node\", pod=~\"$pod\"}[$__rate_interval])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}} avg",
@@ -11252,7 +11252,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -11333,9 +11333,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Service\", pod=~\"$pod\"}[5m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Service\", pod=~\"$pod\"}[$__rate_interval])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}}",
@@ -11348,7 +11348,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -11429,9 +11429,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Endpoint\", pod=~\"$pod\"}[5m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Endpoint\", pod=~\"$pod\"}[$__rate_interval])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}}",
@@ -11444,7 +11444,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -11525,9 +11525,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
-              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Namespace\", pod=~\"$pod\"}[5m])) by (pod, action) * 60",
+              "expr": "avg(rate(cilium_kubernetes_events_total{cluster_id=\"$cluster_id\",scope=\"Namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod, action) * 60",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{action}}",
@@ -11542,7 +11542,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -11566,7 +11566,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -11720,7 +11720,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(cilium_api_limiter_adjustment_factor{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod, api_call)",
@@ -11737,7 +11737,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -11891,7 +11891,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "avg(cilium_api_limiter_rate_limit{cluster_id=\"$cluster_id\",pod=~\"$pod\"}) by (pod, api_call, value)",
@@ -11908,7 +11908,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -12161,10 +12161,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(cilium_api_limiter_processed_requests_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[5m])) by (pod, api_call, outcome) * 60",
+          "expr": "sum(rate(cilium_api_limiter_processed_requests_total{cluster_id=\"$cluster_id\",pod=~\"$pod\"}[$__rate_interval])) by (pod, api_call, outcome) * 60",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{api_call}} {{outcome}}",
@@ -12181,15 +12181,33 @@
   "style": "dark",
   "tags": [
     "topic:networking",
-    "owner:team-phoenix"
+    "owner:team-cabbage"
   ],
   "templating": {
     "list": [
       {
         "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "label": "Data source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
           "selected": true,
           "text": "gaia",
           "value": "gaia"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
         "definition": "label_values(cilium_version, cluster_id)",
         "hide": 0,
@@ -12202,7 +12220,7 @@
           "query": "label_values(cilium_version, cluster_id)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -12217,7 +12235,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "${datasource}"
         },
         "definition": "label_values(cilium_version{cluster_id=\"$cluster_id\"}, pod)",
         "hide": 0,

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/dns.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/dns.json
@@ -31,7 +31,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "gridPos": {
         "h": 1,
@@ -45,7 +45,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "refId": "A"
         }
@@ -56,7 +56,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "description": "Rate of requests made to CoreDNS.",
       "fieldConfig": {
@@ -144,11 +144,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by(app) (rate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\", zone!=\"dropped\",zone=\"$zone\"}[5m]))",
+          "expr": "sum by(app) (rate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\", zone!=\"dropped\",zone=\"$zone\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -163,7 +163,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "description": "Rate of responses returned by CoreDNS, broken down by response code.\n\nWe expect some degree of `NXDOMAIN` responses.",
       "fieldConfig": {
@@ -252,11 +252,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate({__name__=~\"coredns_dns_response_rcode_count_total|coredns_dns_responses_total\", cluster_id=\"$cluster\", organization=\"$organization\", zone=\"$zone\"}[5m])) by (rcode)",
+          "expr": "sum(rate({__name__=~\"coredns_dns_response_rcode_count_total|coredns_dns_responses_total\", cluster_id=\"$cluster\", organization=\"$organization\", zone=\"$zone\"}[$__rate_interval])) by (rcode)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -272,7 +272,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "gridPos": {
         "h": 1,
@@ -286,7 +286,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "refId": "A"
         }
@@ -297,7 +297,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "description": "- Mean is defined here as the sum of all samples (latency durations), divided by the number of samples.\n- 50th percentile is the value under which 50% of samples fall (equivalent to the median).\n- 95th percentile is the value under which 95% of samples fall.\n\n\n- Lower latencies are, on the whole, better.\n- If the mean is equal or close to the 50th percentile, we have a symmetrical distribution (a bell curve).\n- If the mean is lower than the 50th percentile, the distribution is skewed to the left, or negatively skewed.\n- If the mean is greater than the 50th percentile, the distribution is skewed to the right, or positively skewed.\n\n\n- We expect the 50th percentile to be lower than the mean (positively skewed), as most requests execute quickly.",
       "fieldConfig": {
@@ -383,11 +383,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(irate(coredns_dns_request_duration_seconds_sum{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[5m])) / sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[5m]))",
+          "expr": "sum(irate(coredns_dns_request_duration_seconds_sum{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[$__rate_interval])) / sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -398,11 +398,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.5, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -414,11 +414,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -430,11 +430,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -459,7 +459,7 @@
       "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "description": "For each cumulative bucket exposed by CoreDNS, the percentage of requests that take less than that amount of time to complete.\n\nE.g:\n- 0.001s = 95% means that 95% of requests took less than 0.001s to complete.\n- 0.128s = 99.9% means that 99.9% of requests took less than 0.128s to complete.\n\nAs buckets are cumulative, buckets for higher latencies (e.g: 0.128 is higher than 0.001s) include the values of the smaller lower latencies.",
       "fieldConfig": {
@@ -534,11 +534,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",zone=\"$zone\"}[5m])) by (le) / ignoring (le) group_left sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",zone=\"$zone\"}[5m]))",
+          "expr": "sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",zone=\"$zone\"}[$__rate_interval])) by (le) / ignoring (le) group_left sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",zone=\"$zone\"}[$__rate_interval]))",
           "format": "heatmap",
           "interval": "",
           "intervalFactor": 1,
@@ -579,7 +579,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "description": "- Mean is defined here as the sum of all samples (latency durations), divided by the number of samples.\n- 50th percentile is the value under which 50% of samples fall (equivalent to the median).\n- 95th percentile is the value under which 95% of samples fall.\n\n\n- Lower latencies are, on the whole, better.\n- If the mean is equal or close to the 50th percentile, we have a symmetrical distribution (a bell curve).\n- If the mean is lower than the 50th percentile, the distribution is skewed to the left, or negatively skewed.\n- If the mean is greater than the 50th percentile, the distribution is skewed to the right, or positively skewed.\n\n\n- We expect the 50th percentile to be lower than the mean (positively skewed), as most requests execute quickly.",
       "fieldConfig": {
@@ -665,11 +665,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(irate(coredns_dns_request_duration_seconds_sum{cluster_id=\"$cluster\", organization=\"$organization\",app=\"coredns\",zone=\"$zone\"}[5m])) / sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\",app=\"coredns\",zone=\"$zone\"}[5m]))",
+          "expr": "sum(irate(coredns_dns_request_duration_seconds_sum{cluster_id=\"$cluster\", organization=\"$organization\",app=\"coredns\",zone=\"$zone\"}[$__rate_interval])) / sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\",app=\"coredns\",zone=\"$zone\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -680,11 +680,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.5, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"coredns\",zone=\"$zone\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"coredns\",zone=\"$zone\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -696,11 +696,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"coredns\",zone=\"$zone\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"coredns\",zone=\"$zone\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -712,11 +712,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"coredns\",zone=\"$zone\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"coredns\",zone=\"$zone\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -741,7 +741,7 @@
       "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "description": "For each cumulative bucket exposed by CoreDNS, the percentage of requests that take less than that amount of time to complete.\n\nE.g:\n- 0.001s = 95% means that 95% of requests took less than 0.001s to complete.\n- 0.128s = 99.9% means that 99.9% of requests took less than 0.128s to complete.\n\nAs buckets are cumulative, buckets for higher latencies (e.g: 0.128 is higher than 0.001s) include the values of the smaller lower latencies.",
       "fieldConfig": {
@@ -816,11 +816,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",app=\"coredns\",zone=\"$zone\"}[5m])) by (le) / ignoring (le) group_left sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",app=\"coredns\",zone=\"$zone\"}[5m]))",
+          "expr": "sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",app=\"coredns\",zone=\"$zone\"}[$__rate_interval])) by (le) / ignoring (le) group_left sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",app=\"coredns\",zone=\"$zone\"}[$__rate_interval]))",
           "format": "heatmap",
           "interval": "",
           "intervalFactor": 1,
@@ -861,7 +861,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "description": "- Mean is defined here as the sum of all samples (latency durations), divided by the number of samples.\n- 50th percentile is the value under which 50% of samples fall (equivalent to the median).\n- 95th percentile is the value under which 95% of samples fall.\n\n\n- Lower latencies are, on the whole, better.\n- If the mean is equal or close to the 50th percentile, we have a symmetrical distribution (a bell curve).\n- If the mean is lower than the 50th percentile, the distribution is skewed to the left, or negatively skewed.\n- If the mean is greater than the 50th percentile, the distribution is skewed to the right, or positively skewed.\n\n\n- We expect the 50th percentile to be lower than the mean (positively skewed), as most requests execute quickly.",
       "fieldConfig": {
@@ -947,11 +947,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(irate(coredns_dns_request_duration_seconds_sum{cluster_id=\"$cluster\", organization=\"$organization\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[5m])) / sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[5m]))",
+          "expr": "sum(irate(coredns_dns_request_duration_seconds_sum{cluster_id=\"$cluster\", organization=\"$organization\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[$__rate_interval])) / sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -962,11 +962,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.5, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -978,11 +978,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -994,11 +994,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1023,7 +1023,7 @@
       "dataFormat": "tsbuckets",
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "description": "For each cumulative bucket exposed by CoreDNS, the percentage of requests that take less than that amount of time to complete.\n\nE.g:\n- 0.001s = 95% means that 95% of requests took less than 0.001s to complete.\n- 0.128s = 99.9% means that 99.9% of requests took less than 0.128s to complete.\n\nAs buckets are cumulative, buckets for higher latencies (e.g: 0.128 is higher than 0.001s) include the values of the smaller lower latencies.",
       "fieldConfig": {
@@ -1098,11 +1098,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[5m])) by (le) / ignoring (le) group_left sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[5m]))",
+          "expr": "sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[$__rate_interval])) by (le) / ignoring (le) group_left sum(irate(coredns_dns_request_duration_seconds_count{cluster_id=\"$cluster\", organization=\"$organization\", le!=\"+Inf\",app=\"k8s-dns-node-cache\",zone=\"$zone\"}[$__rate_interval]))",
           "format": "heatmap",
           "interval": "",
           "intervalFactor": 1,
@@ -1131,7 +1131,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "gridPos": {
         "h": 1,
@@ -1145,7 +1145,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "refId": "A"
         }
@@ -1156,7 +1156,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1241,10 +1241,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "exemplar": true,
-          "expr": "rate(container_cpu_usage_seconds_total{container=\"coredns\", cluster_id=\"$cluster\", organization=\"$organization\"}[5m])",
+          "expr": "rate(container_cpu_usage_seconds_total{container=\"coredns\", cluster_id=\"$cluster\", organization=\"$organization\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1258,7 +1258,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1343,7 +1343,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "exemplar": true,
           "expr": "go_memstats_alloc_bytes{app=\"coredns\", cluster_id=\"$cluster\", organization=\"$organization\"}",
@@ -1373,7 +1373,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1458,10 +1458,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "exemplar": true,
-          "expr": "rate(container_cpu_usage_seconds_total{container=\"node-cache\", cluster_id=\"$cluster\", organization=\"$organization\"}[5m])",
+          "expr": "rate(container_cpu_usage_seconds_total{container=\"node-cache\", cluster_id=\"$cluster\", organization=\"$organization\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1475,7 +1475,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1560,7 +1560,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "exemplar": true,
           "expr": "go_memstats_alloc_bytes{app=\"k8s-dns-node-cache\", cluster_id=\"$cluster\", organization=\"$organization\"}",
@@ -1577,7 +1577,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "description": "Ideally the lines on this chart should always be around 0. If they are not, it means DNS requests load is not spread evenly across the CoreDNS replicas running in the cluster. Please be aware that this chart is more accurate when the number of DNS queries is higher.",
       "fieldConfig": {
@@ -1659,10 +1659,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "exemplar": true,
-          "expr": "(sum by (pod) (rate(coredns_dns_requests_total{app=\"coredns\",cluster_id=\"$cluster\", organization=\"$organization\"}[5m])) / ignoring (pod) group_left sum(rate(coredns_dns_requests_total{app=\"coredns\",cluster_id=\"$cluster\", organization=\"$organization\"}[5m])) * 100) - ignoring (pod) group_left 100 / sum(kube_deployment_status_replicas{deployment=~\"coredns-workers|coredns-controlplane\",cluster_id=\"$cluster\", organization=\"$organization\"})",
+          "expr": "(sum by (pod) (rate(coredns_dns_requests_total{app=\"coredns\",cluster_id=\"$cluster\", organization=\"$organization\"}[$__rate_interval])) / ignoring (pod) group_left sum(rate(coredns_dns_requests_total{app=\"coredns\",cluster_id=\"$cluster\", organization=\"$organization\"}[$__rate_interval])) * 100) - ignoring (pod) group_left 100 / sum(kube_deployment_status_replicas{deployment=~\"coredns-workers|coredns-controlplane\",cluster_id=\"$cluster\", organization=\"$organization\"})",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -1687,7 +1687,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1768,10 +1768,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[5m])) by (le,node))",
+          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\",zone=\"$zone\"}[$__rate_interval])) by (le,node))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -1783,7 +1783,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1864,10 +1864,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\",zone=\"$zone\"}[5m])) by (le,node))",
+          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\",zone=\"$zone\"}[$__rate_interval])) by (le,node))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -1879,7 +1879,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1960,10 +1960,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\",zone=\"$zone\"}[5m])) by (le,node))",
+          "expr": "histogram_quantile(0.99, sum(irate(coredns_dns_request_duration_seconds_bucket{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\",zone=\"$zone\"}[$__rate_interval])) by (le,node))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -1988,7 +1988,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -2074,11 +2074,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\", type=\"success\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[5m]))",
+          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\", type=\"success\"}[$__rate_interval])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "hits ratio: success",
           "range": true,
@@ -2087,11 +2087,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\", type=\"denial\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[5m]))",
+          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\", type=\"denial\"}[$__rate_interval])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "hits ratio: denial",
@@ -2101,11 +2101,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "1 - (sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[5m])))",
+          "expr": "1 - (sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[$__rate_interval])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"coredns\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
           "legendFormat": "miss",
@@ -2119,7 +2119,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2204,11 +2204,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\", type=\"success\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[5m]))",
+          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\", type=\"success\"}[$__rate_interval])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "hits ratio: success",
           "range": true,
@@ -2217,11 +2217,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\", type=\"denial\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[5m]))",
+          "expr": "sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\", type=\"denial\"}[$__rate_interval])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "hits ratio: denial",
@@ -2231,11 +2231,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "1 - (sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[5m])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[5m])))",
+          "expr": "1 - (sum(rate(coredns_cache_hits_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[$__rate_interval])) / sum(rate(coredns_cache_requests_total{cluster_id=\"$cluster\", organization=\"$organization\", app=\"k8s-dns-node-cache\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
           "legendFormat": "miss",
@@ -2249,7 +2249,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "$prometheus_datasource"
       },
       "description": "Number of items per second that the cache has prefetched.",
       "fieldConfig": {
@@ -2329,10 +2329,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "$prometheus_datasource"
           },
           "editorMode": "code",
-          "expr": "sum by (app) (rate(coredns_cache_prefetch_total{cluster_id=\"$cluster\", organization=\"$organization\", zones=\"$zone\"}[5m]))",
+          "expr": "sum by (app) (rate(coredns_cache_prefetch_total{cluster_id=\"$cluster\", organization=\"$organization\", zones=\"$zone\"}[$__rate_interval]))",
           "legendFormat": "{{ app }}",
           "range": true,
           "refId": "A"
@@ -2357,7 +2357,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "uid": "$loki_datasource"
       },
       "gridPos": {
         "h": 7,
@@ -2380,7 +2380,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "P8E80F9AEF21F6940"
+            "uid": "$loki_datasource"
           },
           "editorMode": "code",
           "expr": "{app=\"coredns\", cluster_id=\"$cluster\"} | pattern \"[INFO] <ip> - <size> \\\"<query>\\\" <type> <rs> <dunno> <duration>s\" |= `$filter`",
@@ -2394,7 +2394,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "uid": "$loki_datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -2450,10 +2450,10 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "P8E80F9AEF21F6940"
+            "uid": "$loki_datasource"
           },
           "editorMode": "code",
-          "expr": "sum by (type) (count_over_time({app=\"coredns\", cluster_id=\"$cluster\"} | pattern \"[INFO] <ip> - <size> \\\"<query>\\\" <type> <rs> <dunno> <duration>s\" |= `$filter`[5m]))",
+          "expr": "sum by (type) (count_over_time({app=\"coredns\", cluster_id=\"$cluster\"} | pattern \"[INFO] <ip> - <size> \\\"<query>\\\" <type> <rs> <dunno> <duration>s\" |= `$filter`[$__rate_interval]))",
           "hide": false,
           "queryType": "instant",
           "refId": "A"
@@ -2481,22 +2481,34 @@
   "refresh": "",
   "schemaVersion": 39,
   "tags": [
-    "owner:team-phoenix"
+    "owner:team-cabbage"
   ],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
           "text": "default",
           "value": "default"
         },
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "datasource",
+        "hide": 0,
+        "label": "Prometheus data source",
+        "name": "prometheus_datasource",
         "options": [],
         "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Loki data source",
+        "multi": false,
+        "name": "loki_datasource",
+        "options": [],
+        "query": "loki",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -2510,7 +2522,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "$datasource"
+          "uid": "$prometheus_datasource"
         },
         "definition": "label_values(kubernetes_build_info{}, organization)",
         "hide": 0,
@@ -2540,7 +2552,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "$datasource"
+          "uid": "$prometheus_datasource"
         },
         "definition": "label_values(kubernetes_build_info{organization=\"$organization\"}, cluster_id)",
         "hide": 0,
@@ -2568,6 +2580,10 @@
           "text": "cluster.local.",
           "value": "cluster.local."
         },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$prometheus_datasource"
+        },
         "definition": "label_values(coredns_dns_requests_total,zone)",
         "hide": 0,
         "includeAll": false,
@@ -2579,7 +2595,7 @@
           "query": "label_values(coredns_dns_requests_total,zone)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -2598,7 +2614,7 @@
       {
         "datasource": {
           "type": "loki",
-          "uid": "P8E80F9AEF21F6940"
+          "uid": "$loki_datasource"
         },
         "filters": [],
         "hide": 0,


### PR DESCRIPTION
This PR adds a missing datasource to a few of the phoenix dashboards and also changes tags for the dns and cilium dashboards as those should belong to @giantswarm/team-cabbage 

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
