### PR TITLE
alertmanager dashboard: show logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated all dashboars using `decbytes` unit to use `bytes` (IEC units) instead.
+- alertmanager dashboard: show related logs
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated all dashboars using `decbytes` unit to use `bytes` (IEC units) instead.
-- alertmanager dashboard: show related logs
+- Updated alertmanager dashboard to show related logs
 
 ### Fixed
 

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/alertmanager-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/alertmanager-overview.json
@@ -18,6 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": 79,
   "links": [],
   "panels": [
     {
@@ -505,6 +506,57 @@
       ],
       "title": "$integration: Notification Duration",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 28,
+      "panels": [],
+      "title": "Logs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 49,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "editorMode": "code",
+          "expr": "{scrape_job=\"kubernetes-pods\", namespace=\"monitoring\", pod=~\"alertmanager-.*\"} | logfmt | integration=~\"($integration).*\" | line_format `{{.integration}}/{{.receiver}}: {{.msg}} / {{.err}}`",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "logs"
     }
   ],
   "refresh": "30s",
@@ -529,6 +581,7 @@
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/scripts/update-monitoring-mixin-dashboards.sh
+++ b/scripts/update-monitoring-mixin-dashboards.sh
@@ -58,8 +58,8 @@ echo_warning_customupdates() {
   echo "and make sure you didn't lose these custom updates."
   echo ""
   echo "known custom changes:"
-  echo "- alertmanager: select specific integration"
-  echo "- alertmanager: show logs"
+  echo "- alertmanager: integrations filter"
+  echo "- alertmanager: logs panel"
   echo ""
 }
 

--- a/scripts/update-monitoring-mixin-dashboards.sh
+++ b/scripts/update-monitoring-mixin-dashboards.sh
@@ -34,6 +34,7 @@ main() {
       echo "$gst"
       echo_changes > "$TMPDIR"/tmp_changes
       sed -i '/^## \[Unreleased\]/r '"$TMPDIR"'/tmp_changes' CHANGELOG.md
+      echo_warning_customupdates
   fi
 
 }
@@ -49,5 +50,17 @@ echo_changes() {
   echo "\`\`\`"
 }
 
+echo_warning_customupdates() {
+  echo ""
+  echo "### Warning"
+  echo ""
+  echo "These dashboards have custom updates, please review the changes"
+  echo "and make sure you didn't lose these custom updates."
+  echo ""
+  echo "known custom changes:"
+  echo "- alertmanager: select specific integration"
+  echo "- alertmanager: show logs"
+  echo ""
+}
 
 main "$@"


### PR DESCRIPTION
This PR shows alertmanager logs.

Snapshot of the added section:
![image](https://github.com/user-attachments/assets/83568b41-5b9a-40c0-9543-847a2da41c31)

The logs are filtered by `integration`, like the rest of the dashboard.

As the alertmanager dashboard is originally retrieved from mixins (but has since diverged), I also added a note to the update-from-mixins script.

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
