### PR TITLE
Fix alloy mixin dashboard tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Alloy mixins tags.
+
 ## [3.23.0] - 2024-08-22
 
 ### Added

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-node.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-node.json
@@ -399,7 +399,7 @@
     "alloy-mixin",
     "owner:team-atlas",
     "topic:observability",
-    "component:mimir"
+    "component:alloy"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-overview.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-overview.json
@@ -285,7 +285,7 @@
     "alloy-mixin",
     "owner:team-atlas",
     "topic:observability",
-    "component:mimir"
+    "component:alloy"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-controller.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-controller.json
@@ -463,7 +463,7 @@
     "alloy-mixin",
     "owner:team-atlas",
     "topic:observability",
-    "component:mimir"
+    "component:alloy"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-logs.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-logs.json
@@ -211,7 +211,7 @@
     "alloy-mixin",
     "owner:team-atlas",
     "topic:observability",
-    "component:mimir"
+    "component:alloy"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-opentelemetry.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-opentelemetry.json
@@ -326,7 +326,7 @@
     "alloy-mixin",
     "owner:team-atlas",
     "topic:observability",
-    "component:mimir"
+    "component:alloy"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-prometheus-remote-write.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-prometheus-remote-write.json
@@ -542,7 +542,7 @@
     "alloy-mixin",
     "owner:team-atlas",
     "topic:observability",
-    "component:mimir"
+    "component:alloy"
   ],
   "templating": {
     "list": [

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-resources.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-resources.json
@@ -235,7 +235,7 @@
     "alloy-mixin",
     "owner:team-atlas",
     "topic:observability",
-    "component:mimir"
+    "component:alloy"
   ],
   "templating": {
     "list": [


### PR DESCRIPTION
This PR

- fixes the alloy mixins tags because they are now visible with the mimir tags
![image](https://github.com/user-attachments/assets/53aa54af-5242-4324-83ac-01ec84cd7ef6)

The tags were changed by running `make update-alloy-mixin`

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
