### PR TITLE
Mimir Cost Estimation: fix RAM usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fluentbit dashboard: cluster selection
 
+### Fixed
+
+- Mimir Cost Estimation: fix RAM usage
+
 ### Removed
 
 - Removed the dashboard 'Webhook Health'. 

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-cost-estimation.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-cost-estimation.json
@@ -1,6 +1,19 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
@@ -84,7 +97,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "11.0.0",
       "targets": [
         {
           "datasource": "$datasource",
@@ -148,7 +161,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "11.0.0",
       "targets": [
         {
           "datasource": "$datasource",
@@ -273,6 +286,7 @@
           "showLegend": true
         },
         "tooltip": {
+          "maxHeight": 600,
           "mode": "multi",
           "sort": "none"
         }
@@ -358,7 +372,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "11.0.0",
       "targets": [
         {
           "datasource": "$datasource",
@@ -494,6 +508,7 @@
           "width": 450
         },
         "tooltip": {
+          "maxHeight": 600,
           "mode": "single",
           "sort": "none"
         }
@@ -531,7 +546,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": "$datasource",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "description": "Total memory used by all mimir pods",
       "fieldConfig": {
         "defaults": {
@@ -580,12 +598,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "11.0.0",
       "targets": [
         {
           "datasource": "$datasource",
           "editorMode": "code",
-          "expr": "sum(sum(max_over_time(container_memory_usage_bytes{pod=~\"mimir-.*\", cluster_type=~\"management_cluster\"}[$__range] ) ) by (pod))",
+          "expr": "max_over_time(sum(sum(container_memory_usage_bytes{pod=~\"mimir-.*\", cluster_type=~\"management_cluster\"}) by (pod))[$__range:$__rate_interval])",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -681,6 +699,7 @@
           "showLegend": true
         },
         "tooltip": {
+          "maxHeight": 600,
           "mode": "single",
           "sort": "none"
         }
@@ -755,7 +774,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "11.0.0",
       "targets": [
         {
           "datasource": "$datasource",
@@ -825,8 +844,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -915,8 +933,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1062,16 +1079,20 @@
     "list": [
       {
         "current": {
+          "selected": false,
           "text": "default",
           "value": "default"
         },
         "hide": 0,
+        "includeAll": false,
         "label": "Data source",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
@@ -1084,7 +1105,10 @@
             "$__all"
           ]
         },
-        "datasource": "$datasource",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
         "definition": "label_values(kube_pod_container_info{image=~\".*mimir.*\"},cluster_id)",
         "description": "Allows to select a particular cluster in the installation",
         "hide": 0,
@@ -1109,6 +1133,7 @@
     "from": "now-6h",
     "to": "now"
   },
+  "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {},
   "timezone": "",
   "title": "Mimir / Cost Estimation",


### PR DESCRIPTION
This PR fixes RAM usage on Mimir Cost Estimation dashboard.

The previous query was:
- taking all pods over the timerange
- reading their max over the timerange
- doing the sum of all of that


The new query does:
- normal RAM sum like for a graph (at each time taking only alive pods)
- take the max over the timerange

It's more resource consuming because it uses a subquery, but it gives the expected result.

Before: see the 409GB is not realistic 
![image](https://github.com/giantswarm/dashboards/assets/12008875/f68926bb-2d1d-4a82-8017-e6f0f2427a82)

After, we get 60GB which is the actual value when we zoom on the peak on the left of the graph.
![image](https://github.com/giantswarm/dashboards/assets/12008875/f449cb36-ae09-468d-8b42-26c3f82eed05)


### Checklist

- [ ] Update changelog in CHANGELOG.md in an end-user friendly language.
