### PR TITLE
Add observability organization label to GS private dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed nodes overview dashboard to avoid master duplicating numbers.
+- Add observability organization label to GS private dashboards.
 
 ## [3.26.1] - 2024-11-12
 

--- a/helm/dashboards/charts/private_dashboards_al/templates/configmap-dashboards.yaml
+++ b/helm/dashboards/charts/private_dashboards_al/templates/configmap-dashboards.yaml
@@ -9,6 +9,7 @@ items:
   metadata:
     annotations:
       k8s-sidecar-target-directory: "/var/lib/grafana/dashboards/private/shared"
+      observability.giantswarm.io/organization: "Giant Swarm"
     labels:
       {{- include "labels.common" $ | nindent 6 }}
     name: {{ printf "grafana-shared-%s-dashboard" $dashboardName | trunc 63 | trimSuffix "-" }}

--- a/helm/dashboards/charts/private_dashboards_mz/templates/configmap-dashboards.yaml
+++ b/helm/dashboards/charts/private_dashboards_mz/templates/configmap-dashboards.yaml
@@ -9,6 +9,7 @@ items:
   metadata:
     annotations:
       k8s-sidecar-target-directory: "/var/lib/grafana/dashboards/private/shared"
+      observability.giantswarm.io/organization: "Giant Swarm"
     labels:
       {{- include "labels.common" $ | nindent 6 }}
     name: {{ printf "grafana-shared-%s-dashboard" $dashboardName | trunc 63 | trimSuffix "-" }}

--- a/helm/dashboards/templates/configmap-dashboards.yaml
+++ b/helm/dashboards/templates/configmap-dashboards.yaml
@@ -21,6 +21,7 @@ items:
   metadata:
     annotations:
       k8s-sidecar-target-directory: "/var/lib/grafana/dashboards/private/mixin"
+      observability.giantswarm.io/organization: "Giant Swarm"
     labels:
       {{- include "labels.common" $ | nindent 6 }}
     name: {{ printf "grafana-mixin-%s-dashboard" $dashboardName | trunc 63 | trimSuffix "-" }}
@@ -51,6 +52,7 @@ items:
   metadata:
     annotations:
       k8s-sidecar-target-directory: "/var/lib/grafana/dashboards/private/{{ $.Values.provider.kind }}"
+      observability.giantswarm.io/organization: "Giant Swarm"
     labels:
       {{- include "labels.common" $ | nindent 6 }}
     name: {{ printf "grafana-%s-%s-dashboard" $.Values.provider.kind $dashboardName | trunc 63 | trimSuffix "-" }}


### PR DESCRIPTION
This PR sets private dashboards annotations so they're pushed to the "Giant Swarm" organization.
Towards https://github.com/giantswarm/roadmap/issues/3696.
Requires https://github.com/giantswarm/observability-operator/pull/173 for it to work, but won't break anything if released before.


### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
