### PR TITLE
Add Makefile target to update Alertmanager and Kubernetes dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `scripts/update-alloy-mixin.sh` to update the Alloy mixin dashboards
 
+- Added `update-alertmanager-mixin` and `update-kubernetes-mixin` Makefile targets
+
 ### Changed
 
 - Updated all dashboars using `decbytes` unit to use `bytes` (IEC units) instead.
+
+### Fixed
+
+- Fix dashboards destination path in `update-monitoring-mixin-dashboards.sh` script
 
 ## [3.22.0] - 2024-08-01
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,6 +1,6 @@
 ##@ Dashboards
 
-.PHONY: install-tools update-mimir-mixin update-alloy-mixin lint-dashboards
+.PHONY: install-tools lint-dashboards update-alertmanager-mixin update-alloy-mixin update-kubernetes-mixin update-mimir-mixin
 
 SHELL:=/bin/bash -O globstar
 
@@ -9,13 +9,19 @@ dashboards = helm/dashboards/dashboards/**/*.json helm/dashboards/charts/**/*.js
 install-tools: ## Install dependencies tools
 	./scripts/install-tools.sh
 
-update-mimir-mixin: install-tools ## Update Mimir mixin dashboards
-	./mimir/update.sh
+update-alertmanager-mixin: ## Update Alertmanager mixin dashboards
+	./scripts/update-monitoring-mixin-dashboards.sh
 
 update-alloy-mixin: install-tools ## Update Alloy mixin dashboards
 	./scripts/update-alloy-mixin.sh
 
-update-mixin: update-mimir-mixin update-alloy-mixin ## Update all mixins dashboards
+update-kubernetes-mixin: ## Update Kubernetes mixin dashboards
+	./scripts/sync-kube-mixin.sh
+
+update-mimir-mixin: install-tools ## Update Mimir mixin dashboards
+	./mimir/update.sh
+
+update-mixin: update-alertmanager-mixin update-alloy-mixin update-kubernetes-mixin update-mimir-mixin ## Update all mixins dashboards
 
 lint-dashboards: install-tools ## Run dashboard-linter for all dashboards in the helm/dashboards directory
 		@for file in $(dashboards); do \

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ If you need help with the tool or its output, please contact @team-atlas.
 
 ## Grafana Cloud dashboards
 
+### Requirements
+
+* jsonnet: https://github.com/google/jsonnet
+
+`pip install jsonnet`
+
+* grafonnet: https://github.com/grafana/grafonnet-lib
+
+`git clone https://github.com/grafana/grafonnet-lib.git $GOPATH/src/github.com/grafana/grafonnet-lib`
+
+### Building and uploading
+
 The dashboards located under `dashboards` are the dashboards hosted on Giant Swarm's Grafana Cloud.
 
 To build and upload the Grafana Cloud dashboards, here is what you need to do:
@@ -57,30 +69,27 @@ To upload a dashboard while editing, run:
 ./scripts/upload-dashboard.sh metrics.json
 ```
 
-
 ## Mixins Dashboards
 
-### Requirements
+### Update
 
-* jsonnet: https://github.com/google/jsonnet
-
-`pip install jsonnet`
-
-* grafonnet: https://github.com/grafana/grafonnet-lib
-
-`git clone https://github.com/grafana/grafonnet-lib.git $GOPATH/src/github.com/grafana/grafonnet-lib`
-
-### Update 
-
-* To Update the `kubernetes-mixin` dashboards:
-
-  * Follow the instructions in [giantswarm-kubernetes-mixin](https://github.com/giantswarm/giantswarm-kubernetes-mixin)
-  * Run `./scripts/sync-kube-mixin.sh (?my-fancy-branch-or-tag)` to update the `helm/dashboards/dashboards/mixin` folder.
-
-* To Update the `alertmanager-monitoring-mixins` dashboards:
+* Alertmanager dashboard
 
   * The Github Action `update-monitoring-mixins` runs automatically every month and it creates a PR to update the dashboard.
-  * Or you can run the action named `update-monitoring-mixins` manually.
+  * Run `make update-alertmanager-mixin` manually.
+
+* Alloy dashboards
+
+  * Run `make update-alloy-mixin` manually.
+
+* Kubernetes dashboards
+
+  * Follow the instructions in [giantswarm-kubernetes-mixin](https://github.com/giantswarm/giantswarm-kubernetes-mixin).
+  * Run `make update-kubernetes-mixin` manually.
+
+* Mimir dashboards
+
+  * Run `make update-mimir-mixin` manually.
 
 ## Origins of the dashboards
 

--- a/scripts/update-monitoring-mixin-dashboards.sh
+++ b/scripts/update-monitoring-mixin-dashboards.sh
@@ -25,7 +25,7 @@ main() {
   ## Copy and overwrite
   for app in "${apps[@]}"; do
       echo "copying $app dashboard"
-      cp "$TMPDIR"/monitoring-mixins/assets/"$app"/dashboards/* ./helm/dashboards/dashboards/shared/public/
+      cp "$TMPDIR"/monitoring-mixins/assets/"$app"/dashboards/* ./helm/dashboards/charts/public_dashboards/dashboards/shared/public/
   done
 
   echo "------- Update Changelog"


### PR DESCRIPTION
This PR `update-alertmanager-mixin` and `update-kubernetes-mixin` Makefile targets.

Also fixes a path issue in the Kubernetes mixin update script.

Update README to add information about Alloy and Mimir mixin dashboard update procedure.

Move the required dependency section to Grafana Cloud, as dependencies for other scripts are handled via `scripts/install-tools.sh` and Makefile