### PR TITLE
Replace SI units for data amounts with IEC units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated all dashboars using `decbytes` unit to use `bytes` (IEC units) instead.
+
 ## [3.22.0] - 2024-08-01
 
 ### Added

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/api-performance.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/api-performance.json
@@ -1061,7 +1061,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-backup.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-backup.json
@@ -93,7 +93,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-health.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/etcd-health.json
@@ -2476,7 +2476,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/grafana.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/grafana.json
@@ -588,7 +588,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-cost-estimation.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-cost-estimation.json
@@ -353,7 +353,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": [
           {
@@ -523,7 +523,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -625,7 +625,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -696,7 +696,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -819,7 +819,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-logs.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/loki-logs.json
@@ -552,7 +552,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-query-stats.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-query-stats.json
@@ -214,7 +214,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "decbytes"
+                "value": "bytes"
               }
             ]
           },
@@ -238,7 +238,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "decbytes"
+                "value": "bytes"
               }
             ]
           },
@@ -262,7 +262,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "decbytes"
+                "value": "bytes"
               }
             ]
           },

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/network-anomaly-detection.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/network-anomaly-detection.json
@@ -102,7 +102,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -198,7 +198,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -294,7 +294,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -390,7 +390,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -487,7 +487,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/node-utilization.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/node-utilization.json
@@ -359,7 +359,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -427,7 +427,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -861,7 +861,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/zot.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/zot.json
@@ -182,7 +182,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": [
           {
@@ -315,7 +315,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -389,7 +389,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -2142,7 +2142,7 @@
                   }
                 ]
               },
-              "unit": "decbytes"
+              "unit": "bytes"
             },
             "overrides": []
           },

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/dns.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/dns.json
@@ -1312,7 +1312,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -1529,7 +1529,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/nodes-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/nodes-overview.json
@@ -845,7 +845,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -1338,7 +1338,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/servicemonitors-overview.json
@@ -250,7 +250,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -576,7 +576,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },

--- a/helm/dashboards/dashboards/aws/private/kiam.json
+++ b/helm/dashboards/dashboards/aws/private/kiam.json
@@ -3162,7 +3162,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -3510,7 +3510,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },


### PR DESCRIPTION
This PR updates 14 dashboards using unit `decbytes` to use `bytes` instead. For the dashboard user, this means that the units displayed will be KiB, MiB, GiB, TiB etc.

This is in line with a general decision we made recently. See

- https://intranet.giantswarm.io/docs/product/pdr/011-iec-units/
- https://github.com/giantswarm/roadmap/issues/3529

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
