### PR TITLE
servicemonitors overview: add info about agent pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace Cluster ID with cluster in dashboard labels.
 - remotewrite: improve legends
 - remotewrite: add count of agent replicas
+- servicemonitors-overview: add info about agent pods
 
 ### Fixed
 

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
@@ -19,7 +19,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 35,
   "links": [
     {
       "asDropdown": true,
@@ -83,6 +82,331 @@
         "w": 24,
         "x": 0,
         "y": 5
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Agent pods",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "RAM estimation based on the ratio of series / total Prometheus RAM usage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "prometheus_agent_active_series{cluster_id=\"$cluster\"}",
+          "instant": false,
+          "legendFormat": "{{cluster_id}} / {{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Agent metrics per pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "RAM estimation based on the ratio of series / total Prometheus RAM usage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cluster_id,pod) (container_memory_usage_bytes{cluster_id=\"$cluster\", pod=~\".*prometheus-agent.*\"})",
+          "instant": false,
+          "legendFormat": "{{cluster_id}} / {{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Agent RAM per pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "RAM estimation based on the ratio of series / total Prometheus RAM usage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(prometheus_agent_active_series{cluster_id=~\"$cluster\"}) by (cluster_id)",
+          "instant": false,
+          "legendFormat": "{{cluster_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Number of agent pods",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
       },
       "id": 4,
       "panels": [],
@@ -155,7 +479,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 6
+        "y": 23
       },
       "id": 1,
       "options": {
@@ -259,9 +583,9 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 6
+        "y": 23
       },
-      "id": 9,
+      "id": 10,
       "options": {
         "legend": {
           "calcs": [
@@ -363,7 +687,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 33
       },
       "id": 3,
       "options": {
@@ -467,7 +791,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 33
       },
       "id": 8,
       "options": {
@@ -571,7 +895,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 43
       },
       "id": 7,
       "options": {
@@ -746,6 +1070,6 @@
   "timezone": "browser",
   "title": "ServiceMonitors Overview",
   "uid": "servicemonitors-overview",
-  "version": 1,
+  "version": 4,
   "weekStart": ""
 }

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
@@ -287,6 +287,7 @@
           },
           "editorMode": "code",
           "expr": "sum by (cluster_id,pod) (container_memory_usage_bytes{cluster_id=\"$cluster\", pod=~\".*prometheus-agent.*\"})",
+          "expr": "sum by (cluster_id,pod) (container_memory_rss{cluster_id=\"$cluster\", pod=~\".*prometheus-agent.*\", container=~\".+\"})",
           "instant": false,
           "legendFormat": "{{cluster_id}} / {{pod}}",
           "range": true,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30727

This PR improves the "Servicemonitors overview" dashboard with a new row for agent pods information that shows:
- the number of metrics per pod
- the amount of RAM per pod
- the total number of pods

Screenshot:
![image](https://github.com/giantswarm/dashboards/assets/12008875/235899b6-3b74-4f80-8e9e-cb12f54d0003)




### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
