### PR TITLE
Add Alloy mixin dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added Alloy mixin dashboards
+
 - Added Makefile.custom.mk to group scripts usage
   - Added `make update-mixin` to update mixin dasbhboards
   - Added `make lint-dashboards` to dashboards linting

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -13,7 +13,7 @@ update-alertmanager-mixin: ## Update Alertmanager mixin dashboards
 	./scripts/update-monitoring-mixin-dashboards.sh
 
 update-alloy-mixin: install-tools ## Update Alloy mixin dashboards
-	./scripts/update-alloy-mixin.sh
+	./alloy/update-alloy-mixin.sh
 
 update-kubernetes-mixin: ## Update Kubernetes mixin dashboards
 	./scripts/sync-kube-mixin.sh

--- a/alloy/tags.json
+++ b/alloy/tags.json
@@ -1,5 +1,5 @@
 [
       "owner:team-atlas",
       "topic:observability",
-      "component:mimir"
+      "component:alloy"
 ]

--- a/alloy/tags.json
+++ b/alloy/tags.json
@@ -1,0 +1,5 @@
+[
+      "owner:team-atlas",
+      "topic:observability",
+      "component:mimir"
+]

--- a/alloy/update-alloy-mixin.sh
+++ b/alloy/update-alloy-mixin.sh
@@ -26,11 +26,11 @@ mixtool generate dashboards mixin.libsonnet -d "$TMPDIR/dashboards"
 
 tags="$(cat $SCRIPT_DIR/tags.json)"
 for file in "$TMPDIR/dashboards"/*.json; do
-		echo "$file"
-		(
-				set -x
-						$TOOLS_DIR/yq '.tags += '"$tags"'' -i "$file"
-		)
+	echo "$file"
+	(
+		set -x
+		$TOOLS_DIR/yq '.tags += '"$tags"'' -i "$file"
+	)
 done
 
 set -x

--- a/alloy/update-alloy-mixin.sh
+++ b/alloy/update-alloy-mixin.sh
@@ -21,4 +21,17 @@ set -x
 git clone https://github.com/grafana/alloy.git --depth 1 "$TMPDIR/alloy"
 cd "$alloy_mixin_dir"
 "$TOOLS_DIR/jb" install
-mixtool generate dashboards mixin.libsonnet -d "$helm_dir"
+mixtool generate dashboards mixin.libsonnet -d "$TMPDIR/dashboards"
+{ set +x; } 2>/dev/null
+
+tags="$(cat $SCRIPT_DIR/tags.json)"
+for file in "$TMPDIR/dashboards"/*.json; do
+		echo "$file"
+		(
+				set -x
+						$TOOLS_DIR/yq '.tags += '"$tags"'' -i "$file"
+		)
+done
+
+set -x
+mv "$TMPDIR/dashboards"/*.json "$helm_dir"

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-node.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-node.json
@@ -1,0 +1,505 @@
+{
+      "annotations": {
+         "list": [
+            {
+               "datasource": "$loki_datasource",
+               "enable": true,
+               "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+               "iconColor": "rgba(0, 211, 255, 1)",
+               "instant": false,
+               "name": "Deployments",
+               "titleFormat": "{{cluster}}/{{namespace}}"
+            }
+         ]
+      },
+      "graphTooltip": 1,
+      "links": [
+         {
+            "icon": "doc",
+            "targetBlank": true,
+            "title": "Documentation",
+            "tooltip": "Clustering documentation",
+            "type": "link",
+            "url": "https://grafana.com/docs/alloy/latest/reference/cli/run/#clustering"
+         },
+         {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [
+               "alloy-mixin"
+            ],
+            "targetBlank": false,
+            "title": "Dashboards",
+            "type": "dashboards"
+         }
+      ],
+      "panels": [
+         {
+            "datasource": "${datasource}",
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 0
+            },
+            "title": "Node Info",
+            "type": "row"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Information about a specific cluster node.\n\n* Lamport clock time: The observed Lamport time on the specific node's clock used to provide partial ordering around gossip messages. Nodes should ideally be observing roughly the same time, meaning they are up-to-date on the cluster state. If a node is falling behind, it means that it has not recently processed the same number of messages and may have an outdated view of its peers.\n\n* Internal cluster state observers: The number of Observer functions that are registered to run whenever the node detects a cluster change.\n\n* Gossip health score: A health score assigned to this node by the memberlist implementation. The lower, the better.\n\n* Gossip protocol version: The protocol version used by nodes to communicate with one another. It should match across all nodes.\n",
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 0,
+               "y": 1
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(cluster_node_lamport_time{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}) \n",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false,
+                  "refId": "Lamport clock time"
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(cluster_node_update_observers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false,
+                  "refId": "Internal cluster state observers"
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(cluster_node_gossip_health_score{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false,
+                  "refId": "Gossip health score"
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(cluster_node_gossip_proto_version{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false,
+                  "refId": "Gossip protocol version"
+               }
+            ],
+            "title": "Node Info",
+            "transformations": [
+               {
+                  "id": "renameByRegex",
+                  "options": {
+                     "regex": "Value #(.*)",
+                     "renamePattern": "$1"
+                  }
+               },
+               {
+                  "id": "reduce",
+                  "options": { }
+               },
+               {
+                  "id": "organize",
+                  "options": {
+                     "excludeByName": { },
+                     "indexByName": { },
+                     "renameByName": {
+                        "Field": "Metric",
+                        "Max": "Value"
+                     }
+                  }
+               }
+            ],
+            "type": "table"
+         },
+         {
+            "datasource": "${datasource}",
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 12,
+               "y": 1
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(cluster_node_gossip_received_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "{{event}}",
+                  "range": true
+               }
+            ],
+            "title": "Gossip ops/s",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Known peers to the node (including the local node).\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "suffix:peers"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 0,
+               "y": 9
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+                  "instant": false,
+                  "legendFormat": "__auto",
+                  "range": true
+               }
+            ],
+            "title": "Known peers",
+            "type": "stat"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Known peers to the node by state (including the local node).\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "suffix:nodes"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 12,
+               "y": 9
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+                  "instant": false,
+                  "legendFormat": "{{state}}",
+                  "range": true
+               }
+            ],
+            "title": "Peers by state",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 17
+            },
+            "title": "Gossip Transport",
+            "type": "row"
+         },
+         {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "axisCenteredZero": true
+                  },
+                  "unit": "Bps"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 8,
+               "x": 0,
+               "y": 18
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(cluster_transport_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "rx",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "-1 * rate(cluster_transport_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "tx",
+                  "range": true
+               }
+            ],
+            "title": "Transport bandwidth",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "percentunit"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 8,
+               "x": 8,
+               "y": 18
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "1 - (\n  rate(cluster_transport_tx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_tx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+                  "instant": false,
+                  "legendFormat": "Tx success %",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "1 - (\n  rate(cluster_transport_rx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_rx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+                  "instant": false,
+                  "legendFormat": "Rx success %",
+                  "range": true
+               }
+            ],
+            "title": "Packet write success rate",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "The number of packets enqueued currently to be decoded or encoded and sent during communication with other nodes.\n\nThe incoming and outgoing packet queue should be as empty as possible; a growing queue means that Alloy cannot keep up with the number of messages required to have all nodes informed of cluster changes, and the nodes may not converge in a timely fashion.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "pkts"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 8,
+               "x": 16,
+               "y": 18
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "cluster_transport_tx_packet_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+                  "instant": false,
+                  "legendFormat": "tx queue",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "cluster_transport_rx_packet_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+                  "instant": false,
+                  "legendFormat": "rx queue",
+                  "range": true
+               }
+            ],
+            "title": "Pending packet queue",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "axisCenteredZero": true
+                  },
+                  "unit": "Bps"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 8,
+               "x": 0,
+               "y": 26
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(cluster_transport_stream_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "rx",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "-1 * rate(cluster_transport_stream_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "tx",
+                  "range": true
+               }
+            ],
+            "title": "Stream bandwidth",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "percentunit"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 8,
+               "x": 8,
+               "y": 26
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "1 - (\n  rate(cluster_transport_stream_tx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_tx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+                  "instant": false,
+                  "legendFormat": "Tx success %",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "1 - (\n  rate(cluster_transport_stream_rx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_rx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+                  "instant": false,
+                  "legendFormat": "Rx success %",
+                  "range": true
+               }
+            ],
+            "title": "Stream write success rate",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "The number of open connections from this node to its peers.\n\nEach node picks up a subset of its peers to continuously gossip messages around cluster status using streaming HTTP/2 connections. This panel can be used to detect networking failures that result in cluster communication being disrupted and convergence taking longer than expected or outright failing.\n",
+            "gridPos": {
+               "h": 8,
+               "w": 8,
+               "x": 16,
+               "y": 26
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "cluster_transport_streams{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+                  "instant": false,
+                  "legendFormat": "Open streams",
+                  "range": true
+               }
+            ],
+            "title": "Open transport streams",
+            "type": "timeseries"
+         }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 36,
+      "tags": [
+         "alloy-mixin"
+      ],
+      "templating": {
+         "list": [
+            {
+               "label": "Data Source",
+               "name": "datasource",
+               "query": "prometheus",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "label": "Loki Data Source",
+               "name": "loki_datasource",
+               "query": "loki",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "cluster",
+               "name": "cluster",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+                  "refId": "cluster"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "namespace",
+               "name": "namespace",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+                  "refId": "namespace"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "job",
+               "name": "job",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+                  "refId": "job"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": "${datasource}",
+               "includeAll": true,
+               "label": "instance",
+               "multi": true,
+               "name": "instance",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+                  "refId": "instance"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            }
+         ]
+      },
+      "time": {
+         "from": "now-1h",
+         "to": "now"
+      },
+      "timepicker": {
+         "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+         ],
+         "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d",
+            "90d"
+         ]
+      },
+      "timezone": "utc",
+      "title": "Alloy / Cluster Node",
+      "uid": "4047e755d822da63c8158cde32ae4dce"
+   }

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-node.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-node.json
@@ -1,505 +1,508 @@
 {
-      "annotations": {
-         "list": [
-            {
-               "datasource": "$loki_datasource",
-               "enable": true,
-               "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
-               "iconColor": "rgba(0, 211, 255, 1)",
-               "instant": false,
-               "name": "Deployments",
-               "titleFormat": "{{cluster}}/{{namespace}}"
-            }
-         ]
-      },
-      "graphTooltip": 1,
-      "links": [
-         {
-            "icon": "doc",
-            "targetBlank": true,
-            "title": "Documentation",
-            "tooltip": "Clustering documentation",
-            "type": "link",
-            "url": "https://grafana.com/docs/alloy/latest/reference/cli/run/#clustering"
-         },
-         {
-            "asDropdown": true,
-            "icon": "external link",
-            "includeVars": true,
-            "keepTime": true,
-            "tags": [
-               "alloy-mixin"
-            ],
-            "targetBlank": false,
-            "title": "Dashboards",
-            "type": "dashboards"
-         }
-      ],
-      "panels": [
-         {
-            "datasource": "${datasource}",
-            "gridPos": {
-               "h": 1,
-               "w": 24,
-               "x": 0,
-               "y": 0
-            },
-            "title": "Node Info",
-            "type": "row"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Information about a specific cluster node.\n\n* Lamport clock time: The observed Lamport time on the specific node's clock used to provide partial ordering around gossip messages. Nodes should ideally be observing roughly the same time, meaning they are up-to-date on the cluster state. If a node is falling behind, it means that it has not recently processed the same number of messages and may have an outdated view of its peers.\n\n* Internal cluster state observers: The number of Observer functions that are registered to run whenever the node detects a cluster change.\n\n* Gossip health score: A health score assigned to this node by the memberlist implementation. The lower, the better.\n\n* Gossip protocol version: The protocol version used by nodes to communicate with one another. It should match across all nodes.\n",
-            "gridPos": {
-               "h": 8,
-               "w": 12,
-               "x": 0,
-               "y": 1
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(cluster_node_lamport_time{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}) \n",
-                  "format": "table",
-                  "instant": true,
-                  "legendFormat": "__auto",
-                  "range": false,
-                  "refId": "Lamport clock time"
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(cluster_node_update_observers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
-                  "format": "table",
-                  "instant": true,
-                  "legendFormat": "__auto",
-                  "range": false,
-                  "refId": "Internal cluster state observers"
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(cluster_node_gossip_health_score{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
-                  "format": "table",
-                  "instant": true,
-                  "legendFormat": "__auto",
-                  "range": false,
-                  "refId": "Gossip health score"
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(cluster_node_gossip_proto_version{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
-                  "format": "table",
-                  "instant": true,
-                  "legendFormat": "__auto",
-                  "range": false,
-                  "refId": "Gossip protocol version"
-               }
-            ],
-            "title": "Node Info",
-            "transformations": [
-               {
-                  "id": "renameByRegex",
-                  "options": {
-                     "regex": "Value #(.*)",
-                     "renamePattern": "$1"
-                  }
-               },
-               {
-                  "id": "reduce",
-                  "options": { }
-               },
-               {
-                  "id": "organize",
-                  "options": {
-                     "excludeByName": { },
-                     "indexByName": { },
-                     "renameByName": {
-                        "Field": "Metric",
-                        "Max": "Value"
-                     }
-                  }
-               }
-            ],
-            "type": "table"
-         },
-         {
-            "datasource": "${datasource}",
-            "gridPos": {
-               "h": 8,
-               "w": 12,
-               "x": 12,
-               "y": 1
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(cluster_node_gossip_received_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "{{event}}",
-                  "range": true
-               }
-            ],
-            "title": "Gossip ops/s",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Known peers to the node (including the local node).\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "suffix:peers"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 12,
-               "x": 0,
-               "y": 9
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
-                  "instant": false,
-                  "legendFormat": "__auto",
-                  "range": true
-               }
-            ],
-            "title": "Known peers",
-            "type": "stat"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Known peers to the node by state (including the local node).\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "suffix:nodes"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 12,
-               "x": 12,
-               "y": 9
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
-                  "instant": false,
-                  "legendFormat": "{{state}}",
-                  "range": true
-               }
-            ],
-            "title": "Peers by state",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "gridPos": {
-               "h": 1,
-               "w": 24,
-               "x": 0,
-               "y": 17
-            },
-            "title": "Gossip Transport",
-            "type": "row"
-         },
-         {
-            "datasource": "${datasource}",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "axisCenteredZero": true
-                  },
-                  "unit": "Bps"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 8,
-               "x": 0,
-               "y": 18
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(cluster_transport_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "rx",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "-1 * rate(cluster_transport_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "tx",
-                  "range": true
-               }
-            ],
-            "title": "Transport bandwidth",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "percentunit"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 8,
-               "x": 8,
-               "y": 18
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "1 - (\n  rate(cluster_transport_tx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_tx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
-                  "instant": false,
-                  "legendFormat": "Tx success %",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "1 - (\n  rate(cluster_transport_rx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_rx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
-                  "instant": false,
-                  "legendFormat": "Rx success %",
-                  "range": true
-               }
-            ],
-            "title": "Packet write success rate",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "The number of packets enqueued currently to be decoded or encoded and sent during communication with other nodes.\n\nThe incoming and outgoing packet queue should be as empty as possible; a growing queue means that Alloy cannot keep up with the number of messages required to have all nodes informed of cluster changes, and the nodes may not converge in a timely fashion.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "pkts"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 8,
-               "x": 16,
-               "y": 18
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "cluster_transport_tx_packet_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
-                  "instant": false,
-                  "legendFormat": "tx queue",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "cluster_transport_rx_packet_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
-                  "instant": false,
-                  "legendFormat": "rx queue",
-                  "range": true
-               }
-            ],
-            "title": "Pending packet queue",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "axisCenteredZero": true
-                  },
-                  "unit": "Bps"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 8,
-               "x": 0,
-               "y": 26
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(cluster_transport_stream_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "rx",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "-1 * rate(cluster_transport_stream_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "tx",
-                  "range": true
-               }
-            ],
-            "title": "Stream bandwidth",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "percentunit"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 8,
-               "x": 8,
-               "y": 26
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "1 - (\n  rate(cluster_transport_stream_tx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_tx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
-                  "instant": false,
-                  "legendFormat": "Tx success %",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "1 - (\n  rate(cluster_transport_stream_rx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_rx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
-                  "instant": false,
-                  "legendFormat": "Rx success %",
-                  "range": true
-               }
-            ],
-            "title": "Stream write success rate",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "The number of open connections from this node to its peers.\n\nEach node picks up a subset of its peers to continuously gossip messages around cluster status using streaming HTTP/2 connections. This panel can be used to detect networking failures that result in cluster communication being disrupted and convergence taking longer than expected or outright failing.\n",
-            "gridPos": {
-               "h": 8,
-               "w": 8,
-               "x": 16,
-               "y": 26
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "cluster_transport_streams{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
-                  "instant": false,
-                  "legendFormat": "Open streams",
-                  "range": true
-               }
-            ],
-            "title": "Open transport streams",
-            "type": "timeseries"
-         }
-      ],
-      "refresh": "10s",
-      "schemaVersion": 36,
+  "annotations": {
+    "list": [
+      {
+        "datasource": "$loki_datasource",
+        "enable": true,
+        "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "instant": false,
+        "name": "Deployments",
+        "titleFormat": "{{cluster}}/{{namespace}}"
+      }
+    ]
+  },
+  "graphTooltip": 1,
+  "links": [
+    {
+      "icon": "doc",
+      "targetBlank": true,
+      "title": "Documentation",
+      "tooltip": "Clustering documentation",
+      "type": "link",
+      "url": "https://grafana.com/docs/alloy/latest/reference/cli/run/#clustering"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
-         "alloy-mixin"
+        "alloy-mixin"
       ],
-      "templating": {
-         "list": [
-            {
-               "label": "Data Source",
-               "name": "datasource",
-               "query": "prometheus",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
-            },
-            {
-               "label": "Loki Data Source",
-               "name": "loki_datasource",
-               "query": "loki",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "cluster",
-               "name": "cluster",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
-                  "refId": "cluster"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "namespace",
-               "name": "namespace",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
-                  "refId": "namespace"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "job",
-               "name": "job",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
-                  "refId": "job"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "allValue": ".*",
-               "datasource": "${datasource}",
-               "includeAll": true,
-               "label": "instance",
-               "multi": true,
-               "name": "instance",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
-                  "refId": "instance"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "title": "Node Info",
+      "type": "row"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Information about a specific cluster node.\n\n* Lamport clock time: The observed Lamport time on the specific node's clock used to provide partial ordering around gossip messages. Nodes should ideally be observing roughly the same time, meaning they are up-to-date on the cluster state. If a node is falling behind, it means that it has not recently processed the same number of messages and may have an outdated view of its peers.\n\n* Internal cluster state observers: The number of Observer functions that are registered to run whenever the node detects a cluster change.\n\n* Gossip health score: A health score assigned to this node by the memberlist implementation. The lower, the better.\n\n* Gossip protocol version: The protocol version used by nodes to communicate with one another. It should match across all nodes.\n",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(cluster_node_lamport_time{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}) \n",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Lamport clock time"
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(cluster_node_update_observers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Internal cluster state observers"
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(cluster_node_gossip_health_score{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Gossip health score"
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(cluster_node_gossip_proto_version{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Gossip protocol version"
+        }
+      ],
+      "title": "Node Info",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "Value #(.*)",
+            "renamePattern": "$1"
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Field": "Metric",
+              "Max": "Value"
             }
-         ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
       },
-      "time": {
-         "from": "now-1h",
-         "to": "now"
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(cluster_node_gossip_received_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "{{event}}",
+          "range": true
+        }
+      ],
+      "title": "Gossip ops/s",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Known peers to the node (including the local node).\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "suffix:peers"
+        }
       },
-      "timepicker": {
-         "refresh_intervals": [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
-         ],
-         "time_options": [
-            "5m",
-            "15m",
-            "1h",
-            "6h",
-            "12h",
-            "24h",
-            "2d",
-            "7d",
-            "30d",
-            "90d"
-         ]
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
       },
-      "timezone": "utc",
-      "title": "Alloy / Cluster Node",
-      "uid": "4047e755d822da63c8158cde32ae4dce"
-   }
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true
+        }
+      ],
+      "title": "Known peers",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Known peers to the node by state (including the local node).\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "suffix:nodes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "instant": false,
+          "legendFormat": "{{state}}",
+          "range": true
+        }
+      ],
+      "title": "Peers by state",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "title": "Gossip Transport",
+      "type": "row"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisCenteredZero": true
+          },
+          "unit": "Bps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(cluster_transport_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "rx",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "-1 * rate(cluster_transport_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "tx",
+          "range": true
+        }
+      ],
+      "title": "Transport bandwidth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "1 - (\n  rate(cluster_transport_tx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_tx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+          "instant": false,
+          "legendFormat": "Tx success %",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "1 - (\n  rate(cluster_transport_rx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_rx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+          "instant": false,
+          "legendFormat": "Rx success %",
+          "range": true
+        }
+      ],
+      "title": "Packet write success rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "The number of packets enqueued currently to be decoded or encoded and sent during communication with other nodes.\n\nThe incoming and outgoing packet queue should be as empty as possible; a growing queue means that Alloy cannot keep up with the number of messages required to have all nodes informed of cluster changes, and the nodes may not converge in a timely fashion.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pkts"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "cluster_transport_tx_packet_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "instant": false,
+          "legendFormat": "tx queue",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "cluster_transport_rx_packet_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "instant": false,
+          "legendFormat": "rx queue",
+          "range": true
+        }
+      ],
+      "title": "Pending packet queue",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisCenteredZero": true
+          },
+          "unit": "Bps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(cluster_transport_stream_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "rx",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "-1 * rate(cluster_transport_stream_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "tx",
+          "range": true
+        }
+      ],
+      "title": "Stream bandwidth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "1 - (\n  rate(cluster_transport_stream_tx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_tx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+          "instant": false,
+          "legendFormat": "Tx success %",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "1 - (\n  rate(cluster_transport_stream_rx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_rx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+          "instant": false,
+          "legendFormat": "Rx success %",
+          "range": true
+        }
+      ],
+      "title": "Stream write success rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "The number of open connections from this node to its peers.\n\nEach node picks up a subset of its peers to continuously gossip messages around cluster status using streaming HTTP/2 connections. This panel can be used to detect networking failures that result in cluster communication being disrupted and convergence taking longer than expected or outright failing.\n",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 26
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "cluster_transport_streams{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "instant": false,
+          "legendFormat": "Open streams",
+          "range": true
+        }
+      ],
+      "title": "Open transport streams",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "tags": [
+    "alloy-mixin",
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
+  ],
+  "templating": {
+    "list": [
+      {
+        "label": "Data Source",
+        "name": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "label": "Loki Data Source",
+        "name": "loki_datasource",
+        "query": "loki",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "cluster",
+        "name": "cluster",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "refId": "cluster"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "namespace",
+        "name": "namespace",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "refId": "namespace"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "job",
+        "name": "job",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "refId": "job"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": "${datasource}",
+        "includeAll": true,
+        "label": "instance",
+        "multi": true,
+        "name": "instance",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+          "refId": "instance"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d",
+      "90d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Alloy / Cluster Node",
+  "uid": "4047e755d822da63c8158cde32ae4dce"
+}

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-overview.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-overview.json
@@ -1,376 +1,379 @@
 {
-      "annotations": {
-         "list": [
-            {
-               "datasource": "$loki_datasource",
-               "enable": true,
-               "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
-               "iconColor": "rgba(0, 211, 255, 1)",
-               "instant": false,
-               "name": "Deployments",
-               "titleFormat": "{{cluster}}/{{namespace}}"
-            }
-         ]
-      },
-      "graphTooltip": 1,
-      "links": [
-         {
-            "icon": "doc",
-            "targetBlank": true,
-            "title": "Documentation",
-            "tooltip": "Clustering documentation",
-            "type": "link",
-            "url": "https://grafana.com/docs/alloy/latest/reference/cli/run/#clustering"
-         },
-         {
-            "asDropdown": true,
-            "icon": "external link",
-            "includeVars": true,
-            "keepTime": true,
-            "tags": [
-               "alloy-mixin"
-            ],
-            "targetBlank": false,
-            "title": "Dashboards",
-            "type": "dashboards"
-         }
-      ],
-      "panels": [
-         {
-            "datasource": "${datasource}",
-            "gridPos": {
-               "h": 9,
-               "w": 8,
-               "x": 0,
-               "y": 0
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
-                  "instant": true,
-                  "legendFormat": "__auto",
-                  "range": false
-               }
-            ],
-            "title": "Nodes",
-            "type": "stat"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Nodes info.\n",
-            "fieldConfig": {
-               "overrides": [
-                  {
-                     "matcher": {
-                        "id": "byName",
-                        "options": "Dashboard"
-                     },
-                     "properties": [
-                        {
-                           "id": "mappings",
-                           "value": [
-                              {
-                                 "options": {
-                                    "1": {
-                                       "index": 0,
-                                       "text": "Link"
-                                    }
-                                 },
-                                 "type": "value"
-                              }
-                           ]
-                        },
-                        {
-                           "id": "links",
-                           "value": [
-                              {
-                                 "targetBlank": false,
-                                 "title": "Detail dashboard for node",
-                                 "url": "/d/4047e755d822da63c8158cde32ae4dce/alloy-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-job=${job}&var-cluster=${cluster}&var-namespace=${namespace}"
-                              }
-                           ]
-                        }
-                     ]
-                  }
-               ]
-            },
-            "gridPos": {
-               "h": 9,
-               "w": 16,
-               "x": 8,
-               "y": 0
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}\n",
-                  "format": "table",
-                  "instant": true,
-                  "legendFormat": "__auto",
-                  "range": false
-               }
-            ],
-            "title": "Node table",
-            "transformations": [
-               {
-                  "id": "organize",
-                  "options": {
-                     "excludeByName": {
-                        "Time": true,
-                        "Value": false,
-                        "__name__": true,
-                        "cluster": true,
-                        "namespace": true,
-                        "state": false
-                     },
-                     "indexByName": { },
-                     "renameByName": {
-                        "Value": "Dashboard",
-                        "instance": "",
-                        "state": ""
-                     }
-                  }
-               }
-            ],
-            "type": "table"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Whether the cluster state has converged.\n\nIt is normal for the cluster state to be diverged briefly as gossip events propagate. It is not normal for the cluster state to be diverged for a long period of time.\n\nThis will show one of the following:\n\n* Converged: Nodes are aware of all other nodes, with the correct states.\n* Not converged: A subset of nodes aren't aware of their peers, or don't have an updated view of peer states.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "mappings": [
-                     {
-                        "options": {
-                           "1": {
-                              "color": "red",
-                              "index": 1,
-                              "text": "Not converged"
-                           }
-                        },
-                        "type": "value"
-                     },
-                     {
-                        "options": {
-                           "match": "null",
-                           "result": {
-                              "color": "green",
-                              "index": 0,
-                              "text": "Converged"
-                           }
-                        },
-                        "type": "special"
-                     }
-                  ],
-                  "unit": "suffix:nodes"
-               }
-            },
-            "gridPos": {
-               "h": 9,
-               "w": 8,
-               "x": 0,
-               "y": 9
-            },
-            "options": {
-               "colorMode": "background",
-               "graphMode": "none",
-               "justifyMode": "auto",
-               "orientation": "auto",
-               "reduceOptions": {
-                  "calcs": [
-                     "lastNotNull"
-                  ],
-                  "fields": "",
-                  "values": false
-               },
-               "textMode": "auto"
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) != 0) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) != 0))\n  ),\n  1, 1\n)\n",
-                  "format": "time_series",
-                  "instant": true,
-                  "legendFormat": "__auto",
-                  "range": false
-               }
-            ],
-            "title": "Convergance state",
-            "type": "stat"
-         },
-         {
-            "datasource": "${datasource}",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "fillOpacity": 80,
-                     "spanNulls": true
-                  },
-                  "mappings": [
-                     {
-                        "options": {
-                           "0": {
-                              "color": "green",
-                              "text": "Yes"
-                           }
-                        },
-                        "type": "value"
-                     },
-                     {
-                        "options": {
-                           "1": {
-                              "color": "red",
-                              "text": "No"
-                           }
-                        },
-                        "type": "value"
-                     }
-                  ],
-                  "max": 1,
-                  "noValue": 0
-               }
-            },
-            "gridPos": {
-               "h": 9,
-               "w": 16,
-               "x": 8,
-               "y": 9
-            },
-            "options": {
-               "mergeValues": true
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "ceil(clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}))))\n  ),\n  0, 1\n))\n",
-                  "instant": false,
-                  "legendFormat": "Converged",
-                  "range": true
-               }
-            ],
-            "title": "Convergance state timeline",
-            "type": "state-timeline"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "The number of cluster peers seen by each instance.\n\nWhen cluster is converged, every peer should see all the other instances. When we have a split brain or one\npeer not joining the cluster, we will see two or more groups of instances that report different peer numbers\nfor an extended period of time and not converging.\n\nThis graph helps to identify which instances may be in a split brain state.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "peers"
-               }
-            },
-            "gridPos": {
-               "h": 12,
-               "w": 24,
-               "x": 0,
-               "y": 18
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum by(instance) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}}",
-                  "range": true
-               }
-            ],
-            "title": "Number of peers seen by each instance",
-            "type": "timeseries"
-         }
-      ],
-      "refresh": "10s",
-      "schemaVersion": 36,
+  "annotations": {
+    "list": [
+      {
+        "datasource": "$loki_datasource",
+        "enable": true,
+        "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "instant": false,
+        "name": "Deployments",
+        "titleFormat": "{{cluster}}/{{namespace}}"
+      }
+    ]
+  },
+  "graphTooltip": 1,
+  "links": [
+    {
+      "icon": "doc",
+      "targetBlank": true,
+      "title": "Documentation",
+      "tooltip": "Clustering documentation",
+      "type": "link",
+      "url": "https://grafana.com/docs/alloy/latest/reference/cli/run/#clustering"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
-         "alloy-mixin"
+        "alloy-mixin"
       ],
-      "templating": {
-         "list": [
-            {
-               "label": "Data Source",
-               "name": "datasource",
-               "query": "prometheus",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false
+        }
+      ],
+      "title": "Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Nodes info.\n",
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Dashboard"
             },
-            {
-               "label": "Loki Data Source",
-               "name": "loki_datasource",
-               "query": "loki",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "1": {
+                        "index": 0,
+                        "text": "Link"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": false,
+                    "title": "Detail dashboard for node",
+                    "url": "/d/4047e755d822da63c8158cde32ae4dce/alloy-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-job=${job}&var-cluster=${cluster}&var-namespace=${namespace}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 16,
+        "x": 8,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}\n",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false
+        }
+      ],
+      "title": "Node table",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": false,
+              "__name__": true,
+              "cluster": true,
+              "namespace": true,
+              "state": false
             },
-            {
-               "datasource": "${datasource}",
-               "label": "cluster",
-               "name": "cluster",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
-                  "refId": "cluster"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "namespace",
-               "name": "namespace",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
-                  "refId": "namespace"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "job",
-               "name": "job",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
-                  "refId": "job"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Dashboard",
+              "instance": "",
+              "state": ""
             }
-         ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Whether the cluster state has converged.\n\nIt is normal for the cluster state to be diverged briefly as gossip events propagate. It is not normal for the cluster state to be diverged for a long period of time.\n\nThis will show one of the following:\n\n* Converged: Nodes are aware of all other nodes, with the correct states.\n* Not converged: A subset of nodes aren't aware of their peers, or don't have an updated view of peer states.\n",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Not converged"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Converged"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "unit": "suffix:nodes"
+        }
       },
-      "time": {
-         "from": "now-1h",
-         "to": "now"
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 9
       },
-      "timepicker": {
-         "refresh_intervals": [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
-         ],
-         "time_options": [
-            "5m",
-            "15m",
-            "1h",
-            "6h",
-            "12h",
-            "24h",
-            "2d",
-            "7d",
-            "30d",
-            "90d"
-         ]
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
       },
-      "timezone": "utc",
-      "title": "Alloy / Cluster Overview",
-      "uid": "3a6b7020692f53d8e53b49196f7637dd"
-   }
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) != 0) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) != 0))\n  ),\n  1, 1\n)\n",
+          "format": "time_series",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false
+        }
+      ],
+      "title": "Convergance state",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 80,
+            "spanNulls": true
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "text": "Yes"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "1": {
+                  "color": "red",
+                  "text": "No"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "max": 1,
+          "noValue": 0
+        }
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 16,
+        "x": 8,
+        "y": 9
+      },
+      "options": {
+        "mergeValues": true
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "ceil(clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}))))\n  ),\n  0, 1\n))\n",
+          "instant": false,
+          "legendFormat": "Converged",
+          "range": true
+        }
+      ],
+      "title": "Convergance state timeline",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "The number of cluster peers seen by each instance.\n\nWhen cluster is converged, every peer should see all the other instances. When we have a split brain or one\npeer not joining the cluster, we will see two or more groups of instances that report different peer numbers\nfor an extended period of time and not converging.\n\nThis graph helps to identify which instances may be in a split brain state.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "peers"
+        }
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum by(instance) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true
+        }
+      ],
+      "title": "Number of peers seen by each instance",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "tags": [
+    "alloy-mixin",
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
+  ],
+  "templating": {
+    "list": [
+      {
+        "label": "Data Source",
+        "name": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "label": "Loki Data Source",
+        "name": "loki_datasource",
+        "query": "loki",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "cluster",
+        "name": "cluster",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "refId": "cluster"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "namespace",
+        "name": "namespace",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "refId": "namespace"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "job",
+        "name": "job",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "refId": "job"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d",
+      "90d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Alloy / Cluster Overview",
+  "uid": "3a6b7020692f53d8e53b49196f7637dd"
+}

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-overview.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-overview.json
@@ -1,0 +1,376 @@
+{
+      "annotations": {
+         "list": [
+            {
+               "datasource": "$loki_datasource",
+               "enable": true,
+               "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+               "iconColor": "rgba(0, 211, 255, 1)",
+               "instant": false,
+               "name": "Deployments",
+               "titleFormat": "{{cluster}}/{{namespace}}"
+            }
+         ]
+      },
+      "graphTooltip": 1,
+      "links": [
+         {
+            "icon": "doc",
+            "targetBlank": true,
+            "title": "Documentation",
+            "tooltip": "Clustering documentation",
+            "type": "link",
+            "url": "https://grafana.com/docs/alloy/latest/reference/cli/run/#clustering"
+         },
+         {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [
+               "alloy-mixin"
+            ],
+            "targetBlank": false,
+            "title": "Dashboards",
+            "type": "dashboards"
+         }
+      ],
+      "panels": [
+         {
+            "datasource": "${datasource}",
+            "gridPos": {
+               "h": 9,
+               "w": 8,
+               "x": 0,
+               "y": 0
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false
+               }
+            ],
+            "title": "Nodes",
+            "type": "stat"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Nodes info.\n",
+            "fieldConfig": {
+               "overrides": [
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "Dashboard"
+                     },
+                     "properties": [
+                        {
+                           "id": "mappings",
+                           "value": [
+                              {
+                                 "options": {
+                                    "1": {
+                                       "index": 0,
+                                       "text": "Link"
+                                    }
+                                 },
+                                 "type": "value"
+                              }
+                           ]
+                        },
+                        {
+                           "id": "links",
+                           "value": [
+                              {
+                                 "targetBlank": false,
+                                 "title": "Detail dashboard for node",
+                                 "url": "/d/4047e755d822da63c8158cde32ae4dce/alloy-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-job=${job}&var-cluster=${cluster}&var-namespace=${namespace}"
+                              }
+                           ]
+                        }
+                     ]
+                  }
+               ]
+            },
+            "gridPos": {
+               "h": 9,
+               "w": 16,
+               "x": 8,
+               "y": 0
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}\n",
+                  "format": "table",
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false
+               }
+            ],
+            "title": "Node table",
+            "transformations": [
+               {
+                  "id": "organize",
+                  "options": {
+                     "excludeByName": {
+                        "Time": true,
+                        "Value": false,
+                        "__name__": true,
+                        "cluster": true,
+                        "namespace": true,
+                        "state": false
+                     },
+                     "indexByName": { },
+                     "renameByName": {
+                        "Value": "Dashboard",
+                        "instance": "",
+                        "state": ""
+                     }
+                  }
+               }
+            ],
+            "type": "table"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Whether the cluster state has converged.\n\nIt is normal for the cluster state to be diverged briefly as gossip events propagate. It is not normal for the cluster state to be diverged for a long period of time.\n\nThis will show one of the following:\n\n* Converged: Nodes are aware of all other nodes, with the correct states.\n* Not converged: A subset of nodes aren't aware of their peers, or don't have an updated view of peer states.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "mappings": [
+                     {
+                        "options": {
+                           "1": {
+                              "color": "red",
+                              "index": 1,
+                              "text": "Not converged"
+                           }
+                        },
+                        "type": "value"
+                     },
+                     {
+                        "options": {
+                           "match": "null",
+                           "result": {
+                              "color": "green",
+                              "index": 0,
+                              "text": "Converged"
+                           }
+                        },
+                        "type": "special"
+                     }
+                  ],
+                  "unit": "suffix:nodes"
+               }
+            },
+            "gridPos": {
+               "h": 9,
+               "w": 8,
+               "x": 0,
+               "y": 9
+            },
+            "options": {
+               "colorMode": "background",
+               "graphMode": "none",
+               "justifyMode": "auto",
+               "orientation": "auto",
+               "reduceOptions": {
+                  "calcs": [
+                     "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+               },
+               "textMode": "auto"
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) != 0) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) != 0))\n  ),\n  1, 1\n)\n",
+                  "format": "time_series",
+                  "instant": true,
+                  "legendFormat": "__auto",
+                  "range": false
+               }
+            ],
+            "title": "Convergance state",
+            "type": "stat"
+         },
+         {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 80,
+                     "spanNulls": true
+                  },
+                  "mappings": [
+                     {
+                        "options": {
+                           "0": {
+                              "color": "green",
+                              "text": "Yes"
+                           }
+                        },
+                        "type": "value"
+                     },
+                     {
+                        "options": {
+                           "1": {
+                              "color": "red",
+                              "text": "No"
+                           }
+                        },
+                        "type": "value"
+                     }
+                  ],
+                  "max": 1,
+                  "noValue": 0
+               }
+            },
+            "gridPos": {
+               "h": 9,
+               "w": 16,
+               "x": 8,
+               "y": 9
+            },
+            "options": {
+               "mergeValues": true
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "ceil(clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}))))\n  ),\n  0, 1\n))\n",
+                  "instant": false,
+                  "legendFormat": "Converged",
+                  "range": true
+               }
+            ],
+            "title": "Convergance state timeline",
+            "type": "state-timeline"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "The number of cluster peers seen by each instance.\n\nWhen cluster is converged, every peer should see all the other instances. When we have a split brain or one\npeer not joining the cluster, we will see two or more groups of instances that report different peer numbers\nfor an extended period of time and not converging.\n\nThis graph helps to identify which instances may be in a split brain state.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "peers"
+               }
+            },
+            "gridPos": {
+               "h": 12,
+               "w": 24,
+               "x": 0,
+               "y": 18
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum by(instance) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}}",
+                  "range": true
+               }
+            ],
+            "title": "Number of peers seen by each instance",
+            "type": "timeseries"
+         }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 36,
+      "tags": [
+         "alloy-mixin"
+      ],
+      "templating": {
+         "list": [
+            {
+               "label": "Data Source",
+               "name": "datasource",
+               "query": "prometheus",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "label": "Loki Data Source",
+               "name": "loki_datasource",
+               "query": "loki",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "cluster",
+               "name": "cluster",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+                  "refId": "cluster"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "namespace",
+               "name": "namespace",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+                  "refId": "namespace"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "job",
+               "name": "job",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+                  "refId": "job"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            }
+         ]
+      },
+      "time": {
+         "from": "now-1h",
+         "to": "now"
+      },
+      "timepicker": {
+         "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+         ],
+         "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d",
+            "90d"
+         ]
+      },
+      "timezone": "utc",
+      "title": "Alloy / Cluster Overview",
+      "uid": "3a6b7020692f53d8e53b49196f7637dd"
+   }

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-controller.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-controller.json
@@ -1,0 +1,554 @@
+{
+      "annotations": {
+         "list": [
+            {
+               "datasource": "$loki_datasource",
+               "enable": true,
+               "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+               "iconColor": "rgba(0, 211, 255, 1)",
+               "instant": false,
+               "name": "Deployments",
+               "titleFormat": "{{cluster}}/{{namespace}}"
+            }
+         ]
+      },
+      "graphTooltip": 1,
+      "links": [
+         {
+            "icon": "doc",
+            "targetBlank": true,
+            "title": "Documentation",
+            "tooltip": "Component controller documentation",
+            "type": "link",
+            "url": "https://grafana.com/docs/alloy/latest/concepts/component_controller/"
+         },
+         {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [
+               "alloy-mixin"
+            ],
+            "targetBlank": false,
+            "title": "Dashboards",
+            "type": "dashboards"
+         }
+      ],
+      "panels": [
+         {
+            "datasource": "${datasource}",
+            "description": "The number of Alloy instances whose metrics are being sent and reported.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "instances"
+               }
+            },
+            "gridPos": {
+               "h": 4,
+               "w": 10,
+               "x": 0,
+               "y": 0
+            },
+            "options": {
+               "colorMode": "none",
+               "graphMode": "none"
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "count(group(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) by (instance))\n",
+                  "instant": false,
+                  "legendFormat": "__auto",
+                  "range": true
+               }
+            ],
+            "title": "Running instances",
+            "type": "stat"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "The number of running components across all running instances.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "components"
+               }
+            },
+            "gridPos": {
+               "h": 4,
+               "w": 10,
+               "x": 0,
+               "y": 4
+            },
+            "options": {
+               "colorMode": "none",
+               "graphMode": "none"
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+                  "instant": false,
+                  "legendFormat": "__auto",
+                  "range": true
+               }
+            ],
+            "title": "Running components",
+            "type": "stat"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "The percentage of components which are in a healthy state.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "max": 1,
+                  "min": 0,
+                  "noValue": "No components",
+                  "unit": "percentunit"
+               }
+            },
+            "gridPos": {
+               "h": 4,
+               "w": 10,
+               "x": 0,
+               "y": 8
+            },
+            "options": {
+               "colorMode": "value",
+               "graphMode": "area",
+               "text": {
+                  "valueSize": 80
+               }
+            },
+            "pluginVersion": "9.0.6",
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\",health_type=\"healthy\"}) /\nsum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+                  "instant": false,
+                  "legendFormat": "__auto",
+                  "range": true
+               }
+            ],
+            "title": "Overall component health",
+            "type": "stat"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Breakdown of components by health across all running instances.\n\n* Healthy: components have been evaluated completely and are reporting themselves as healthy.\n* Unhealthy: Components either could not be evaluated or are reporting themselves as unhealthy.\n* Unknown: A component has been created but has not yet been started.\n* Exited: A component has exited. It will not return to the running state.\n\nMore information on a component's health state can be retrieved using\nthe Alloy UI.\n\nNote that components may be in a degraded state even if they report\nthemselves as healthy. Use component-specific dashboards and alerts\nto observe detailed information about the behavior of a component.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "min": 0,
+                  "thresholds": {
+                     "mode": "absolute",
+                     "steps": [
+                        {
+                           "color": "green",
+                           "value": null
+                        }
+                     ]
+                  }
+               },
+               "overrides": [
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "Unhealthy"
+                     },
+                     "properties": [
+                        {
+                           "id": "thresholds",
+                           "value": {
+                              "mode": "absolute",
+                              "steps": [
+                                 {
+                                    "color": "green",
+                                    "value": null
+                                 },
+                                 {
+                                    "color": "red",
+                                    "value": 1
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "Unknown"
+                     },
+                     "properties": [
+                        {
+                           "id": "thresholds",
+                           "value": {
+                              "mode": "absolute",
+                              "steps": [
+                                 {
+                                    "color": "green",
+                                    "value": null
+                                 },
+                                 {
+                                    "color": "blue",
+                                    "value": 1
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "Exited"
+                     },
+                     "properties": [
+                        {
+                           "id": "thresholds",
+                           "value": {
+                              "mode": "absolute",
+                              "steps": [
+                                 {
+                                    "color": "green",
+                                    "value": null
+                                 },
+                                 {
+                                    "color": "orange",
+                                    "value": 1
+                                 }
+                              ]
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "gridPos": {
+               "h": 12,
+               "w": 14,
+               "x": 10,
+               "y": 0
+            },
+            "options": {
+               "orientation": "vertical",
+               "showUnfilled": true
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"healthy\"}) or vector(0)\n",
+                  "instant": true,
+                  "legendFormat": "Healthy",
+                  "range": false
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unhealthy\"}) or vector(0)\n",
+                  "instant": true,
+                  "legendFormat": "Unhealthy",
+                  "range": false
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unknown\"}) or vector(0)\n",
+                  "instant": true,
+                  "legendFormat": "Unknown",
+                  "range": false
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"exited\"}) or vector(0)\n",
+                  "instant": true,
+                  "legendFormat": "Exited",
+                  "range": false
+               }
+            ],
+            "title": "Components by health",
+            "type": "bargauge"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "The frequency at which components get updated.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "drawStyle": "points",
+                     "pointSize": 3
+                  },
+                  "unit": "ops"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 0,
+               "y": 12
+            },
+            "options": {
+               "tooltip": {
+                  "mode": "multi"
+               }
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum by (instance) (rate(alloy_component_evaluation_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+                  "instant": false,
+                  "legendFormat": "__auto",
+                  "range": true
+               }
+            ],
+            "title": "Component evaluation rate",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "The percentiles for how long it takes to complete component evaluations.\n\nComponent evaluations must complete for components to have the latest\narguments. The longer the evaluations take, the slower it will be to\nreconcile the state of components.\n\nIf evaluation is taking too long, consider sharding your components to\ndeal with smaller amounts of data and reuse data as much as possible.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "s"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 8,
+               "y": 12
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "histogram_quantile(0.99, sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.99, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
+                  "instant": false,
+                  "legendFormat": "99th percentile",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "histogram_quantile(0.50, sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.50, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
+                  "instant": false,
+                  "legendFormat": "50th percentile",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "(\n  histogram_sum(sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))) /\n  histogram_count(sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n)\nor\n(\n  sum(rate(alloy_component_evaluation_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])) /\n  sum(rate(alloy_component_evaluation_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n)\n",
+                  "instant": false,
+                  "legendFormat": "Average",
+                  "range": true
+               }
+            ],
+            "title": "Component evaluation time",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "The percentage of time spent evaluating 'slow' components - components that took longer than 1 minute to evaluate.\n\nIdeally, no component should take more than 1 minute to evaluate. The components displayed in this chart\nmay be a sign of a problem with the pipeline.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "percentunit"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 16,
+               "y": 12
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum by (component_path, component_id) (rate(alloy_component_evaluation_slow_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n/ scalar(sum(rate(alloy_component_evaluation_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
+                  "instant": false,
+                  "legendFormat": "{{component path}} {{component_id}}",
+                  "range": true
+               }
+            ],
+            "title": "Slow components evaluation times",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Detailed histogram view of how long component evaluations take.\n\nThe goal is to design your config so that evaluations take as little\ntime as possible; under 100ms is a good goal.\n",
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 0,
+               "y": 22
+            },
+            "maxDataPoints": 30,
+            "options": {
+               "calculate": false,
+               "cellGap": 0,
+               "color": {
+                  "scheme": "Spectral"
+               },
+               "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+               },
+               "filterValues": {
+                  "le": 0.10000000000000001
+               },
+               "tooltip": {
+                  "show": true,
+                  "yHistogram": true
+               },
+               "yAxis": {
+                  "unit": "s"
+               }
+            },
+            "pluginVersion": "9.0.6",
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(increase(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+                  "format": "heatmap",
+                  "instant": false,
+                  "legendFormat": "{{le}}",
+                  "range": true
+               }
+            ],
+            "title": "Component evaluation histogram",
+            "type": "heatmap"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Detailed histogram of how long components wait to be evaluated after their dependency is updated.\n\nThe goal is to design your config so that most of the time components do not\nqueue for long; under 10ms is a good goal.\n",
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 8,
+               "y": 22
+            },
+            "maxDataPoints": 30,
+            "options": {
+               "calculate": false,
+               "cellGap": 0,
+               "color": {
+                  "scheme": "Spectral"
+               },
+               "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+               },
+               "filterValues": {
+                  "le": 0.10000000000000001
+               },
+               "tooltip": {
+                  "show": true,
+                  "yHistogram": true
+               },
+               "yAxis": {
+                  "unit": "s"
+               }
+            },
+            "pluginVersion": "9.0.6",
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(increase(alloy_component_dependencies_wait_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_dependencies_wait_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+                  "format": "heatmap",
+                  "instant": false,
+                  "legendFormat": "{{le}}",
+                  "range": true
+               }
+            ],
+            "title": "Component dependency wait histogram",
+            "type": "heatmap"
+         }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 36,
+      "tags": [
+         "alloy-mixin"
+      ],
+      "templating": {
+         "list": [
+            {
+               "label": "Data Source",
+               "name": "datasource",
+               "query": "prometheus",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "label": "Loki Data Source",
+               "name": "loki_datasource",
+               "query": "loki",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "cluster",
+               "name": "cluster",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+                  "refId": "cluster"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "namespace",
+               "name": "namespace",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+                  "refId": "namespace"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "job",
+               "name": "job",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+                  "refId": "job"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            }
+         ]
+      },
+      "time": {
+         "from": "now-1h",
+         "to": "now"
+      },
+      "timepicker": {
+         "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+         ],
+         "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d",
+            "90d"
+         ]
+      },
+      "timezone": "utc",
+      "title": "Alloy / Controller",
+      "uid": "bf9f456aad7108b2c808dbd9973e386f"
+   }

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-controller.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-controller.json
@@ -1,554 +1,557 @@
 {
-      "annotations": {
-         "list": [
-            {
-               "datasource": "$loki_datasource",
-               "enable": true,
-               "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
-               "iconColor": "rgba(0, 211, 255, 1)",
-               "instant": false,
-               "name": "Deployments",
-               "titleFormat": "{{cluster}}/{{namespace}}"
-            }
-         ]
-      },
-      "graphTooltip": 1,
-      "links": [
-         {
-            "icon": "doc",
-            "targetBlank": true,
-            "title": "Documentation",
-            "tooltip": "Component controller documentation",
-            "type": "link",
-            "url": "https://grafana.com/docs/alloy/latest/concepts/component_controller/"
-         },
-         {
-            "asDropdown": true,
-            "icon": "external link",
-            "includeVars": true,
-            "keepTime": true,
-            "tags": [
-               "alloy-mixin"
-            ],
-            "targetBlank": false,
-            "title": "Dashboards",
-            "type": "dashboards"
-         }
-      ],
-      "panels": [
-         {
-            "datasource": "${datasource}",
-            "description": "The number of Alloy instances whose metrics are being sent and reported.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "instances"
-               }
-            },
-            "gridPos": {
-               "h": 4,
-               "w": 10,
-               "x": 0,
-               "y": 0
-            },
-            "options": {
-               "colorMode": "none",
-               "graphMode": "none"
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "count(group(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) by (instance))\n",
-                  "instant": false,
-                  "legendFormat": "__auto",
-                  "range": true
-               }
-            ],
-            "title": "Running instances",
-            "type": "stat"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "The number of running components across all running instances.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "components"
-               }
-            },
-            "gridPos": {
-               "h": 4,
-               "w": 10,
-               "x": 0,
-               "y": 4
-            },
-            "options": {
-               "colorMode": "none",
-               "graphMode": "none"
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
-                  "instant": false,
-                  "legendFormat": "__auto",
-                  "range": true
-               }
-            ],
-            "title": "Running components",
-            "type": "stat"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "The percentage of components which are in a healthy state.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "max": 1,
-                  "min": 0,
-                  "noValue": "No components",
-                  "unit": "percentunit"
-               }
-            },
-            "gridPos": {
-               "h": 4,
-               "w": 10,
-               "x": 0,
-               "y": 8
-            },
-            "options": {
-               "colorMode": "value",
-               "graphMode": "area",
-               "text": {
-                  "valueSize": 80
-               }
-            },
-            "pluginVersion": "9.0.6",
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\",health_type=\"healthy\"}) /\nsum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
-                  "instant": false,
-                  "legendFormat": "__auto",
-                  "range": true
-               }
-            ],
-            "title": "Overall component health",
-            "type": "stat"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Breakdown of components by health across all running instances.\n\n* Healthy: components have been evaluated completely and are reporting themselves as healthy.\n* Unhealthy: Components either could not be evaluated or are reporting themselves as unhealthy.\n* Unknown: A component has been created but has not yet been started.\n* Exited: A component has exited. It will not return to the running state.\n\nMore information on a component's health state can be retrieved using\nthe Alloy UI.\n\nNote that components may be in a degraded state even if they report\nthemselves as healthy. Use component-specific dashboards and alerts\nto observe detailed information about the behavior of a component.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "min": 0,
-                  "thresholds": {
-                     "mode": "absolute",
-                     "steps": [
-                        {
-                           "color": "green",
-                           "value": null
-                        }
-                     ]
-                  }
-               },
-               "overrides": [
-                  {
-                     "matcher": {
-                        "id": "byName",
-                        "options": "Unhealthy"
-                     },
-                     "properties": [
-                        {
-                           "id": "thresholds",
-                           "value": {
-                              "mode": "absolute",
-                              "steps": [
-                                 {
-                                    "color": "green",
-                                    "value": null
-                                 },
-                                 {
-                                    "color": "red",
-                                    "value": 1
-                                 }
-                              ]
-                           }
-                        }
-                     ]
-                  },
-                  {
-                     "matcher": {
-                        "id": "byName",
-                        "options": "Unknown"
-                     },
-                     "properties": [
-                        {
-                           "id": "thresholds",
-                           "value": {
-                              "mode": "absolute",
-                              "steps": [
-                                 {
-                                    "color": "green",
-                                    "value": null
-                                 },
-                                 {
-                                    "color": "blue",
-                                    "value": 1
-                                 }
-                              ]
-                           }
-                        }
-                     ]
-                  },
-                  {
-                     "matcher": {
-                        "id": "byName",
-                        "options": "Exited"
-                     },
-                     "properties": [
-                        {
-                           "id": "thresholds",
-                           "value": {
-                              "mode": "absolute",
-                              "steps": [
-                                 {
-                                    "color": "green",
-                                    "value": null
-                                 },
-                                 {
-                                    "color": "orange",
-                                    "value": 1
-                                 }
-                              ]
-                           }
-                        }
-                     ]
-                  }
-               ]
-            },
-            "gridPos": {
-               "h": 12,
-               "w": 14,
-               "x": 10,
-               "y": 0
-            },
-            "options": {
-               "orientation": "vertical",
-               "showUnfilled": true
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"healthy\"}) or vector(0)\n",
-                  "instant": true,
-                  "legendFormat": "Healthy",
-                  "range": false
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unhealthy\"}) or vector(0)\n",
-                  "instant": true,
-                  "legendFormat": "Unhealthy",
-                  "range": false
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unknown\"}) or vector(0)\n",
-                  "instant": true,
-                  "legendFormat": "Unknown",
-                  "range": false
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"exited\"}) or vector(0)\n",
-                  "instant": true,
-                  "legendFormat": "Exited",
-                  "range": false
-               }
-            ],
-            "title": "Components by health",
-            "type": "bargauge"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "The frequency at which components get updated.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "drawStyle": "points",
-                     "pointSize": 3
-                  },
-                  "unit": "ops"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 0,
-               "y": 12
-            },
-            "options": {
-               "tooltip": {
-                  "mode": "multi"
-               }
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum by (instance) (rate(alloy_component_evaluation_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
-                  "instant": false,
-                  "legendFormat": "__auto",
-                  "range": true
-               }
-            ],
-            "title": "Component evaluation rate",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "The percentiles for how long it takes to complete component evaluations.\n\nComponent evaluations must complete for components to have the latest\narguments. The longer the evaluations take, the slower it will be to\nreconcile the state of components.\n\nIf evaluation is taking too long, consider sharding your components to\ndeal with smaller amounts of data and reuse data as much as possible.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "s"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 8,
-               "y": 12
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "histogram_quantile(0.99, sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.99, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
-                  "instant": false,
-                  "legendFormat": "99th percentile",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "histogram_quantile(0.50, sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.50, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
-                  "instant": false,
-                  "legendFormat": "50th percentile",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "(\n  histogram_sum(sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))) /\n  histogram_count(sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n)\nor\n(\n  sum(rate(alloy_component_evaluation_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])) /\n  sum(rate(alloy_component_evaluation_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n)\n",
-                  "instant": false,
-                  "legendFormat": "Average",
-                  "range": true
-               }
-            ],
-            "title": "Component evaluation time",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "The percentage of time spent evaluating 'slow' components - components that took longer than 1 minute to evaluate.\n\nIdeally, no component should take more than 1 minute to evaluate. The components displayed in this chart\nmay be a sign of a problem with the pipeline.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "percentunit"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 16,
-               "y": 12
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum by (component_path, component_id) (rate(alloy_component_evaluation_slow_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n/ scalar(sum(rate(alloy_component_evaluation_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
-                  "instant": false,
-                  "legendFormat": "{{component path}} {{component_id}}",
-                  "range": true
-               }
-            ],
-            "title": "Slow components evaluation times",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Detailed histogram view of how long component evaluations take.\n\nThe goal is to design your config so that evaluations take as little\ntime as possible; under 100ms is a good goal.\n",
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 0,
-               "y": 22
-            },
-            "maxDataPoints": 30,
-            "options": {
-               "calculate": false,
-               "cellGap": 0,
-               "color": {
-                  "scheme": "Spectral"
-               },
-               "exemplars": {
-                  "color": "rgba(255,0,255,0.7)"
-               },
-               "filterValues": {
-                  "le": 0.10000000000000001
-               },
-               "tooltip": {
-                  "show": true,
-                  "yHistogram": true
-               },
-               "yAxis": {
-                  "unit": "s"
-               }
-            },
-            "pluginVersion": "9.0.6",
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(increase(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
-                  "format": "heatmap",
-                  "instant": false,
-                  "legendFormat": "{{le}}",
-                  "range": true
-               }
-            ],
-            "title": "Component evaluation histogram",
-            "type": "heatmap"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Detailed histogram of how long components wait to be evaluated after their dependency is updated.\n\nThe goal is to design your config so that most of the time components do not\nqueue for long; under 10ms is a good goal.\n",
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 8,
-               "y": 22
-            },
-            "maxDataPoints": 30,
-            "options": {
-               "calculate": false,
-               "cellGap": 0,
-               "color": {
-                  "scheme": "Spectral"
-               },
-               "exemplars": {
-                  "color": "rgba(255,0,255,0.7)"
-               },
-               "filterValues": {
-                  "le": 0.10000000000000001
-               },
-               "tooltip": {
-                  "show": true,
-                  "yHistogram": true
-               },
-               "yAxis": {
-                  "unit": "s"
-               }
-            },
-            "pluginVersion": "9.0.6",
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(increase(alloy_component_dependencies_wait_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_dependencies_wait_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
-                  "format": "heatmap",
-                  "instant": false,
-                  "legendFormat": "{{le}}",
-                  "range": true
-               }
-            ],
-            "title": "Component dependency wait histogram",
-            "type": "heatmap"
-         }
-      ],
-      "refresh": "10s",
-      "schemaVersion": 36,
+  "annotations": {
+    "list": [
+      {
+        "datasource": "$loki_datasource",
+        "enable": true,
+        "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "instant": false,
+        "name": "Deployments",
+        "titleFormat": "{{cluster}}/{{namespace}}"
+      }
+    ]
+  },
+  "graphTooltip": 1,
+  "links": [
+    {
+      "icon": "doc",
+      "targetBlank": true,
+      "title": "Documentation",
+      "tooltip": "Component controller documentation",
+      "type": "link",
+      "url": "https://grafana.com/docs/alloy/latest/concepts/component_controller/"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
-         "alloy-mixin"
+        "alloy-mixin"
       ],
-      "templating": {
-         "list": [
-            {
-               "label": "Data Source",
-               "name": "datasource",
-               "query": "prometheus",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
-            },
-            {
-               "label": "Loki Data Source",
-               "name": "loki_datasource",
-               "query": "loki",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "cluster",
-               "name": "cluster",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
-                  "refId": "cluster"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "namespace",
-               "name": "namespace",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
-                  "refId": "namespace"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "job",
-               "name": "job",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
-                  "refId": "job"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            }
-         ]
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "description": "The number of Alloy instances whose metrics are being sent and reported.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "instances"
+        }
       },
-      "time": {
-         "from": "now-1h",
-         "to": "now"
+      "gridPos": {
+        "h": 4,
+        "w": 10,
+        "x": 0,
+        "y": 0
       },
-      "timepicker": {
-         "refresh_intervals": [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
-         ],
-         "time_options": [
-            "5m",
-            "15m",
-            "1h",
-            "6h",
-            "12h",
-            "24h",
-            "2d",
-            "7d",
-            "30d",
-            "90d"
-         ]
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none"
       },
-      "timezone": "utc",
-      "title": "Alloy / Controller",
-      "uid": "bf9f456aad7108b2c808dbd9973e386f"
-   }
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "count(group(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) by (instance))\n",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true
+        }
+      ],
+      "title": "Running instances",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "The number of running components across all running instances.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "components"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 10,
+        "x": 0,
+        "y": 4
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true
+        }
+      ],
+      "title": "Running components",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "The percentage of components which are in a healthy state.\n",
+      "fieldConfig": {
+        "defaults": {
+          "max": 1,
+          "min": 0,
+          "noValue": "No components",
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 10,
+        "x": 0,
+        "y": 8
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "text": {
+          "valueSize": 80
+        }
+      },
+      "pluginVersion": "9.0.6",
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\",health_type=\"healthy\"}) /\nsum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true
+        }
+      ],
+      "title": "Overall component health",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Breakdown of components by health across all running instances.\n\n* Healthy: components have been evaluated completely and are reporting themselves as healthy.\n* Unhealthy: Components either could not be evaluated or are reporting themselves as unhealthy.\n* Unknown: A component has been created but has not yet been started.\n* Exited: A component has exited. It will not return to the running state.\n\nMore information on a component's health state can be retrieved using\nthe Alloy UI.\n\nNote that components may be in a degraded state even if they report\nthemselves as healthy. Use component-specific dashboards and alerts\nto observe detailed information about the behavior of a component.\n",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Unhealthy"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Unknown"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "blue",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Exited"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 14,
+        "x": 10,
+        "y": 0
+      },
+      "options": {
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"healthy\"}) or vector(0)\n",
+          "instant": true,
+          "legendFormat": "Healthy",
+          "range": false
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unhealthy\"}) or vector(0)\n",
+          "instant": true,
+          "legendFormat": "Unhealthy",
+          "range": false
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unknown\"}) or vector(0)\n",
+          "instant": true,
+          "legendFormat": "Unknown",
+          "range": false
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"exited\"}) or vector(0)\n",
+          "instant": true,
+          "legendFormat": "Exited",
+          "range": false
+        }
+      ],
+      "title": "Components by health",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "The frequency at which components get updated.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "points",
+            "pointSize": 3
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 12
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum by (instance) (rate(alloy_component_evaluation_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true
+        }
+      ],
+      "title": "Component evaluation rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "The percentiles for how long it takes to complete component evaluations.\n\nComponent evaluations must complete for components to have the latest\narguments. The longer the evaluations take, the slower it will be to\nreconcile the state of components.\n\nIf evaluation is taking too long, consider sharding your components to\ndeal with smaller amounts of data and reuse data as much as possible.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 12
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "histogram_quantile(0.99, sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.99, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
+          "instant": false,
+          "legendFormat": "99th percentile",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "histogram_quantile(0.50, sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.50, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
+          "instant": false,
+          "legendFormat": "50th percentile",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "(\n  histogram_sum(sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))) /\n  histogram_count(sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n)\nor\n(\n  sum(rate(alloy_component_evaluation_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])) /\n  sum(rate(alloy_component_evaluation_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n)\n",
+          "instant": false,
+          "legendFormat": "Average",
+          "range": true
+        }
+      ],
+      "title": "Component evaluation time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "The percentage of time spent evaluating 'slow' components - components that took longer than 1 minute to evaluate.\n\nIdeally, no component should take more than 1 minute to evaluate. The components displayed in this chart\nmay be a sign of a problem with the pipeline.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 12
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum by (component_path, component_id) (rate(alloy_component_evaluation_slow_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n/ scalar(sum(rate(alloy_component_evaluation_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
+          "instant": false,
+          "legendFormat": "{{component path}} {{component_id}}",
+          "range": true
+        }
+      ],
+      "title": "Slow components evaluation times",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Detailed histogram view of how long component evaluations take.\n\nThe goal is to design your config so that evaluations take as little\ntime as possible; under 100ms is a good goal.\n",
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 22
+      },
+      "maxDataPoints": 30,
+      "options": {
+        "calculate": false,
+        "cellGap": 0,
+        "color": {
+          "scheme": "Spectral"
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 0.1
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "9.0.6",
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(increase(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+          "format": "heatmap",
+          "instant": false,
+          "legendFormat": "{{le}}",
+          "range": true
+        }
+      ],
+      "title": "Component evaluation histogram",
+      "type": "heatmap"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Detailed histogram of how long components wait to be evaluated after their dependency is updated.\n\nThe goal is to design your config so that most of the time components do not\nqueue for long; under 10ms is a good goal.\n",
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 22
+      },
+      "maxDataPoints": 30,
+      "options": {
+        "calculate": false,
+        "cellGap": 0,
+        "color": {
+          "scheme": "Spectral"
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 0.1
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "9.0.6",
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(increase(alloy_component_dependencies_wait_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_dependencies_wait_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+          "format": "heatmap",
+          "instant": false,
+          "legendFormat": "{{le}}",
+          "range": true
+        }
+      ],
+      "title": "Component dependency wait histogram",
+      "type": "heatmap"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "tags": [
+    "alloy-mixin",
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
+  ],
+  "templating": {
+    "list": [
+      {
+        "label": "Data Source",
+        "name": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "label": "Loki Data Source",
+        "name": "loki_datasource",
+        "query": "loki",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "cluster",
+        "name": "cluster",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "refId": "cluster"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "namespace",
+        "name": "namespace",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "refId": "namespace"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "job",
+        "name": "job",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "refId": "job"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d",
+      "90d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Alloy / Controller",
+  "uid": "bf9f456aad7108b2c808dbd9973e386f"
+}

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-logs.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-logs.json
@@ -1,0 +1,324 @@
+{
+      "links": [
+         {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [
+               "alloy-mixin"
+            ],
+            "targetBlank": false,
+            "title": "Dashboards",
+            "type": "dashboards"
+         }
+      ],
+      "panels": [
+         {
+            "datasource": {
+               "type": "loki",
+               "uid": "${loki_datasource}"
+            },
+            "description": "Logs volume grouped by \"level\" label.",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "drawStyle": "bars",
+                     "fillOpacity": 50,
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  },
+                  "unit": "none"
+               },
+               "overrides": [
+                  {
+                     "matcher": {
+                        "id": "byRegexp",
+                        "options": "(E|e)merg|(F|f)atal|(A|a)lert|(C|c)rit.*"
+                     },
+                     "properties": [
+                        {
+                           "id": "color",
+                           "value": {
+                              "fixedColor": "purple",
+                              "mode": "fixed"
+                           }
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byRegexp",
+                        "options": "(E|e)(rr.*|RR.*)"
+                     },
+                     "properties": [
+                        {
+                           "id": "color",
+                           "value": {
+                              "fixedColor": "red",
+                              "mode": "fixed"
+                           }
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byRegexp",
+                        "options": "(W|w)(arn.*|ARN.*|rn|RN)"
+                     },
+                     "properties": [
+                        {
+                           "id": "color",
+                           "value": {
+                              "fixedColor": "orange",
+                              "mode": "fixed"
+                           }
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byRegexp",
+                        "options": "(N|n)(otice|ote)|(I|i)(nf.*|NF.*)"
+                     },
+                     "properties": [
+                        {
+                           "id": "color",
+                           "value": {
+                              "fixedColor": "green",
+                              "mode": "fixed"
+                           }
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byRegexp",
+                        "options": "dbg.*|DBG.*|(D|d)(EBUG|ebug)"
+                     },
+                     "properties": [
+                        {
+                           "id": "color",
+                           "value": {
+                              "fixedColor": "blue",
+                              "mode": "fixed"
+                           }
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byRegexp",
+                        "options": "(T|t)(race|RACE)"
+                     },
+                     "properties": [
+                        {
+                           "id": "color",
+                           "value": {
+                              "fixedColor": "light-blue",
+                              "mode": "fixed"
+                           }
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byRegexp",
+                        "options": "logs"
+                     },
+                     "properties": [
+                        {
+                           "id": "color",
+                           "value": {
+                              "fixedColor": "text",
+                              "mode": "fixed"
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "gridPos": {
+               "h": 6,
+               "w": 24
+            },
+            "id": 1,
+            "interval": "30s",
+            "options": {
+               "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+               }
+            },
+            "pluginVersion": "v10.0.0",
+            "targets": [
+               {
+                  "datasource": {
+                     "type": "loki",
+                     "uid": "${loki_datasource}"
+                  },
+                  "expr": "sum by (level) (count_over_time({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"}\n|~ \"$regex_search\"\n\n[$__interval]))\n",
+                  "legendFormat": "{{ level }}"
+               }
+            ],
+            "title": "Logs volume",
+            "transformations": [
+               {
+                  "id": "renameByRegex",
+                  "options": {
+                     "regex": "Value",
+                     "renamePattern": "logs"
+                  }
+               }
+            ],
+            "type": "timeseries"
+         },
+         {
+            "datasource": {
+               "type": "datasource",
+               "uid": "-- Mixed --"
+            },
+            "gridPos": {
+               "h": 18,
+               "w": 24
+            },
+            "id": 2,
+            "options": {
+               "dedupStrategy": "exact",
+               "enableLogDetails": true,
+               "prettifyLogMessage": true,
+               "showTime": false,
+               "wrapLogMessage": true
+            },
+            "pluginVersion": "v10.0.0",
+            "targets": [
+               {
+                  "datasource": {
+                     "type": "loki",
+                     "uid": "${loki_datasource}"
+                  },
+                  "expr": "{,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"} \n|~ \"$regex_search\"\n\n\n"
+               }
+            ],
+            "title": "Logs",
+            "type": "logs"
+         }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 36,
+      "tags": [
+         "alloy-mixin"
+      ],
+      "templating": {
+         "list": [
+            {
+               "label": "Loki data source",
+               "name": "loki_datasource",
+               "query": "loki",
+               "regex": "",
+               "type": "datasource"
+            },
+            {
+               "allValue": ".*",
+               "datasource": {
+                  "type": "loki",
+                  "uid": "${loki_datasource}"
+               },
+               "includeAll": true,
+               "label": "Cluster",
+               "multi": true,
+               "name": "cluster",
+               "query": "label_values({}, cluster)",
+               "refresh": 2,
+               "sort": 1,
+               "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": {
+                  "type": "loki",
+                  "uid": "${loki_datasource}"
+               },
+               "includeAll": true,
+               "label": "Namespace",
+               "multi": true,
+               "name": "namespace",
+               "query": "label_values({,cluster=~\"$cluster\"}, namespace)",
+               "refresh": 2,
+               "sort": 1,
+               "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": {
+                  "type": "loki",
+                  "uid": "${loki_datasource}"
+               },
+               "includeAll": true,
+               "label": "Job",
+               "multi": true,
+               "name": "job",
+               "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+               "refresh": 2,
+               "sort": 1,
+               "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": {
+                  "type": "loki",
+                  "uid": "${loki_datasource}"
+               },
+               "includeAll": true,
+               "label": "Instance",
+               "multi": true,
+               "name": "instance",
+               "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\"}, instance)",
+               "refresh": 2,
+               "sort": 1,
+               "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": {
+                  "type": "loki",
+                  "uid": "${loki_datasource}"
+               },
+               "includeAll": true,
+               "label": "Level",
+               "multi": true,
+               "name": "level",
+               "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\"}, level)",
+               "refresh": 2,
+               "sort": 1,
+               "type": "query"
+            },
+            {
+               "current": {
+                  "selected": false,
+                  "text": "",
+                  "value": ""
+               },
+               "label": "Regex search",
+               "name": "regex_search",
+               "options": [
+                  {
+                     "selected": true,
+                     "text": "",
+                     "value": ""
+                  }
+               ],
+               "query": "",
+               "type": "textbox"
+            }
+         ]
+      },
+      "time": {
+         "from": "now-6h",
+         "to": "now"
+      },
+      "timezone": "utc",
+      "title": "Alloy / Logs Overview",
+      "uid": "53c1ecddc3a1d5d4b8d6cd0c23676c31"
+   }

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-logs.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-logs.json
@@ -1,324 +1,327 @@
 {
-      "links": [
-         {
-            "asDropdown": true,
-            "icon": "external link",
-            "includeVars": true,
-            "keepTime": true,
-            "tags": [
-               "alloy-mixin"
-            ],
-            "targetBlank": false,
-            "title": "Dashboards",
-            "type": "dashboards"
-         }
-      ],
-      "panels": [
-         {
-            "datasource": {
-               "type": "loki",
-               "uid": "${loki_datasource}"
-            },
-            "description": "Logs volume grouped by \"level\" label.",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "drawStyle": "bars",
-                     "fillOpacity": 50,
-                     "stacking": {
-                        "mode": "normal"
-                     }
-                  },
-                  "unit": "none"
-               },
-               "overrides": [
-                  {
-                     "matcher": {
-                        "id": "byRegexp",
-                        "options": "(E|e)merg|(F|f)atal|(A|a)lert|(C|c)rit.*"
-                     },
-                     "properties": [
-                        {
-                           "id": "color",
-                           "value": {
-                              "fixedColor": "purple",
-                              "mode": "fixed"
-                           }
-                        }
-                     ]
-                  },
-                  {
-                     "matcher": {
-                        "id": "byRegexp",
-                        "options": "(E|e)(rr.*|RR.*)"
-                     },
-                     "properties": [
-                        {
-                           "id": "color",
-                           "value": {
-                              "fixedColor": "red",
-                              "mode": "fixed"
-                           }
-                        }
-                     ]
-                  },
-                  {
-                     "matcher": {
-                        "id": "byRegexp",
-                        "options": "(W|w)(arn.*|ARN.*|rn|RN)"
-                     },
-                     "properties": [
-                        {
-                           "id": "color",
-                           "value": {
-                              "fixedColor": "orange",
-                              "mode": "fixed"
-                           }
-                        }
-                     ]
-                  },
-                  {
-                     "matcher": {
-                        "id": "byRegexp",
-                        "options": "(N|n)(otice|ote)|(I|i)(nf.*|NF.*)"
-                     },
-                     "properties": [
-                        {
-                           "id": "color",
-                           "value": {
-                              "fixedColor": "green",
-                              "mode": "fixed"
-                           }
-                        }
-                     ]
-                  },
-                  {
-                     "matcher": {
-                        "id": "byRegexp",
-                        "options": "dbg.*|DBG.*|(D|d)(EBUG|ebug)"
-                     },
-                     "properties": [
-                        {
-                           "id": "color",
-                           "value": {
-                              "fixedColor": "blue",
-                              "mode": "fixed"
-                           }
-                        }
-                     ]
-                  },
-                  {
-                     "matcher": {
-                        "id": "byRegexp",
-                        "options": "(T|t)(race|RACE)"
-                     },
-                     "properties": [
-                        {
-                           "id": "color",
-                           "value": {
-                              "fixedColor": "light-blue",
-                              "mode": "fixed"
-                           }
-                        }
-                     ]
-                  },
-                  {
-                     "matcher": {
-                        "id": "byRegexp",
-                        "options": "logs"
-                     },
-                     "properties": [
-                        {
-                           "id": "color",
-                           "value": {
-                              "fixedColor": "text",
-                              "mode": "fixed"
-                           }
-                        }
-                     ]
-                  }
-               ]
-            },
-            "gridPos": {
-               "h": 6,
-               "w": 24
-            },
-            "id": 1,
-            "interval": "30s",
-            "options": {
-               "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-               }
-            },
-            "pluginVersion": "v10.0.0",
-            "targets": [
-               {
-                  "datasource": {
-                     "type": "loki",
-                     "uid": "${loki_datasource}"
-                  },
-                  "expr": "sum by (level) (count_over_time({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"}\n|~ \"$regex_search\"\n\n[$__interval]))\n",
-                  "legendFormat": "{{ level }}"
-               }
-            ],
-            "title": "Logs volume",
-            "transformations": [
-               {
-                  "id": "renameByRegex",
-                  "options": {
-                     "regex": "Value",
-                     "renamePattern": "logs"
-                  }
-               }
-            ],
-            "type": "timeseries"
-         },
-         {
-            "datasource": {
-               "type": "datasource",
-               "uid": "-- Mixed --"
-            },
-            "gridPos": {
-               "h": 18,
-               "w": 24
-            },
-            "id": 2,
-            "options": {
-               "dedupStrategy": "exact",
-               "enableLogDetails": true,
-               "prettifyLogMessage": true,
-               "showTime": false,
-               "wrapLogMessage": true
-            },
-            "pluginVersion": "v10.0.0",
-            "targets": [
-               {
-                  "datasource": {
-                     "type": "loki",
-                     "uid": "${loki_datasource}"
-                  },
-                  "expr": "{,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"} \n|~ \"$regex_search\"\n\n\n"
-               }
-            ],
-            "title": "Logs",
-            "type": "logs"
-         }
-      ],
-      "refresh": "10s",
-      "schemaVersion": 36,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
-         "alloy-mixin"
+        "alloy-mixin"
       ],
-      "templating": {
-         "list": [
-            {
-               "label": "Loki data source",
-               "name": "loki_datasource",
-               "query": "loki",
-               "regex": "",
-               "type": "datasource"
-            },
-            {
-               "allValue": ".*",
-               "datasource": {
-                  "type": "loki",
-                  "uid": "${loki_datasource}"
-               },
-               "includeAll": true,
-               "label": "Cluster",
-               "multi": true,
-               "name": "cluster",
-               "query": "label_values({}, cluster)",
-               "refresh": 2,
-               "sort": 1,
-               "type": "query"
-            },
-            {
-               "allValue": ".*",
-               "datasource": {
-                  "type": "loki",
-                  "uid": "${loki_datasource}"
-               },
-               "includeAll": true,
-               "label": "Namespace",
-               "multi": true,
-               "name": "namespace",
-               "query": "label_values({,cluster=~\"$cluster\"}, namespace)",
-               "refresh": 2,
-               "sort": 1,
-               "type": "query"
-            },
-            {
-               "allValue": ".*",
-               "datasource": {
-                  "type": "loki",
-                  "uid": "${loki_datasource}"
-               },
-               "includeAll": true,
-               "label": "Job",
-               "multi": true,
-               "name": "job",
-               "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
-               "refresh": 2,
-               "sort": 1,
-               "type": "query"
-            },
-            {
-               "allValue": ".*",
-               "datasource": {
-                  "type": "loki",
-                  "uid": "${loki_datasource}"
-               },
-               "includeAll": true,
-               "label": "Instance",
-               "multi": true,
-               "name": "instance",
-               "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\"}, instance)",
-               "refresh": 2,
-               "sort": 1,
-               "type": "query"
-            },
-            {
-               "allValue": ".*",
-               "datasource": {
-                  "type": "loki",
-                  "uid": "${loki_datasource}"
-               },
-               "includeAll": true,
-               "label": "Level",
-               "multi": true,
-               "name": "level",
-               "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\"}, level)",
-               "refresh": 2,
-               "sort": 1,
-               "type": "query"
-            },
-            {
-               "current": {
-                  "selected": false,
-                  "text": "",
-                  "value": ""
-               },
-               "label": "Regex search",
-               "name": "regex_search",
-               "options": [
-                  {
-                     "selected": true,
-                     "text": "",
-                     "value": ""
-                  }
-               ],
-               "query": "",
-               "type": "textbox"
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${loki_datasource}"
+      },
+      "description": "Logs volume grouped by \"level\" label.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 50,
+            "stacking": {
+              "mode": "normal"
             }
-         ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "(E|e)merg|(F|f)atal|(A|a)lert|(C|c)rit.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "(E|e)(rr.*|RR.*)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "(W|w)(arn.*|ARN.*|rn|RN)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "(N|n)(otice|ote)|(I|i)(nf.*|NF.*)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "dbg.*|DBG.*|(D|d)(EBUG|ebug)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "(T|t)(race|RACE)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "logs"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
-      "time": {
-         "from": "now-6h",
-         "to": "now"
+      "gridPos": {
+        "h": 6,
+        "w": 24
       },
-      "timezone": "utc",
-      "title": "Alloy / Logs Overview",
-      "uid": "53c1ecddc3a1d5d4b8d6cd0c23676c31"
-   }
+      "id": 1,
+      "interval": "30s",
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${loki_datasource}"
+          },
+          "expr": "sum by (level) (count_over_time({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"}\n|~ \"$regex_search\"\n\n[$__interval]))\n",
+          "legendFormat": "{{ level }}"
+        }
+      ],
+      "title": "Logs volume",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "Value",
+            "renamePattern": "logs"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 24
+      },
+      "id": 2,
+      "options": {
+        "dedupStrategy": "exact",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showTime": false,
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "v10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${loki_datasource}"
+          },
+          "expr": "{,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"} \n|~ \"$regex_search\"\n\n\n"
+        }
+      ],
+      "title": "Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "tags": [
+    "alloy-mixin",
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
+  ],
+  "templating": {
+    "list": [
+      {
+        "label": "Loki data source",
+        "name": "loki_datasource",
+        "query": "loki",
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "datasource": {
+          "type": "loki",
+          "uid": "${loki_datasource}"
+        },
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "query": "label_values({}, cluster)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": {
+          "type": "loki",
+          "uid": "${loki_datasource}"
+        },
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "query": "label_values({,cluster=~\"$cluster\"}, namespace)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": {
+          "type": "loki",
+          "uid": "${loki_datasource}"
+        },
+        "includeAll": true,
+        "label": "Job",
+        "multi": true,
+        "name": "job",
+        "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": {
+          "type": "loki",
+          "uid": "${loki_datasource}"
+        },
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\"}, instance)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": {
+          "type": "loki",
+          "uid": "${loki_datasource}"
+        },
+        "includeAll": true,
+        "label": "Level",
+        "multi": true,
+        "name": "level",
+        "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\"}, level)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "label": "Regex search",
+        "name": "regex_search",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "utc",
+  "title": "Alloy / Logs Overview",
+  "uid": "53c1ecddc3a1d5d4b8d6cd0c23676c31"
+}

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-opentelemetry.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-opentelemetry.json
@@ -1,0 +1,432 @@
+{
+      "graphTooltip": 1,
+      "links": [
+         {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [
+               "alloy-mixin"
+            ],
+            "targetBlank": false,
+            "title": "Dashboards",
+            "type": "dashboards"
+         }
+      ],
+      "panels": [
+         {
+            "datasource": "${datasource}",
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 0
+            },
+            "title": "Receivers for traces [otelcol.receiver]",
+            "type": "row"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Number of spans successfully pushed into the pipeline.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 20,
+                     "gradientMode": "hue",
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  }
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 0,
+               "y": 0
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(receiver_accepted_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "{{ pod }} / {{ transport }}",
+                  "range": true
+               }
+            ],
+            "title": "Accepted spans",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Number of spans that could not be pushed into the pipeline.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 20,
+                     "gradientMode": "hue",
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  }
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 8,
+               "y": 0
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(receiver_refused_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "{{ pod }} / {{ transport }}",
+                  "range": true
+               }
+            ],
+            "title": "Refused spans",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "The duration of inbound RPCs.\n",
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 16,
+               "y": 0
+            },
+            "maxDataPoints": 30,
+            "options": {
+               "calculate": false,
+               "color": {
+                  "exponent": 0.5,
+                  "fill": "dark-orange",
+                  "mode": "scheme",
+                  "scale": "exponential",
+                  "scheme": "Oranges",
+                  "steps": 65
+               },
+               "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+               },
+               "filterValues": {
+                  "le": 1.0000000000000001e-09
+               },
+               "tooltip": {
+                  "show": true,
+                  "yHistogram": true
+               },
+               "yAxis": {
+                  "unit": "ms"
+               }
+            },
+            "pluginVersion": "9.0.6",
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum by (le) (increase(rpc_server_duration_milliseconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", rpc_service=\"opentelemetry.proto.collector.trace.v1.TraceService\"}[$__rate_interval]))\n",
+                  "format": "heatmap",
+                  "instant": false,
+                  "legendFormat": "{{le}}",
+                  "range": true
+               }
+            ],
+            "title": "RPC server duration",
+            "type": "heatmap"
+         },
+         {
+            "datasource": "${datasource}",
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 10
+            },
+            "title": "Batching of logs, metrics, and traces [otelcol.processor.batch]",
+            "type": "row"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Number of spans, metric datapoints, or log lines in a batch\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "short"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 0,
+               "y": 10
+            },
+            "maxDataPoints": 30,
+            "options": {
+               "calculate": false,
+               "color": {
+                  "exponent": 0.5,
+                  "fill": "dark-orange",
+                  "mode": "scheme",
+                  "scale": "exponential",
+                  "scheme": "Oranges",
+                  "steps": 65
+               },
+               "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+               },
+               "filterValues": {
+                  "le": 1.0000000000000001e-09
+               },
+               "tooltip": {
+                  "show": true,
+                  "yHistogram": true
+               },
+               "yAxis": {
+                  "unit": "short"
+               }
+            },
+            "pluginVersion": "9.0.6",
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum by (le) (increase(processor_batch_batch_send_size_ratio_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+                  "format": "heatmap",
+                  "instant": false,
+                  "legendFormat": "{{le}}",
+                  "range": true
+               }
+            ],
+            "title": "Number of units in the batch",
+            "type": "heatmap"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Number of distinct metadata value combinations being processed\n",
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 8,
+               "y": 10
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "processor_batch_metadata_cardinality_ratio{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+                  "instant": false,
+                  "legendFormat": "{{ pod }}",
+                  "range": true
+               }
+            ],
+            "title": "Distinct metadata values",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Number of times the batch was sent due to a timeout trigger\n",
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 16,
+               "y": 10
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(processor_batch_timeout_trigger_send_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "{{ pod }}",
+                  "range": true
+               }
+            ],
+            "title": "Timeout trigger",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 20
+            },
+            "title": "Exporters for traces [otelcol.exporter]",
+            "type": "row"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Number of spans successfully sent to destination.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 20,
+                     "gradientMode": "hue",
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  }
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 0,
+               "y": 20
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(exporter_sent_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "{{ pod }}",
+                  "range": true
+               }
+            ],
+            "title": "Exported sent spans",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Number of spans in failed attempts to send to destination.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 20,
+                     "gradientMode": "hue",
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  }
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 8,
+               "y": 20
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(exporter_send_failed_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "{{ pod }}",
+                  "range": true
+               }
+            ],
+            "title": "Exported failed spans",
+            "type": "timeseries"
+         }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 36,
+      "tags": [
+         "alloy-mixin"
+      ],
+      "templating": {
+         "list": [
+            {
+               "label": "Data Source",
+               "name": "datasource",
+               "query": "prometheus",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "label": "Loki Data Source",
+               "name": "loki_datasource",
+               "query": "loki",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "cluster",
+               "name": "cluster",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+                  "refId": "cluster"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "namespace",
+               "name": "namespace",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+                  "refId": "namespace"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "job",
+               "name": "job",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+                  "refId": "job"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": "${datasource}",
+               "includeAll": true,
+               "label": "instance",
+               "multi": true,
+               "name": "instance",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+                  "refId": "instance"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            }
+         ]
+      },
+      "time": {
+         "from": "now-1h",
+         "to": "now"
+      },
+      "timepicker": {
+         "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+         ],
+         "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d",
+            "90d"
+         ]
+      },
+      "timezone": "utc",
+      "title": "Alloy / OpenTelemetry",
+      "uid": "9b6d37c8603e19e8922133984faad93d"
+   }

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-opentelemetry.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-opentelemetry.json
@@ -1,432 +1,435 @@
 {
-      "graphTooltip": 1,
-      "links": [
-         {
-            "asDropdown": true,
-            "icon": "external link",
-            "includeVars": true,
-            "keepTime": true,
-            "tags": [
-               "alloy-mixin"
-            ],
-            "targetBlank": false,
-            "title": "Dashboards",
-            "type": "dashboards"
-         }
-      ],
-      "panels": [
-         {
-            "datasource": "${datasource}",
-            "gridPos": {
-               "h": 1,
-               "w": 24,
-               "x": 0,
-               "y": 0
-            },
-            "title": "Receivers for traces [otelcol.receiver]",
-            "type": "row"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Number of spans successfully pushed into the pipeline.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "fillOpacity": 20,
-                     "gradientMode": "hue",
-                     "stacking": {
-                        "mode": "normal"
-                     }
-                  }
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 0,
-               "y": 0
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(receiver_accepted_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "{{ pod }} / {{ transport }}",
-                  "range": true
-               }
-            ],
-            "title": "Accepted spans",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Number of spans that could not be pushed into the pipeline.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "fillOpacity": 20,
-                     "gradientMode": "hue",
-                     "stacking": {
-                        "mode": "normal"
-                     }
-                  }
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 8,
-               "y": 0
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(receiver_refused_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "{{ pod }} / {{ transport }}",
-                  "range": true
-               }
-            ],
-            "title": "Refused spans",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "The duration of inbound RPCs.\n",
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 16,
-               "y": 0
-            },
-            "maxDataPoints": 30,
-            "options": {
-               "calculate": false,
-               "color": {
-                  "exponent": 0.5,
-                  "fill": "dark-orange",
-                  "mode": "scheme",
-                  "scale": "exponential",
-                  "scheme": "Oranges",
-                  "steps": 65
-               },
-               "exemplars": {
-                  "color": "rgba(255,0,255,0.7)"
-               },
-               "filterValues": {
-                  "le": 1.0000000000000001e-09
-               },
-               "tooltip": {
-                  "show": true,
-                  "yHistogram": true
-               },
-               "yAxis": {
-                  "unit": "ms"
-               }
-            },
-            "pluginVersion": "9.0.6",
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum by (le) (increase(rpc_server_duration_milliseconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", rpc_service=\"opentelemetry.proto.collector.trace.v1.TraceService\"}[$__rate_interval]))\n",
-                  "format": "heatmap",
-                  "instant": false,
-                  "legendFormat": "{{le}}",
-                  "range": true
-               }
-            ],
-            "title": "RPC server duration",
-            "type": "heatmap"
-         },
-         {
-            "datasource": "${datasource}",
-            "gridPos": {
-               "h": 1,
-               "w": 24,
-               "x": 0,
-               "y": 10
-            },
-            "title": "Batching of logs, metrics, and traces [otelcol.processor.batch]",
-            "type": "row"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Number of spans, metric datapoints, or log lines in a batch\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "short"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 0,
-               "y": 10
-            },
-            "maxDataPoints": 30,
-            "options": {
-               "calculate": false,
-               "color": {
-                  "exponent": 0.5,
-                  "fill": "dark-orange",
-                  "mode": "scheme",
-                  "scale": "exponential",
-                  "scheme": "Oranges",
-                  "steps": 65
-               },
-               "exemplars": {
-                  "color": "rgba(255,0,255,0.7)"
-               },
-               "filterValues": {
-                  "le": 1.0000000000000001e-09
-               },
-               "tooltip": {
-                  "show": true,
-                  "yHistogram": true
-               },
-               "yAxis": {
-                  "unit": "short"
-               }
-            },
-            "pluginVersion": "9.0.6",
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum by (le) (increase(processor_batch_batch_send_size_ratio_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
-                  "format": "heatmap",
-                  "instant": false,
-                  "legendFormat": "{{le}}",
-                  "range": true
-               }
-            ],
-            "title": "Number of units in the batch",
-            "type": "heatmap"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Number of distinct metadata value combinations being processed\n",
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 8,
-               "y": 10
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "processor_batch_metadata_cardinality_ratio{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
-                  "instant": false,
-                  "legendFormat": "{{ pod }}",
-                  "range": true
-               }
-            ],
-            "title": "Distinct metadata values",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Number of times the batch was sent due to a timeout trigger\n",
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 16,
-               "y": 10
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(processor_batch_timeout_trigger_send_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "{{ pod }}",
-                  "range": true
-               }
-            ],
-            "title": "Timeout trigger",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "gridPos": {
-               "h": 1,
-               "w": 24,
-               "x": 0,
-               "y": 20
-            },
-            "title": "Exporters for traces [otelcol.exporter]",
-            "type": "row"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Number of spans successfully sent to destination.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "fillOpacity": 20,
-                     "gradientMode": "hue",
-                     "stacking": {
-                        "mode": "normal"
-                     }
-                  }
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 0,
-               "y": 20
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(exporter_sent_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "{{ pod }}",
-                  "range": true
-               }
-            ],
-            "title": "Exported sent spans",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Number of spans in failed attempts to send to destination.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "fillOpacity": 20,
-                     "gradientMode": "hue",
-                     "stacking": {
-                        "mode": "normal"
-                     }
-                  }
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 8,
-               "y": 20
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(exporter_send_failed_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "{{ pod }}",
-                  "range": true
-               }
-            ],
-            "title": "Exported failed spans",
-            "type": "timeseries"
-         }
-      ],
-      "refresh": "10s",
-      "schemaVersion": 36,
+  "graphTooltip": 1,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
-         "alloy-mixin"
+        "alloy-mixin"
       ],
-      "templating": {
-         "list": [
-            {
-               "label": "Data Source",
-               "name": "datasource",
-               "query": "prometheus",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
-            },
-            {
-               "label": "Loki Data Source",
-               "name": "loki_datasource",
-               "query": "loki",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "cluster",
-               "name": "cluster",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
-                  "refId": "cluster"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "namespace",
-               "name": "namespace",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
-                  "refId": "namespace"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "job",
-               "name": "job",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
-                  "refId": "job"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "allValue": ".*",
-               "datasource": "${datasource}",
-               "includeAll": true,
-               "label": "instance",
-               "multi": true,
-               "name": "instance",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
-                  "refId": "instance"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "title": "Receivers for traces [otelcol.receiver]",
+      "type": "row"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Number of spans successfully pushed into the pipeline.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 20,
+            "gradientMode": "hue",
+            "stacking": {
+              "mode": "normal"
             }
-         ]
+          }
+        }
       },
-      "time": {
-         "from": "now-1h",
-         "to": "now"
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 0
       },
-      "timepicker": {
-         "refresh_intervals": [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
-         ],
-         "time_options": [
-            "5m",
-            "15m",
-            "1h",
-            "6h",
-            "12h",
-            "24h",
-            "2d",
-            "7d",
-            "30d",
-            "90d"
-         ]
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(receiver_accepted_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "{{ pod }} / {{ transport }}",
+          "range": true
+        }
+      ],
+      "title": "Accepted spans",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Number of spans that could not be pushed into the pipeline.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 20,
+            "gradientMode": "hue",
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        }
       },
-      "timezone": "utc",
-      "title": "Alloy / OpenTelemetry",
-      "uid": "9b6d37c8603e19e8922133984faad93d"
-   }
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(receiver_refused_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "{{ pod }} / {{ transport }}",
+          "range": true
+        }
+      ],
+      "title": "Refused spans",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "The duration of inbound RPCs.\n",
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "maxDataPoints": 30,
+      "options": {
+        "calculate": false,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 65
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "unit": "ms"
+        }
+      },
+      "pluginVersion": "9.0.6",
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum by (le) (increase(rpc_server_duration_milliseconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", rpc_service=\"opentelemetry.proto.collector.trace.v1.TraceService\"}[$__rate_interval]))\n",
+          "format": "heatmap",
+          "instant": false,
+          "legendFormat": "{{le}}",
+          "range": true
+        }
+      ],
+      "title": "RPC server duration",
+      "type": "heatmap"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "title": "Batching of logs, metrics, and traces [otelcol.processor.batch]",
+      "type": "row"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Number of spans, metric datapoints, or log lines in a batch\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "maxDataPoints": 30,
+      "options": {
+        "calculate": false,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 65
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "9.0.6",
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum by (le) (increase(processor_batch_batch_send_size_ratio_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+          "format": "heatmap",
+          "instant": false,
+          "legendFormat": "{{le}}",
+          "range": true
+        }
+      ],
+      "title": "Number of units in the batch",
+      "type": "heatmap"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Number of distinct metadata value combinations being processed\n",
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "processor_batch_metadata_cardinality_ratio{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "instant": false,
+          "legendFormat": "{{ pod }}",
+          "range": true
+        }
+      ],
+      "title": "Distinct metadata values",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Number of times the batch was sent due to a timeout trigger\n",
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(processor_batch_timeout_trigger_send_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "{{ pod }}",
+          "range": true
+        }
+      ],
+      "title": "Timeout trigger",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "title": "Exporters for traces [otelcol.exporter]",
+      "type": "row"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Number of spans successfully sent to destination.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 20,
+            "gradientMode": "hue",
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 20
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(exporter_sent_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "{{ pod }}",
+          "range": true
+        }
+      ],
+      "title": "Exported sent spans",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Number of spans in failed attempts to send to destination.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 20,
+            "gradientMode": "hue",
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 20
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(exporter_send_failed_spans_ratio_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "{{ pod }}",
+          "range": true
+        }
+      ],
+      "title": "Exported failed spans",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "tags": [
+    "alloy-mixin",
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
+  ],
+  "templating": {
+    "list": [
+      {
+        "label": "Data Source",
+        "name": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "label": "Loki Data Source",
+        "name": "loki_datasource",
+        "query": "loki",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "cluster",
+        "name": "cluster",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "refId": "cluster"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "namespace",
+        "name": "namespace",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "refId": "namespace"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "job",
+        "name": "job",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "refId": "job"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": "${datasource}",
+        "includeAll": true,
+        "label": "instance",
+        "multi": true,
+        "name": "instance",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+          "refId": "instance"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d",
+      "90d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Alloy / OpenTelemetry",
+  "uid": "9b6d37c8603e19e8922133984faad93d"
+}

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-prometheus-remote-write.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-prometheus-remote-write.json
@@ -1,693 +1,696 @@
 {
-      "annotations": {
-         "list": [
-            {
-               "datasource": "$loki_datasource",
-               "enable": true,
-               "expr": "{cluster=~\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
-               "iconColor": "rgba(0, 211, 255, 1)",
-               "instant": false,
-               "name": "Deployments",
-               "titleFormat": "{{cluster}}/{{namespace}}"
-            }
-         ]
-      },
-      "graphTooltip": 1,
-      "links": [
-         {
-            "icon": "doc",
-            "targetBlank": true,
-            "title": "Documentation",
-            "tooltip": "Component documentation",
-            "type": "link",
-            "url": "https://grafana.com/docs/alloy/latest/reference/components/prometheus.remote_write/"
-         },
-         {
-            "asDropdown": true,
-            "icon": "external link",
-            "includeVars": true,
-            "keepTime": true,
-            "tags": [
-               "alloy-mixin"
-            ],
-            "targetBlank": false,
-            "title": "Dashboards",
-            "type": "dashboards"
-         }
-      ],
-      "panels": [
-         {
-            "collapsed": false,
-            "datasource": "${datasource}",
-            "gridPos": {
-               "h": 1,
-               "w": 24,
-               "x": 0,
-               "y": 0
-            },
-            "title": "prometheus.scrape",
-            "type": "row"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Percentage of targets successfully scraped by prometheus.scrape\ncomponents.\n\nThis metric is calculated by dividing the number of targets\nsuccessfully scraped by the total number of targets scraped,\nacross all the namespaces in the selected cluster.\n\nLow success rates can indicate a problem with scrape targets,\nstale service discovery, or Alloy misconfiguration.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "percentunit"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 12,
-               "x": 0,
-               "y": 1
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(up{job=~\"$job\", cluster=~\"$cluster\"})\n/\ncount (up{job=~\"$job\", cluster=~\"$cluster\"})\n",
-                  "instant": false,
-                  "legendFormat": "% of targets successfully scraped",
-                  "range": true
-               }
-            ],
-            "title": "Scrape success rate in $cluster",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Duration of successful scrapes by prometheus.scrape components,\nacross all the namespaces in the selected cluster.\n\nThis metric should be below your configured scrape interval.\nHigh durations can indicate a problem with a scrape target or\na performance issue with Alloy.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "s"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 12,
-               "x": 12,
-               "y": 1
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "quantile(0.99, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
-                  "instant": false,
-                  "legendFormat": "p99",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "quantile(0.95, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
-                  "instant": false,
-                  "legendFormat": "p95",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "quantile(0.50, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
-                  "instant": false,
-                  "legendFormat": "p50",
-                  "range": true
-               }
-            ],
-            "title": "Scrape duration in $cluster",
-            "type": "timeseries"
-         },
-         {
-            "collapsed": false,
-            "datasource": "${datasource}",
-            "gridPos": {
-               "h": 1,
-               "w": 24,
-               "x": 0,
-               "y": 11
-            },
-            "title": "prometheus.remote_write",
-            "type": "row"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Percentage of samples sent by prometheus.remote_write that succeeded.\n\nLow success rates can indicate a problem with Alloy or the remote storage.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "percentunit"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 12,
-               "x": 0,
-               "y": 12
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "(\n    1 - \n    (\n        sum(rate(prometheus_remote_storage_samples_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n    /\n    (\n        sum(rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n)\n",
-                  "instant": false,
-                  "legendFormat": "% of samples successfully sent",
-                  "range": true
-               }
-            ],
-            "title": "Remote write success rate in $cluster",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Latency of writes to the remote system made by\nprometheus.remote_write.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "s"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 12,
-               "x": 12,
-               "y": 12
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "histogram_quantile(0.99, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
-                  "instant": false,
-                  "legendFormat": "99th percentile",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "histogram_quantile(0.50, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
-                  "instant": false,
-                  "legendFormat": "50th percentile",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(rate(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval])) /\nsum(rate(prometheus_remote_storage_sent_batch_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval]))\n",
-                  "instant": false,
-                  "legendFormat": "Average",
-                  "range": true
-               }
-            ],
-            "title": "Write latency in $cluster",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "How far behind prometheus.remote_write from samples recently written\nto the WAL.\n\nEach endpoint prometheus.remote_write is configured to send metrics\nhas its own delay. The time shown here is the sum across all\nendpoints for the given component.\n\nIt is normal for the WAL delay to be within 1-3 scrape intervals. If\nthe WAL delay continues to increase beyond that amount, try\nincreasing the number of maximum shards.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "s"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 0,
-               "y": 22
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum by (instance, component_path, component_id) (\n  prometheus_remote_storage_highest_timestamp_in_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}\n  - ignoring(url, remote_name) group_right(instance)\n  prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
-                  "range": true
-               }
-            ],
-            "title": "WAL delay",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Rate of data containing samples and metadata sent by\nprometheus.remote_write.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "fillOpacity": 20,
-                     "gradientMode": "hue",
-                     "stacking": {
-                        "mode": "normal"
-                     }
-                  },
-                  "unit": "Bps"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 8,
-               "y": 22
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum without (remote_name, url) (\n    rate(prometheus_remote_storage_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]) +\n    rate(prometheus_remote_storage_metadata_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
-                  "range": true
-               }
-            ],
-            "title": "Data write throughput",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Total number of shards which are concurrently sending samples read\nfrom the Write-Ahead Log.\n\nShards are bound to a minimum and maximum, displayed on the graph.\nThe lowest minimum and the highest maximum across all clients is\nshown.\n\nEach client has its own set of shards, minimum shards, and maximum\nshards; filter to a specific URL to display more granular\ninformation.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "none"
-               },
-               "overrides": [
-                  {
-                     "matcher": {
-                        "id": "byName",
-                        "options": "Minimum"
-                     },
-                     "properties": [
-                        {
-                           "id": "custom.lineStyle",
-                           "value": {
-                              "dash": [
-                                 10,
-                                 15
-                              ],
-                              "fill": "dash"
-                           }
-                        },
-                        {
-                           "id": "custom.showPoints",
-                           "value": "never"
-                        },
-                        {
-                           "id": "custom.hideFrom",
-                           "value": {
-                              "legend": true,
-                              "tooltip": false,
-                              "viz": false
-                           }
-                        }
-                     ]
-                  },
-                  {
-                     "matcher": {
-                        "id": "byName",
-                        "options": "Maximum"
-                     },
-                     "properties": [
-                        {
-                           "id": "custom.lineStyle",
-                           "value": {
-                              "dash": [
-                                 10,
-                                 15
-                              ],
-                              "fill": "dash"
-                           }
-                        },
-                        {
-                           "id": "custom.showPoints",
-                           "value": "never"
-                        },
-                        {
-                           "id": "custom.hideFrom",
-                           "value": {
-                              "legend": true,
-                              "tooltip": false,
-                              "viz": false
-                           }
-                        }
-                     ]
-                  }
-               ]
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 16,
-               "y": 22
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum without (remote_name, url) (\n    prometheus_remote_storage_shards{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "min (\n    prometheus_remote_storage_shards_min{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
-                  "instant": false,
-                  "legendFormat": "Minimum",
-                  "range": true
-               },
-               {
-                  "datasource": "${datasource}",
-                  "expr": "max (\n    prometheus_remote_storage_shards_max{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
-                  "instant": false,
-                  "legendFormat": "Maximum",
-                  "range": true
-               }
-            ],
-            "title": "Shards",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Total outgoing samples sent by prometheus.remote_write.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "fillOpacity": 20,
-                     "gradientMode": "hue",
-                     "stacking": {
-                        "mode": "normal"
-                     }
-                  },
-                  "unit": "cps"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 0,
-               "y": 32
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum without (url, remote_name) (\n  rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
-                  "range": true
-               }
-            ],
-            "title": "Sent samples / second",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Rate of samples which prometheus.remote_write could not send due to\nnon-recoverable errors.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "fillOpacity": 20,
-                     "gradientMode": "hue",
-                     "stacking": {
-                        "mode": "normal"
-                     }
-                  },
-                  "unit": "cps"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 8,
-               "y": 32
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum without (url,remote_name) (\n  rate(prometheus_remote_storage_samples_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
-                  "range": true
-               }
-            ],
-            "title": "Failed samples / second",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Rate of samples which prometheus.remote_write attempted to resend\nafter receiving a recoverable error.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "fillOpacity": 20,
-                     "gradientMode": "hue",
-                     "stacking": {
-                        "mode": "normal"
-                     }
-                  },
-                  "unit": "cps"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 16,
-               "y": 32
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum without (url,remote_name) (\n  rate(prometheus_remote_storage_samples_retried_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
-                  "range": true
-               }
-            ],
-            "title": "Retried samples / second",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Total number of active series across all components.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "short"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 0,
-               "y": 42
-            },
-            "options": {
-               "legend": {
-                  "showLegend": false
-               }
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum(prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
-                  "instant": false,
-                  "legendFormat": "Series",
-                  "range": true
-               }
-            ],
-            "title": "Active series (total)",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Total number of active series which are currently being tracked by\nprometheus.remote_write components, with separate lines for each Alloy instance.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "short"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 8,
-               "y": 42
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
-                  "range": true
-               }
-            ],
-            "title": "Active series (by instance/component)",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Total number of active series which are currently being tracked by\nprometheus.remote_write components, aggregated across all instances.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "short"
-               }
-            },
-            "gridPos": {
-               "h": 10,
-               "w": 8,
-               "x": 16,
-               "y": 42
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "sum by (component_path, component_id) (prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
-                  "instant": false,
-                  "legendFormat": "{{component_path}} {{component_id}}",
-                  "range": true
-               }
-            ],
-            "title": "Active series (by component)",
-            "type": "timeseries"
-         }
-      ],
-      "refresh": "10s",
-      "schemaVersion": 36,
+  "annotations": {
+    "list": [
+      {
+        "datasource": "$loki_datasource",
+        "enable": true,
+        "expr": "{cluster=~\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "instant": false,
+        "name": "Deployments",
+        "titleFormat": "{{cluster}}/{{namespace}}"
+      }
+    ]
+  },
+  "graphTooltip": 1,
+  "links": [
+    {
+      "icon": "doc",
+      "targetBlank": true,
+      "title": "Documentation",
+      "tooltip": "Component documentation",
+      "type": "link",
+      "url": "https://grafana.com/docs/alloy/latest/reference/components/prometheus.remote_write/"
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
-         "alloy-mixin"
+        "alloy-mixin"
       ],
-      "templating": {
-         "list": [
-            {
-               "label": "Data Source",
-               "name": "datasource",
-               "query": "prometheus",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
-            },
-            {
-               "label": "Loki Data Source",
-               "name": "loki_datasource",
-               "query": "loki",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "cluster",
-               "name": "cluster",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
-                  "refId": "cluster"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "namespace",
-               "name": "namespace",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
-                  "refId": "namespace"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "job",
-               "name": "job",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
-                  "refId": "job"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "allValue": ".*",
-               "datasource": "${datasource}",
-               "includeAll": true,
-               "label": "instance",
-               "multi": true,
-               "name": "instance",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
-                  "refId": "instance"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "allValue": ".*",
-               "datasource": "${datasource}",
-               "includeAll": true,
-               "label": "component_path",
-               "multi": true,
-               "name": "component_path",
-               "query": {
-                  "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\", component_path=~\".*\"}, component_path)\n",
-                  "refId": "component_path"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "allValue": ".*",
-               "datasource": "${datasource}",
-               "includeAll": true,
-               "label": "component",
-               "multi": true,
-               "name": "component",
-               "query": {
-                  "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\"}, component_id)\n",
-                  "refId": "component"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "allValue": ".*",
-               "datasource": "${datasource}",
-               "includeAll": true,
-               "label": "url",
-               "multi": true,
-               "name": "url",
-               "query": {
-                  "query": "label_values(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=\"$job\", instance=~\"$instance\", component_id=~\"$component\"}, url)\n",
-                  "refId": "url"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "title": "prometheus.scrape",
+      "type": "row"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Percentage of targets successfully scraped by prometheus.scrape\ncomponents.\n\nThis metric is calculated by dividing the number of targets\nsuccessfully scraped by the total number of targets scraped,\nacross all the namespaces in the selected cluster.\n\nLow success rates can indicate a problem with scrape targets,\nstale service discovery, or Alloy misconfiguration.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(up{job=~\"$job\", cluster=~\"$cluster\"})\n/\ncount (up{job=~\"$job\", cluster=~\"$cluster\"})\n",
+          "instant": false,
+          "legendFormat": "% of targets successfully scraped",
+          "range": true
+        }
+      ],
+      "title": "Scrape success rate in $cluster",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Duration of successful scrapes by prometheus.scrape components,\nacross all the namespaces in the selected cluster.\n\nThis metric should be below your configured scrape interval.\nHigh durations can indicate a problem with a scrape target or\na performance issue with Alloy.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "quantile(0.99, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+          "instant": false,
+          "legendFormat": "p99",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "quantile(0.95, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+          "instant": false,
+          "legendFormat": "p95",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "quantile(0.50, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+          "instant": false,
+          "legendFormat": "p50",
+          "range": true
+        }
+      ],
+      "title": "Scrape duration in $cluster",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "title": "prometheus.remote_write",
+      "type": "row"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Percentage of samples sent by prometheus.remote_write that succeeded.\n\nLow success rates can indicate a problem with Alloy or the remote storage.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "(\n    1 - \n    (\n        sum(rate(prometheus_remote_storage_samples_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n    /\n    (\n        sum(rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n)\n",
+          "instant": false,
+          "legendFormat": "% of samples successfully sent",
+          "range": true
+        }
+      ],
+      "title": "Remote write success rate in $cluster",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Latency of writes to the remote system made by\nprometheus.remote_write.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "histogram_quantile(0.99, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
+          "instant": false,
+          "legendFormat": "99th percentile",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "histogram_quantile(0.50, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
+          "instant": false,
+          "legendFormat": "50th percentile",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(rate(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval])) /\nsum(rate(prometheus_remote_storage_sent_batch_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval]))\n",
+          "instant": false,
+          "legendFormat": "Average",
+          "range": true
+        }
+      ],
+      "title": "Write latency in $cluster",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "How far behind prometheus.remote_write from samples recently written\nto the WAL.\n\nEach endpoint prometheus.remote_write is configured to send metrics\nhas its own delay. The time shown here is the sum across all\nendpoints for the given component.\n\nIt is normal for the WAL delay to be within 1-3 scrape intervals. If\nthe WAL delay continues to increase beyond that amount, try\nincreasing the number of maximum shards.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 22
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum by (instance, component_path, component_id) (\n  prometheus_remote_storage_highest_timestamp_in_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}\n  - ignoring(url, remote_name) group_right(instance)\n  prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+          "instant": false,
+          "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+          "range": true
+        }
+      ],
+      "title": "WAL delay",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Rate of data containing samples and metadata sent by\nprometheus.remote_write.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 20,
+            "gradientMode": "hue",
+            "stacking": {
+              "mode": "normal"
             }
-         ]
+          },
+          "unit": "Bps"
+        }
       },
-      "time": {
-         "from": "now-1h",
-         "to": "now"
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 22
       },
-      "timepicker": {
-         "refresh_intervals": [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
-         ],
-         "time_options": [
-            "5m",
-            "15m",
-            "1h",
-            "6h",
-            "12h",
-            "24h",
-            "2d",
-            "7d",
-            "30d",
-            "90d"
-         ]
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum without (remote_name, url) (\n    rate(prometheus_remote_storage_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]) +\n    rate(prometheus_remote_storage_metadata_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+          "instant": false,
+          "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+          "range": true
+        }
+      ],
+      "title": "Data write throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Total number of shards which are concurrently sending samples read\nfrom the Write-Ahead Log.\n\nShards are bound to a minimum and maximum, displayed on the graph.\nThe lowest minimum and the highest maximum across all clients is\nshown.\n\nEach client has its own set of shards, minimum shards, and maximum\nshards; filter to a specific URL to display more granular\ninformation.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Minimum"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    15
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Maximum"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    15
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.showPoints",
+                "value": "never"
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
       },
-      "timezone": "utc",
-      "title": "Alloy / Prometheus Components",
-      "uid": "e324cc55567d7f3a8e32860ff8e6d0d9"
-   }
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 22
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum without (remote_name, url) (\n    prometheus_remote_storage_shards{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+          "instant": false,
+          "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "min (\n    prometheus_remote_storage_shards_min{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+          "instant": false,
+          "legendFormat": "Minimum",
+          "range": true
+        },
+        {
+          "datasource": "${datasource}",
+          "expr": "max (\n    prometheus_remote_storage_shards_max{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+          "instant": false,
+          "legendFormat": "Maximum",
+          "range": true
+        }
+      ],
+      "title": "Shards",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Total outgoing samples sent by prometheus.remote_write.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 20,
+            "gradientMode": "hue",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "cps"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 32
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum without (url, remote_name) (\n  rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+          "instant": false,
+          "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+          "range": true
+        }
+      ],
+      "title": "Sent samples / second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Rate of samples which prometheus.remote_write could not send due to\nnon-recoverable errors.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 20,
+            "gradientMode": "hue",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "cps"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 32
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum without (url,remote_name) (\n  rate(prometheus_remote_storage_samples_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+          "instant": false,
+          "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+          "range": true
+        }
+      ],
+      "title": "Failed samples / second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Rate of samples which prometheus.remote_write attempted to resend\nafter receiving a recoverable error.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 20,
+            "gradientMode": "hue",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "cps"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 32
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum without (url,remote_name) (\n  rate(prometheus_remote_storage_samples_retried_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+          "instant": false,
+          "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+          "range": true
+        }
+      ],
+      "title": "Retried samples / second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Total number of active series across all components.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 42
+      },
+      "options": {
+        "legend": {
+          "showLegend": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum(prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
+          "instant": false,
+          "legendFormat": "Series",
+          "range": true
+        }
+      ],
+      "title": "Active series (total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Total number of active series which are currently being tracked by\nprometheus.remote_write components, with separate lines for each Alloy instance.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 42
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n",
+          "instant": false,
+          "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+          "range": true
+        }
+      ],
+      "title": "Active series (by instance/component)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Total number of active series which are currently being tracked by\nprometheus.remote_write components, aggregated across all instances.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 42
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "sum by (component_path, component_id) (prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
+          "instant": false,
+          "legendFormat": "{{component_path}} {{component_id}}",
+          "range": true
+        }
+      ],
+      "title": "Active series (by component)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "tags": [
+    "alloy-mixin",
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
+  ],
+  "templating": {
+    "list": [
+      {
+        "label": "Data Source",
+        "name": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "label": "Loki Data Source",
+        "name": "loki_datasource",
+        "query": "loki",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "cluster",
+        "name": "cluster",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "refId": "cluster"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "namespace",
+        "name": "namespace",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "refId": "namespace"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "job",
+        "name": "job",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "refId": "job"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": "${datasource}",
+        "includeAll": true,
+        "label": "instance",
+        "multi": true,
+        "name": "instance",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+          "refId": "instance"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": "${datasource}",
+        "includeAll": true,
+        "label": "component_path",
+        "multi": true,
+        "name": "component_path",
+        "query": {
+          "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\", component_path=~\".*\"}, component_path)\n",
+          "refId": "component_path"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": "${datasource}",
+        "includeAll": true,
+        "label": "component",
+        "multi": true,
+        "name": "component",
+        "query": {
+          "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\"}, component_id)\n",
+          "refId": "component"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": "${datasource}",
+        "includeAll": true,
+        "label": "url",
+        "multi": true,
+        "name": "url",
+        "query": {
+          "query": "label_values(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=\"$job\", instance=~\"$instance\", component_id=~\"$component\"}, url)\n",
+          "refId": "url"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d",
+      "90d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Alloy / Prometheus Components",
+  "uid": "e324cc55567d7f3a8e32860ff8e6d0d9"
+}

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-prometheus-remote-write.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-prometheus-remote-write.json
@@ -1,0 +1,693 @@
+{
+      "annotations": {
+         "list": [
+            {
+               "datasource": "$loki_datasource",
+               "enable": true,
+               "expr": "{cluster=~\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+               "iconColor": "rgba(0, 211, 255, 1)",
+               "instant": false,
+               "name": "Deployments",
+               "titleFormat": "{{cluster}}/{{namespace}}"
+            }
+         ]
+      },
+      "graphTooltip": 1,
+      "links": [
+         {
+            "icon": "doc",
+            "targetBlank": true,
+            "title": "Documentation",
+            "tooltip": "Component documentation",
+            "type": "link",
+            "url": "https://grafana.com/docs/alloy/latest/reference/components/prometheus.remote_write/"
+         },
+         {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [
+               "alloy-mixin"
+            ],
+            "targetBlank": false,
+            "title": "Dashboards",
+            "type": "dashboards"
+         }
+      ],
+      "panels": [
+         {
+            "collapsed": false,
+            "datasource": "${datasource}",
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 0
+            },
+            "title": "prometheus.scrape",
+            "type": "row"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Percentage of targets successfully scraped by prometheus.scrape\ncomponents.\n\nThis metric is calculated by dividing the number of targets\nsuccessfully scraped by the total number of targets scraped,\nacross all the namespaces in the selected cluster.\n\nLow success rates can indicate a problem with scrape targets,\nstale service discovery, or Alloy misconfiguration.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "percentunit"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 12,
+               "x": 0,
+               "y": 1
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(up{job=~\"$job\", cluster=~\"$cluster\"})\n/\ncount (up{job=~\"$job\", cluster=~\"$cluster\"})\n",
+                  "instant": false,
+                  "legendFormat": "% of targets successfully scraped",
+                  "range": true
+               }
+            ],
+            "title": "Scrape success rate in $cluster",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Duration of successful scrapes by prometheus.scrape components,\nacross all the namespaces in the selected cluster.\n\nThis metric should be below your configured scrape interval.\nHigh durations can indicate a problem with a scrape target or\na performance issue with Alloy.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "s"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 12,
+               "x": 12,
+               "y": 1
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "quantile(0.99, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+                  "instant": false,
+                  "legendFormat": "p99",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "quantile(0.95, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+                  "instant": false,
+                  "legendFormat": "p95",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "quantile(0.50, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+                  "instant": false,
+                  "legendFormat": "p50",
+                  "range": true
+               }
+            ],
+            "title": "Scrape duration in $cluster",
+            "type": "timeseries"
+         },
+         {
+            "collapsed": false,
+            "datasource": "${datasource}",
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0,
+               "y": 11
+            },
+            "title": "prometheus.remote_write",
+            "type": "row"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Percentage of samples sent by prometheus.remote_write that succeeded.\n\nLow success rates can indicate a problem with Alloy or the remote storage.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "percentunit"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 12,
+               "x": 0,
+               "y": 12
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "(\n    1 - \n    (\n        sum(rate(prometheus_remote_storage_samples_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n    /\n    (\n        sum(rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n)\n",
+                  "instant": false,
+                  "legendFormat": "% of samples successfully sent",
+                  "range": true
+               }
+            ],
+            "title": "Remote write success rate in $cluster",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Latency of writes to the remote system made by\nprometheus.remote_write.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "s"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 12,
+               "x": 12,
+               "y": 12
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "histogram_quantile(0.99, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
+                  "instant": false,
+                  "legendFormat": "99th percentile",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "histogram_quantile(0.50, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
+                  "instant": false,
+                  "legendFormat": "50th percentile",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(rate(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval])) /\nsum(rate(prometheus_remote_storage_sent_batch_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval]))\n",
+                  "instant": false,
+                  "legendFormat": "Average",
+                  "range": true
+               }
+            ],
+            "title": "Write latency in $cluster",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "How far behind prometheus.remote_write from samples recently written\nto the WAL.\n\nEach endpoint prometheus.remote_write is configured to send metrics\nhas its own delay. The time shown here is the sum across all\nendpoints for the given component.\n\nIt is normal for the WAL delay to be within 1-3 scrape intervals. If\nthe WAL delay continues to increase beyond that amount, try\nincreasing the number of maximum shards.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "s"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 0,
+               "y": 22
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum by (instance, component_path, component_id) (\n  prometheus_remote_storage_highest_timestamp_in_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}\n  - ignoring(url, remote_name) group_right(instance)\n  prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+                  "range": true
+               }
+            ],
+            "title": "WAL delay",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Rate of data containing samples and metadata sent by\nprometheus.remote_write.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 20,
+                     "gradientMode": "hue",
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  },
+                  "unit": "Bps"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 8,
+               "y": 22
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum without (remote_name, url) (\n    rate(prometheus_remote_storage_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]) +\n    rate(prometheus_remote_storage_metadata_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+                  "range": true
+               }
+            ],
+            "title": "Data write throughput",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Total number of shards which are concurrently sending samples read\nfrom the Write-Ahead Log.\n\nShards are bound to a minimum and maximum, displayed on the graph.\nThe lowest minimum and the highest maximum across all clients is\nshown.\n\nEach client has its own set of shards, minimum shards, and maximum\nshards; filter to a specific URL to display more granular\ninformation.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "none"
+               },
+               "overrides": [
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "Minimum"
+                     },
+                     "properties": [
+                        {
+                           "id": "custom.lineStyle",
+                           "value": {
+                              "dash": [
+                                 10,
+                                 15
+                              ],
+                              "fill": "dash"
+                           }
+                        },
+                        {
+                           "id": "custom.showPoints",
+                           "value": "never"
+                        },
+                        {
+                           "id": "custom.hideFrom",
+                           "value": {
+                              "legend": true,
+                              "tooltip": false,
+                              "viz": false
+                           }
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "Maximum"
+                     },
+                     "properties": [
+                        {
+                           "id": "custom.lineStyle",
+                           "value": {
+                              "dash": [
+                                 10,
+                                 15
+                              ],
+                              "fill": "dash"
+                           }
+                        },
+                        {
+                           "id": "custom.showPoints",
+                           "value": "never"
+                        },
+                        {
+                           "id": "custom.hideFrom",
+                           "value": {
+                              "legend": true,
+                              "tooltip": false,
+                              "viz": false
+                           }
+                        }
+                     ]
+                  }
+               ]
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 16,
+               "y": 22
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum without (remote_name, url) (\n    prometheus_remote_storage_shards{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "min (\n    prometheus_remote_storage_shards_min{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+                  "instant": false,
+                  "legendFormat": "Minimum",
+                  "range": true
+               },
+               {
+                  "datasource": "${datasource}",
+                  "expr": "max (\n    prometheus_remote_storage_shards_max{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+                  "instant": false,
+                  "legendFormat": "Maximum",
+                  "range": true
+               }
+            ],
+            "title": "Shards",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Total outgoing samples sent by prometheus.remote_write.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 20,
+                     "gradientMode": "hue",
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  },
+                  "unit": "cps"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 0,
+               "y": 32
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum without (url, remote_name) (\n  rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+                  "range": true
+               }
+            ],
+            "title": "Sent samples / second",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Rate of samples which prometheus.remote_write could not send due to\nnon-recoverable errors.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 20,
+                     "gradientMode": "hue",
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  },
+                  "unit": "cps"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 8,
+               "y": 32
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum without (url,remote_name) (\n  rate(prometheus_remote_storage_samples_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+                  "range": true
+               }
+            ],
+            "title": "Failed samples / second",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Rate of samples which prometheus.remote_write attempted to resend\nafter receiving a recoverable error.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 20,
+                     "gradientMode": "hue",
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  },
+                  "unit": "cps"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 16,
+               "y": 32
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum without (url,remote_name) (\n  rate(prometheus_remote_storage_samples_retried_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+                  "range": true
+               }
+            ],
+            "title": "Retried samples / second",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Total number of active series across all components.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "short"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 0,
+               "y": 42
+            },
+            "options": {
+               "legend": {
+                  "showLegend": false
+               }
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum(prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
+                  "instant": false,
+                  "legendFormat": "Series",
+                  "range": true
+               }
+            ],
+            "title": "Active series (total)",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Total number of active series which are currently being tracked by\nprometheus.remote_write components, with separate lines for each Alloy instance.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "short"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 8,
+               "y": 42
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
+                  "range": true
+               }
+            ],
+            "title": "Active series (by instance/component)",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Total number of active series which are currently being tracked by\nprometheus.remote_write components, aggregated across all instances.\n\nAn \"active series\" is a series that prometheus.remote_write recently\nreceived a sample for. Active series are garbage collected whenever a\ntruncation of the WAL occurs.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "short"
+               }
+            },
+            "gridPos": {
+               "h": 10,
+               "w": 8,
+               "x": 16,
+               "y": 42
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "sum by (component_path, component_id) (prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
+                  "instant": false,
+                  "legendFormat": "{{component_path}} {{component_id}}",
+                  "range": true
+               }
+            ],
+            "title": "Active series (by component)",
+            "type": "timeseries"
+         }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 36,
+      "tags": [
+         "alloy-mixin"
+      ],
+      "templating": {
+         "list": [
+            {
+               "label": "Data Source",
+               "name": "datasource",
+               "query": "prometheus",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "label": "Loki Data Source",
+               "name": "loki_datasource",
+               "query": "loki",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "cluster",
+               "name": "cluster",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+                  "refId": "cluster"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "namespace",
+               "name": "namespace",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+                  "refId": "namespace"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "job",
+               "name": "job",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+                  "refId": "job"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": "${datasource}",
+               "includeAll": true,
+               "label": "instance",
+               "multi": true,
+               "name": "instance",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+                  "refId": "instance"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": "${datasource}",
+               "includeAll": true,
+               "label": "component_path",
+               "multi": true,
+               "name": "component_path",
+               "query": {
+                  "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\", component_path=~\".*\"}, component_path)\n",
+                  "refId": "component_path"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": "${datasource}",
+               "includeAll": true,
+               "label": "component",
+               "multi": true,
+               "name": "component",
+               "query": {
+                  "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\"}, component_id)\n",
+                  "refId": "component"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": "${datasource}",
+               "includeAll": true,
+               "label": "url",
+               "multi": true,
+               "name": "url",
+               "query": {
+                  "query": "label_values(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=\"$job\", instance=~\"$instance\", component_id=~\"$component\"}, url)\n",
+                  "refId": "url"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            }
+         ]
+      },
+      "time": {
+         "from": "now-1h",
+         "to": "now"
+      },
+      "timepicker": {
+         "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+         ],
+         "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d",
+            "90d"
+         ]
+      },
+      "timezone": "utc",
+      "title": "Alloy / Prometheus Components",
+      "uid": "e324cc55567d7f3a8e32860ff8e6d0d9"
+   }

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-resources.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-resources.json
@@ -1,341 +1,344 @@
 {
-      "annotations": {
-         "list": [
-            {
-               "datasource": "$loki_datasource",
-               "enable": true,
-               "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
-               "iconColor": "rgba(0, 211, 255, 1)",
-               "instant": false,
-               "name": "Deployments",
-               "titleFormat": "{{cluster}}/{{namespace}}"
-            }
-         ]
-      },
-      "graphTooltip": 1,
-      "links": [
-         {
-            "asDropdown": true,
-            "icon": "external link",
-            "includeVars": true,
-            "keepTime": true,
-            "tags": [
-               "alloy-mixin"
-            ],
-            "targetBlank": false,
-            "title": "Dashboards",
-            "type": "dashboards"
-         }
-      ],
-      "panels": [
-         {
-            "datasource": "${datasource}",
-            "description": "CPU usage of the Alloy process relative to 1 CPU core.\n\nFor example, 100% means using one entire CPU core.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "percentunit"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 12,
-               "x": 0,
-               "y": 0
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(alloy_resources_process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}}",
-                  "range": true
-               }
-            ],
-            "title": "CPU usage",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Resident memory size of the Alloy process.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "decbytes"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 12,
-               "x": 12,
-               "y": 0
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "alloy_resources_process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}}",
-                  "range": true
-               }
-            ],
-            "title": "Memory (RSS)",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Rate at which the Alloy process performs garbage collections.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "drawStyle": "points",
-                     "pointSize": 3
-                  },
-                  "unit": "ops"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 8,
-               "x": 0,
-               "y": 8
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(go_gc_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[5m])\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}}",
-                  "range": true
-               }
-            ],
-            "title": "Garbage collections",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Number of goroutines which are running in parallel. An infinitely\ngrowing number of these indicates a goroutine leak.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "none"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 8,
-               "x": 8,
-               "y": 8
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}}",
-                  "range": true
-               }
-            ],
-            "title": "Goroutines",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Heap memory currently in use by the Alloy process.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "unit": "decbytes"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 8,
-               "x": 16,
-               "y": 8
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}}",
-                  "range": true
-               }
-            ],
-            "title": "Memory (heap inuse)",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Rate of data received across all network interfaces for the machine\nAlloy is running on.\n\nData shown here is across all running processes and not exclusive to\nthe running Alloy process.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "fillOpacity": 30,
-                     "gradientMode": "none",
-                     "stacking": {
-                        "mode": "normal"
-                     }
-                  },
-                  "unit": "Bps"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 12,
-               "x": 0,
-               "y": 16
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(alloy_resources_machine_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}}",
-                  "range": true
-               }
-            ],
-            "title": "Network receive bandwidth",
-            "type": "timeseries"
-         },
-         {
-            "datasource": "${datasource}",
-            "description": "Rate of data sent across all network interfaces for the machine\nAlloy is running on.\n\nData shown here is across all running processes and not exclusive to\nthe running Alloy process.\n",
-            "fieldConfig": {
-               "defaults": {
-                  "custom": {
-                     "fillOpacity": 30,
-                     "gradientMode": "none",
-                     "stacking": {
-                        "mode": "normal"
-                     }
-                  },
-                  "unit": "Bps"
-               }
-            },
-            "gridPos": {
-               "h": 8,
-               "w": 12,
-               "x": 12,
-               "y": 16
-            },
-            "targets": [
-               {
-                  "datasource": "${datasource}",
-                  "expr": "rate(alloy_resources_machine_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
-                  "instant": false,
-                  "legendFormat": "{{instance}}",
-                  "range": true
-               }
-            ],
-            "title": "Network send bandwidth",
-            "type": "timeseries"
-         }
-      ],
-      "refresh": "10s",
-      "schemaVersion": 36,
+  "annotations": {
+    "list": [
+      {
+        "datasource": "$loki_datasource",
+        "enable": true,
+        "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "instant": false,
+        "name": "Deployments",
+        "titleFormat": "{{cluster}}/{{namespace}}"
+      }
+    ]
+  },
+  "graphTooltip": 1,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
-         "alloy-mixin"
+        "alloy-mixin"
       ],
-      "templating": {
-         "list": [
-            {
-               "label": "Data Source",
-               "name": "datasource",
-               "query": "prometheus",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
-            },
-            {
-               "label": "Loki Data Source",
-               "name": "loki_datasource",
-               "query": "loki",
-               "refresh": 1,
-               "sort": 2,
-               "type": "datasource"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "cluster",
-               "name": "cluster",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
-                  "refId": "cluster"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "namespace",
-               "name": "namespace",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
-                  "refId": "namespace"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "datasource": "${datasource}",
-               "label": "job",
-               "name": "job",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
-                  "refId": "job"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
-            },
-            {
-               "allValue": ".*",
-               "datasource": "${datasource}",
-               "includeAll": true,
-               "label": "instance",
-               "multi": true,
-               "name": "instance",
-               "query": {
-                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
-                  "refId": "instance"
-               },
-               "refresh": 2,
-               "sort": 2,
-               "type": "query"
+      "targetBlank": false,
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "description": "CPU usage of the Alloy process relative to 1 CPU core.\n\nFor example, 100% means using one entire CPU core.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(alloy_resources_process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true
+        }
+      ],
+      "title": "CPU usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Resident memory size of the Alloy process.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "alloy_resources_process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true
+        }
+      ],
+      "title": "Memory (RSS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Rate at which the Alloy process performs garbage collections.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "points",
+            "pointSize": 3
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(go_gc_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[5m])\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true
+        }
+      ],
+      "title": "Garbage collections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Number of goroutines which are running in parallel. An infinitely\ngrowing number of these indicates a goroutine leak.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Heap memory currently in use by the Alloy process.\n",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true
+        }
+      ],
+      "title": "Memory (heap inuse)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Rate of data received across all network interfaces for the machine\nAlloy is running on.\n\nData shown here is across all running processes and not exclusive to\nthe running Alloy process.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "stacking": {
+              "mode": "normal"
             }
-         ]
+          },
+          "unit": "Bps"
+        }
       },
-      "time": {
-         "from": "now-1h",
-         "to": "now"
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
       },
-      "timepicker": {
-         "refresh_intervals": [
-            "5s",
-            "10s",
-            "30s",
-            "1m",
-            "5m",
-            "15m",
-            "30m",
-            "1h",
-            "2h",
-            "1d"
-         ],
-         "time_options": [
-            "5m",
-            "15m",
-            "1h",
-            "6h",
-            "12h",
-            "24h",
-            "2d",
-            "7d",
-            "30d",
-            "90d"
-         ]
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(alloy_resources_machine_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true
+        }
+      ],
+      "title": "Network receive bandwidth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Rate of data sent across all network interfaces for the machine\nAlloy is running on.\n\nData shown here is across all running processes and not exclusive to\nthe running Alloy process.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "Bps"
+        }
       },
-      "timezone": "utc",
-      "title": "Alloy / Resources",
-      "uid": "d6a8574c31f3d7cb8f1345ec84d15a67"
-   }
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "rate(alloy_resources_machine_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true
+        }
+      ],
+      "title": "Network send bandwidth",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "tags": [
+    "alloy-mixin",
+    "owner:team-atlas",
+    "topic:observability",
+    "component:mimir"
+  ],
+  "templating": {
+    "list": [
+      {
+        "label": "Data Source",
+        "name": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "label": "Loki Data Source",
+        "name": "loki_datasource",
+        "query": "loki",
+        "refresh": 1,
+        "sort": 2,
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "cluster",
+        "name": "cluster",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "refId": "cluster"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "namespace",
+        "name": "namespace",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "refId": "namespace"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "label": "job",
+        "name": "job",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "refId": "job"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "datasource": "${datasource}",
+        "includeAll": true,
+        "label": "instance",
+        "multi": true,
+        "name": "instance",
+        "query": {
+          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+          "refId": "instance"
+        },
+        "refresh": 2,
+        "sort": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d",
+      "90d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Alloy / Resources",
+  "uid": "d6a8574c31f3d7cb8f1345ec84d15a67"
+}

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-resources.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-resources.json
@@ -1,0 +1,341 @@
+{
+      "annotations": {
+         "list": [
+            {
+               "datasource": "$loki_datasource",
+               "enable": true,
+               "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+               "iconColor": "rgba(0, 211, 255, 1)",
+               "instant": false,
+               "name": "Deployments",
+               "titleFormat": "{{cluster}}/{{namespace}}"
+            }
+         ]
+      },
+      "graphTooltip": 1,
+      "links": [
+         {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": true,
+            "keepTime": true,
+            "tags": [
+               "alloy-mixin"
+            ],
+            "targetBlank": false,
+            "title": "Dashboards",
+            "type": "dashboards"
+         }
+      ],
+      "panels": [
+         {
+            "datasource": "${datasource}",
+            "description": "CPU usage of the Alloy process relative to 1 CPU core.\n\nFor example, 100% means using one entire CPU core.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "percentunit"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 0,
+               "y": 0
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(alloy_resources_process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}}",
+                  "range": true
+               }
+            ],
+            "title": "CPU usage",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Resident memory size of the Alloy process.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "decbytes"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 12,
+               "y": 0
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "alloy_resources_process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}}",
+                  "range": true
+               }
+            ],
+            "title": "Memory (RSS)",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Rate at which the Alloy process performs garbage collections.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "drawStyle": "points",
+                     "pointSize": 3
+                  },
+                  "unit": "ops"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 8,
+               "x": 0,
+               "y": 8
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(go_gc_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[5m])\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}}",
+                  "range": true
+               }
+            ],
+            "title": "Garbage collections",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Number of goroutines which are running in parallel. An infinitely\ngrowing number of these indicates a goroutine leak.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "none"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 8,
+               "x": 8,
+               "y": 8
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}}",
+                  "range": true
+               }
+            ],
+            "title": "Goroutines",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Heap memory currently in use by the Alloy process.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "unit": "decbytes"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 8,
+               "x": 16,
+               "y": 8
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}}",
+                  "range": true
+               }
+            ],
+            "title": "Memory (heap inuse)",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Rate of data received across all network interfaces for the machine\nAlloy is running on.\n\nData shown here is across all running processes and not exclusive to\nthe running Alloy process.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 30,
+                     "gradientMode": "none",
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  },
+                  "unit": "Bps"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 0,
+               "y": 16
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(alloy_resources_machine_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}}",
+                  "range": true
+               }
+            ],
+            "title": "Network receive bandwidth",
+            "type": "timeseries"
+         },
+         {
+            "datasource": "${datasource}",
+            "description": "Rate of data sent across all network interfaces for the machine\nAlloy is running on.\n\nData shown here is across all running processes and not exclusive to\nthe running Alloy process.\n",
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 30,
+                     "gradientMode": "none",
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  },
+                  "unit": "Bps"
+               }
+            },
+            "gridPos": {
+               "h": 8,
+               "w": 12,
+               "x": 12,
+               "y": 16
+            },
+            "targets": [
+               {
+                  "datasource": "${datasource}",
+                  "expr": "rate(alloy_resources_machine_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+                  "instant": false,
+                  "legendFormat": "{{instance}}",
+                  "range": true
+               }
+            ],
+            "title": "Network send bandwidth",
+            "type": "timeseries"
+         }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 36,
+      "tags": [
+         "alloy-mixin"
+      ],
+      "templating": {
+         "list": [
+            {
+               "label": "Data Source",
+               "name": "datasource",
+               "query": "prometheus",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "label": "Loki Data Source",
+               "name": "loki_datasource",
+               "query": "loki",
+               "refresh": 1,
+               "sort": 2,
+               "type": "datasource"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "cluster",
+               "name": "cluster",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+                  "refId": "cluster"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "namespace",
+               "name": "namespace",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+                  "refId": "namespace"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "datasource": "${datasource}",
+               "label": "job",
+               "name": "job",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+                  "refId": "job"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": "${datasource}",
+               "includeAll": true,
+               "label": "instance",
+               "multi": true,
+               "name": "instance",
+               "query": {
+                  "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+                  "refId": "instance"
+               },
+               "refresh": 2,
+               "sort": 2,
+               "type": "query"
+            }
+         ]
+      },
+      "time": {
+         "from": "now-1h",
+         "to": "now"
+      },
+      "timepicker": {
+         "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+         ],
+         "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d",
+            "90d"
+         ]
+      },
+      "timezone": "utc",
+      "title": "Alloy / Resources",
+      "uid": "d6a8574c31f3d7cb8f1345ec84d15a67"
+   }


### PR DESCRIPTION
This PR adds the Alloy mixin dashboards

<details>
<summary>Dashboards screenshots</summary>

![image](https://github.com/user-attachments/assets/f52db9c0-48de-4f39-bcf9-fc2d13f178a8)
![image](https://github.com/user-attachments/assets/cb610ef6-9b46-4375-8607-a4fbd6f8716f)
![image](https://github.com/user-attachments/assets/e7df679c-af29-4221-934d-c16623f1cf5c)

**broken needs to be fixed**
![image](https://github.com/user-attachments/assets/f9ec6669-661c-4e5d-9b08-51f7ba764f57)

**empty since not otel receiver are configured**
![image](https://github.com/user-attachments/assets/8714c41d-4001-4643-a24d-fe14a8907081)

![image](https://github.com/user-attachments/assets/a3644320-f427-41b7-aec0-ed73f2c8e117)
![image](https://github.com/user-attachments/assets/d2e3be62-616e-49fc-bdeb-0fc69acdb876)

</details>

NOTE: the dashboards are missing the `owner` tag as there is currently no way to configure this via jsonnet.