### PR TITLE
fix alloy-logs dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update DNS dashboard to include memory requests.
+
+### Fixed
+
+- fix alloy mixins generation
+- fix alloy mixins
 - fix Alloy / Logs Overview dashboard.
 
 ## [3.28.0] - 2025-01-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update DNS dashboard to include memory requests.
+- fix Alloy / Logs Overview dashboard.
 
 ## [3.28.0] - 2025-01-13
 

--- a/alloy/update.sh
+++ b/alloy/update.sh
@@ -33,5 +33,13 @@ for file in "$TMPDIR/dashboards"/*.json; do
 	)
 done
 
+# Fix alloy-logs specific issues
+sed -i 's/{,/{/g' "$TMPDIR"/dashboards/alloy-logs.json
+sed -i 's/job/scrape_job/g' "$TMPDIR"/dashboards/alloy-logs.json
+
+# Fix cluster selector on all dashboards
+sed -i 's/cluster=/cluster_id=/g' "$TMPDIR"/dashboards/*.json
+sed -i 's/\(.*label_values(.*cluster\)\().*\)/\1_id\2/g' "$TMPDIR"/dashboards/*.json
+
 set -x
 mv "$TMPDIR/dashboards"/*.json "$helm_dir"

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-node.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-node.json
@@ -4,7 +4,7 @@
       {
         "datasource": "$loki_datasource",
         "enable": true,
-        "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+        "expr": "{cluster_id=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
         "iconColor": "rgba(0, 211, 255, 1)",
         "instant": false,
         "name": "Deployments",
@@ -59,7 +59,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum(cluster_node_lamport_time{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}) \n",
+          "expr": "sum(cluster_node_lamport_time{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}) \n",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -68,7 +68,7 @@
         },
         {
           "datasource": "${datasource}",
-          "expr": "sum(cluster_node_update_observers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+          "expr": "sum(cluster_node_update_observers{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -77,7 +77,7 @@
         },
         {
           "datasource": "${datasource}",
-          "expr": "sum(cluster_node_gossip_health_score{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+          "expr": "sum(cluster_node_gossip_health_score{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -86,7 +86,7 @@
         },
         {
           "datasource": "${datasource}",
-          "expr": "sum(cluster_node_gossip_proto_version{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+          "expr": "sum(cluster_node_gossip_proto_version{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -132,7 +132,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(cluster_node_gossip_received_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "rate(cluster_node_gossip_received_events_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "{{event}}",
           "range": true
@@ -158,7 +158,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum(cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
+          "expr": "sum(cluster_node_peers{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"})\n",
           "instant": false,
           "legendFormat": "__auto",
           "range": true
@@ -184,7 +184,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "expr": "cluster_node_peers{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
           "instant": false,
           "legendFormat": "{{state}}",
           "range": true
@@ -223,14 +223,14 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(cluster_transport_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "rate(cluster_transport_rx_bytes_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "rx",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "-1 * rate(cluster_transport_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "-1 * rate(cluster_transport_tx_bytes_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "tx",
           "range": true
@@ -255,14 +255,14 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "1 - (\n  rate(cluster_transport_tx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_tx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+          "expr": "1 - (\n  rate(cluster_transport_tx_packets_failed_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_tx_packets_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
           "instant": false,
           "legendFormat": "Tx success %",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "1 - (\n  rate(cluster_transport_rx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_rx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+          "expr": "1 - (\n  rate(cluster_transport_rx_packets_failed_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_rx_packets_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
           "instant": false,
           "legendFormat": "Rx success %",
           "range": true
@@ -288,14 +288,14 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "cluster_transport_tx_packet_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "expr": "cluster_transport_tx_packet_queue_length{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
           "instant": false,
           "legendFormat": "tx queue",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "cluster_transport_rx_packet_queue_length{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "expr": "cluster_transport_rx_packet_queue_length{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
           "instant": false,
           "legendFormat": "rx queue",
           "range": true
@@ -323,14 +323,14 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(cluster_transport_stream_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "rate(cluster_transport_stream_rx_bytes_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "rx",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "-1 * rate(cluster_transport_stream_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "-1 * rate(cluster_transport_stream_tx_bytes_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "tx",
           "range": true
@@ -355,14 +355,14 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "1 - (\n  rate(cluster_transport_stream_tx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_tx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+          "expr": "1 - (\n  rate(cluster_transport_stream_tx_packets_failed_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_tx_packets_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
           "instant": false,
           "legendFormat": "Tx success %",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "1 - (\n  rate(cluster_transport_stream_rx_packets_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_rx_packets_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
+          "expr": "1 - (\n  rate(cluster_transport_stream_rx_packets_failed_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) /\n  rate(cluster_transport_stream_rx_packets_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n)\n",
           "instant": false,
           "legendFormat": "Rx success %",
           "range": true
@@ -383,7 +383,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "cluster_transport_streams{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "expr": "cluster_transport_streams{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
           "instant": false,
           "legendFormat": "Open streams",
           "range": true
@@ -424,7 +424,7 @@
         "label": "cluster",
         "name": "cluster",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "query": "label_values(alloy_component_controller_running_components, cluster_id)\n",
           "refId": "cluster"
         },
         "refresh": 2,
@@ -436,7 +436,7 @@
         "label": "namespace",
         "name": "namespace",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\"}, namespace)\n",
           "refId": "namespace"
         },
         "refresh": 2,
@@ -448,7 +448,7 @@
         "label": "job",
         "name": "job",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
           "refId": "job"
         },
         "refresh": 2,
@@ -463,7 +463,7 @@
         "multi": true,
         "name": "instance",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
           "refId": "instance"
         },
         "refresh": 2,

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-overview.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-cluster-overview.json
@@ -4,7 +4,7 @@
       {
         "datasource": "$loki_datasource",
         "enable": true,
-        "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+        "expr": "{cluster_id=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
         "iconColor": "rgba(0, 211, 255, 1)",
         "instant": false,
         "name": "Deployments",
@@ -47,7 +47,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+          "expr": "count(cluster_node_info{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
           "instant": true,
           "legendFormat": "__auto",
           "range": false
@@ -87,7 +87,7 @@
                   {
                     "targetBlank": false,
                     "title": "Detail dashboard for node",
-                    "url": "/d/4047e755d822da63c8158cde32ae4dce/alloy-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-job=${job}&var-cluster=${cluster}&var-namespace=${namespace}"
+                    "url": "/d/4047e755d822da63c8158cde32ae4dce/alloy-cluster-node?var-instance=${__data.fields.instance}&var-datasource=${datasource}&var-loki_datasource=${loki_datasource}&var-job=${job}&var-cluster_id=${cluster}&var-namespace=${namespace}"
                   }
                 ]
               }
@@ -104,7 +104,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}\n",
+          "expr": "cluster_node_info{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}\n",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -189,7 +189,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) != 0) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) != 0))\n  ),\n  1, 1\n)\n",
+          "expr": "clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) != 0) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) != 0))\n  ),\n  1, 1\n)\n",
           "format": "time_series",
           "instant": true,
           "legendFormat": "__auto",
@@ -243,7 +243,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "ceil(clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}))))\n  ),\n  0, 1\n))\n",
+          "expr": "ceil(clamp((\n  sum(stddev by (state) (cluster_node_peers{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) or\n  (sum(abs(sum without (state) (cluster_node_peers{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})) - scalar(count(cluster_node_info{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}))))\n  ),\n  0, 1\n))\n",
           "instant": false,
           "legendFormat": "Converged",
           "range": true
@@ -269,7 +269,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum by(instance) (cluster_node_peers{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+          "expr": "sum by(instance) (cluster_node_peers{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true
@@ -310,7 +310,7 @@
         "label": "cluster",
         "name": "cluster",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "query": "label_values(alloy_component_controller_running_components, cluster_id)\n",
           "refId": "cluster"
         },
         "refresh": 2,
@@ -322,7 +322,7 @@
         "label": "namespace",
         "name": "namespace",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\"}, namespace)\n",
           "refId": "namespace"
         },
         "refresh": 2,
@@ -334,7 +334,7 @@
         "label": "job",
         "name": "job",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
           "refId": "job"
         },
         "refresh": 2,

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-controller.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-controller.json
@@ -4,7 +4,7 @@
       {
         "datasource": "$loki_datasource",
         "enable": true,
-        "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+        "expr": "{cluster_id=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
         "iconColor": "rgba(0, 211, 255, 1)",
         "instant": false,
         "name": "Deployments",
@@ -57,7 +57,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "count(group(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) by (instance))\n",
+          "expr": "count(group(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}) by (instance))\n",
           "instant": false,
           "legendFormat": "__auto",
           "range": true
@@ -87,7 +87,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+          "expr": "sum(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
           "instant": false,
           "legendFormat": "__auto",
           "range": true
@@ -124,7 +124,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\",health_type=\"healthy\"}) /\nsum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
+          "expr": "sum(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\",health_type=\"healthy\"}) /\nsum(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"})\n",
           "instant": false,
           "legendFormat": "__auto",
           "range": true
@@ -237,28 +237,28 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"healthy\"}) or vector(0)\n",
+          "expr": "sum(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"healthy\"}) or vector(0)\n",
           "instant": true,
           "legendFormat": "Healthy",
           "range": false
         },
         {
           "datasource": "${datasource}",
-          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unhealthy\"}) or vector(0)\n",
+          "expr": "sum(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unhealthy\"}) or vector(0)\n",
           "instant": true,
           "legendFormat": "Unhealthy",
           "range": false
         },
         {
           "datasource": "${datasource}",
-          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unknown\"}) or vector(0)\n",
+          "expr": "sum(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"unknown\"}) or vector(0)\n",
           "instant": true,
           "legendFormat": "Unknown",
           "range": false
         },
         {
           "datasource": "${datasource}",
-          "expr": "sum(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"exited\"}) or vector(0)\n",
+          "expr": "sum(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", health_type=\"exited\"}) or vector(0)\n",
           "instant": true,
           "legendFormat": "Exited",
           "range": false
@@ -293,7 +293,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum by (instance) (rate(alloy_component_evaluation_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+          "expr": "sum by (instance) (rate(alloy_component_evaluation_seconds_count{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
           "instant": false,
           "legendFormat": "__auto",
           "range": true
@@ -319,21 +319,21 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "histogram_quantile(0.99, sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.99, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
+          "expr": "histogram_quantile(0.99, sum(rate(alloy_component_evaluation_seconds{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.99, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
           "instant": false,
           "legendFormat": "99th percentile",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "histogram_quantile(0.50, sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.50, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
+          "expr": "histogram_quantile(0.50, sum(rate(alloy_component_evaluation_seconds{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\nor\nhistogram_quantile(0.50, sum by (le) (rate(alloy_component_evaluation_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
           "instant": false,
           "legendFormat": "50th percentile",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "(\n  histogram_sum(sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))) /\n  histogram_count(sum(rate(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n)\nor\n(\n  sum(rate(alloy_component_evaluation_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])) /\n  sum(rate(alloy_component_evaluation_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n)\n",
+          "expr": "(\n  histogram_sum(sum(rate(alloy_component_evaluation_seconds{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))) /\n  histogram_count(sum(rate(alloy_component_evaluation_seconds{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n)\nor\n(\n  sum(rate(alloy_component_evaluation_seconds_sum{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])) /\n  sum(rate(alloy_component_evaluation_seconds_count{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n)\n",
           "instant": false,
           "legendFormat": "Average",
           "range": true
@@ -359,7 +359,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum by (component_path, component_id) (rate(alloy_component_evaluation_slow_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n/ scalar(sum(rate(alloy_component_evaluation_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
+          "expr": "sum by (component_path, component_id) (rate(alloy_component_evaluation_slow_seconds{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n/ scalar(sum(rate(alloy_component_evaluation_seconds_sum{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval])))\n",
           "instant": false,
           "legendFormat": "{{component path}} {{component_id}}",
           "range": true
@@ -402,7 +402,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum(increase(alloy_component_evaluation_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_evaluation_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+          "expr": "sum(increase(alloy_component_evaluation_seconds{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_evaluation_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
           "format": "heatmap",
           "instant": false,
           "legendFormat": "{{le}}",
@@ -446,7 +446,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum(increase(alloy_component_dependencies_wait_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_dependencies_wait_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
+          "expr": "sum(increase(alloy_component_dependencies_wait_seconds{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\nor ignoring (le)\nsum by (le) (increase(alloy_component_dependencies_wait_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))\n",
           "format": "heatmap",
           "instant": false,
           "legendFormat": "{{le}}",
@@ -488,7 +488,7 @@
         "label": "cluster",
         "name": "cluster",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "query": "label_values(alloy_component_controller_running_components, cluster_id)\n",
           "refId": "cluster"
         },
         "refresh": 2,
@@ -500,7 +500,7 @@
         "label": "namespace",
         "name": "namespace",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\"}, namespace)\n",
           "refId": "namespace"
         },
         "refresh": 2,
@@ -512,7 +512,7 @@
         "label": "job",
         "name": "job",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
           "refId": "job"
         },
         "refresh": 2,

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-logs.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-logs.json
@@ -1,24 +1,4 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 26,
   "links": [
     {
       "asDropdown": true,
@@ -42,55 +22,12 @@
       "description": "Logs volume grouped by \"level\" label.",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
             "drawStyle": "bars",
             "fillOpacity": 50,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
             "stacking": {
-              "group": "A",
               "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
             }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
           },
           "unit": "none"
         },
@@ -204,36 +141,25 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 0
+        "w": 24
       },
       "id": 1,
       "interval": "30s",
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
         "tooltip": {
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "v10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "loki",
             "uid": "${loki_datasource}"
           },
-          "editorMode": "code",
-          "expr": "sum by (level) (\n    count_over_time(\n        {\n            cluster_id=~\"$cluster\",\n            namespace=~\"$namespace\",\n            scrape_job=~\"$job\",\n            instance=~\"$instance\",\n            level=~\"$level\"\n        }\n        |~ \"$regex_search\"\n        [$__interval]\n    )\n)\n",
-          "legendFormat": "{{ level }}",
-          "queryType": "range",
-          "refId": "A"
+          "expr": "sum by (level) (count_over_time({cluster_id=~\"$cluster\",namespace=~\"$namespace\",scrape_job=~\"$scrape_job\",instance=~\"$instance\",level=~\"$level\"}\n|~ \"$regex_search\"\n\n[$__interval]))\n",
+          "legendFormat": "{{ level }}"
         }
       ],
       "title": "Logs volume",
@@ -253,47 +179,34 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "gridPos": {
         "h": 18,
-        "w": 24,
-        "x": 0,
-        "y": 6
+        "w": 24
       },
       "id": 2,
       "options": {
         "dedupStrategy": "exact",
         "enableLogDetails": true,
         "prettifyLogMessage": true,
-        "showCommonLabels": false,
-        "showLabels": false,
         "showTime": false,
-        "sortOrder": "Descending",
         "wrapLogMessage": true
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "v10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "loki",
             "uid": "${loki_datasource}"
           },
-          "editorMode": "code",
-          "expr": "{\n    cluster_id=~\"$cluster\",\n    namespace=~\"$namespace\",\n    scrape_job=~\"$job\",\n    instance=~\"$instance\",\n    level=~\"$level\"\n} \n|~ \"$regex_search\"\n\n\n",
-          "queryType": "range",
-          "refId": "A"
+          "expr": "{cluster_id=~\"$cluster\",namespace=~\"$namespace\",scrape_job=~\"$scrape_job\",instance=~\"$instance\",level=~\"$level\"} \n|~ \"$regex_search\"\n\n\n"
         }
       ],
       "title": "Logs",
       "type": "logs"
     }
   ],
-  "preload": false,
   "refresh": "10s",
-  "schemaVersion": 40,
+  "schemaVersion": 36,
   "tags": [
     "alloy-mixin",
     "owner:team-atlas",
@@ -306,7 +219,6 @@
         "label": "Loki data source",
         "name": "loki_datasource",
         "query": "loki",
-        "refresh": 1,
         "regex": "",
         "type": "datasource"
       },
@@ -316,17 +228,11 @@
           "type": "loki",
           "uid": "${loki_datasource}"
         },
-        "definition": "",
         "includeAll": true,
         "label": "Cluster",
         "multi": true,
         "name": "cluster",
-        "query": {
-          "label": "cluster_id",
-          "refId": "LokiVariableQueryEditor-VariableQuery",
-          "stream": "{}",
-          "type": 1
-        },
+        "query": "label_values({}, cluster_id)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -337,17 +243,11 @@
           "type": "loki",
           "uid": "${loki_datasource}"
         },
-        "definition": "",
         "includeAll": true,
         "label": "Namespace",
         "multi": true,
         "name": "namespace",
-        "query": {
-          "label": "namespace",
-          "refId": "LokiVariableQueryEditor-VariableQuery",
-          "stream": "{cluster_id=~\"$cluster\"}",
-          "type": 1
-        },
+        "query": "label_values({cluster_id=~\"$cluster\"}, namespace)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -358,17 +258,11 @@
           "type": "loki",
           "uid": "${loki_datasource}"
         },
-        "definition": "",
         "includeAll": true,
         "label": "Job",
         "multi": true,
-        "name": "job",
-        "query": {
-          "label": "scrape_job",
-          "refId": "LokiVariableQueryEditor-VariableQuery",
-          "stream": "{cluster_id=~\"$cluster\",namespace=~\"$namespace\"}",
-          "type": 1
-        },
+        "name": "scrape_job",
+        "query": "label_values({cluster_id=~\"$cluster\",namespace=~\"$namespace\"}, scrape_job)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -379,17 +273,11 @@
           "type": "loki",
           "uid": "${loki_datasource}"
         },
-        "definition": "",
         "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
-        "query": {
-          "label": "instance",
-          "refId": "LokiVariableQueryEditor-VariableQuery",
-          "stream": "{cluster_id=~\"$cluster\",namespace=~\"$namespace\",scrape_job=~\"$job\"}",
-          "type": 1
-        },
+        "query": "label_values({cluster_id=~\"$cluster\",namespace=~\"$namespace\",scrape_job=~\"$scrape_job\"}, instance)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -400,23 +288,18 @@
           "type": "loki",
           "uid": "${loki_datasource}"
         },
-        "definition": "",
         "includeAll": true,
         "label": "Level",
         "multi": true,
         "name": "level",
-        "query": {
-          "label": "level",
-          "refId": "LokiVariableQueryEditor-VariableQuery",
-          "stream": "{cluster_id=~\"$cluster\",namespace=~\"$namespace\",scrape_job=~\"$job\",instance=~\"$instance\"}",
-          "type": 1
-        },
+        "query": "label_values({cluster_id=~\"$cluster\",namespace=~\"$namespace\",scrape_job=~\"$scrape_job\",instance=~\"$instance\"}, level)",
         "refresh": 2,
         "sort": 1,
         "type": "query"
       },
       {
         "current": {
+          "selected": false,
           "text": "",
           "value": ""
         },
@@ -438,10 +321,7 @@
     "from": "now-6h",
     "to": "now"
   },
-  "timepicker": {},
   "timezone": "utc",
   "title": "Alloy / Logs Overview",
-  "uid": "53c1ecddc3a1d5d4b8d6cd0c23676c31",
-  "version": 1,
-  "weekStart": ""
+  "uid": "53c1ecddc3a1d5d4b8d6cd0c23676c31"
 }

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-logs.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-logs.json
@@ -1,4 +1,24 @@
 {
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 26,
   "links": [
     {
       "asDropdown": true,
@@ -22,12 +42,55 @@
       "description": "Logs volume grouped by \"level\" label.",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "bars",
             "fillOpacity": 50,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
             "stacking": {
+              "group": "A",
               "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           },
           "unit": "none"
         },
@@ -141,25 +204,36 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 24
+        "w": 24,
+        "x": 0,
+        "y": 0
       },
       "id": 1,
       "interval": "30s",
       "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
         "tooltip": {
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "v10.0.0",
+      "pluginVersion": "11.3.1",
       "targets": [
         {
           "datasource": {
             "type": "loki",
             "uid": "${loki_datasource}"
           },
-          "expr": "sum by (level) (count_over_time({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"}\n|~ \"$regex_search\"\n\n[$__interval]))\n",
-          "legendFormat": "{{ level }}"
+          "editorMode": "code",
+          "expr": "sum by (level) (\n    count_over_time(\n        {\n            cluster_id=~\"$cluster\",\n            namespace=~\"$namespace\",\n            scrape_job=~\"$job\",\n            instance=~\"$instance\",\n            level=~\"$level\"\n        }\n        |~ \"$regex_search\"\n        [$__interval]\n    )\n)\n",
+          "legendFormat": "{{ level }}",
+          "queryType": "range",
+          "refId": "A"
         }
       ],
       "title": "Logs volume",
@@ -179,34 +253,47 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 18,
-        "w": 24
+        "w": 24,
+        "x": 0,
+        "y": 6
       },
       "id": 2,
       "options": {
         "dedupStrategy": "exact",
         "enableLogDetails": true,
         "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
         "showTime": false,
+        "sortOrder": "Descending",
         "wrapLogMessage": true
       },
-      "pluginVersion": "v10.0.0",
+      "pluginVersion": "11.3.1",
       "targets": [
         {
           "datasource": {
             "type": "loki",
             "uid": "${loki_datasource}"
           },
-          "expr": "{,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\",level=~\"$level\"} \n|~ \"$regex_search\"\n\n\n"
+          "editorMode": "code",
+          "expr": "{\n    cluster_id=~\"$cluster\",\n    namespace=~\"$namespace\",\n    scrape_job=~\"$job\",\n    instance=~\"$instance\",\n    level=~\"$level\"\n} \n|~ \"$regex_search\"\n\n\n",
+          "queryType": "range",
+          "refId": "A"
         }
       ],
       "title": "Logs",
       "type": "logs"
     }
   ],
+  "preload": false,
   "refresh": "10s",
-  "schemaVersion": 36,
+  "schemaVersion": 40,
   "tags": [
     "alloy-mixin",
     "owner:team-atlas",
@@ -219,6 +306,7 @@
         "label": "Loki data source",
         "name": "loki_datasource",
         "query": "loki",
+        "refresh": 1,
         "regex": "",
         "type": "datasource"
       },
@@ -228,11 +316,17 @@
           "type": "loki",
           "uid": "${loki_datasource}"
         },
+        "definition": "",
         "includeAll": true,
         "label": "Cluster",
         "multi": true,
         "name": "cluster",
-        "query": "label_values({}, cluster)",
+        "query": {
+          "label": "cluster_id",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "{}",
+          "type": 1
+        },
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -243,11 +337,17 @@
           "type": "loki",
           "uid": "${loki_datasource}"
         },
+        "definition": "",
         "includeAll": true,
         "label": "Namespace",
         "multi": true,
         "name": "namespace",
-        "query": "label_values({,cluster=~\"$cluster\"}, namespace)",
+        "query": {
+          "label": "namespace",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "{cluster_id=~\"$cluster\"}",
+          "type": 1
+        },
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -258,11 +358,17 @@
           "type": "loki",
           "uid": "${loki_datasource}"
         },
+        "definition": "",
         "includeAll": true,
         "label": "Job",
         "multi": true,
         "name": "job",
-        "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\"}, job)",
+        "query": {
+          "label": "scrape_job",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "{cluster_id=~\"$cluster\",namespace=~\"$namespace\"}",
+          "type": 1
+        },
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -273,11 +379,17 @@
           "type": "loki",
           "uid": "${loki_datasource}"
         },
+        "definition": "",
         "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
-        "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\"}, instance)",
+        "query": {
+          "label": "instance",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "{cluster_id=~\"$cluster\",namespace=~\"$namespace\",scrape_job=~\"$job\"}",
+          "type": 1
+        },
         "refresh": 2,
         "sort": 1,
         "type": "query"
@@ -288,18 +400,23 @@
           "type": "loki",
           "uid": "${loki_datasource}"
         },
+        "definition": "",
         "includeAll": true,
         "label": "Level",
         "multi": true,
         "name": "level",
-        "query": "label_values({,cluster=~\"$cluster\",namespace=~\"$namespace\",job=~\"$job\",instance=~\"$instance\"}, level)",
+        "query": {
+          "label": "level",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "{cluster_id=~\"$cluster\",namespace=~\"$namespace\",scrape_job=~\"$job\",instance=~\"$instance\"}",
+          "type": 1
+        },
         "refresh": 2,
         "sort": 1,
         "type": "query"
       },
       {
         "current": {
-          "selected": false,
           "text": "",
           "value": ""
         },
@@ -321,7 +438,10 @@
     "from": "now-6h",
     "to": "now"
   },
+  "timepicker": {},
   "timezone": "utc",
   "title": "Alloy / Logs Overview",
-  "uid": "53c1ecddc3a1d5d4b8d6cd0c23676c31"
+  "uid": "53c1ecddc3a1d5d4b8d6cd0c23676c31",
+  "version": 1,
+  "weekStart": ""
 }

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-opentelemetry.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-opentelemetry.json
@@ -49,7 +49,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(otelcol_receiver_accepted_spans_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "rate(otelcol_receiver_accepted_spans_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "{{ pod }} / {{ transport }}",
           "range": true
@@ -81,7 +81,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(otelcol_receiver_refused_spans_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "rate(otelcol_receiver_refused_spans_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "{{ pod }} / {{ transport }}",
           "range": true
@@ -128,7 +128,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum by (le) (increase(rpc_server_duration_milliseconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", rpc_service=\"opentelemetry.proto.collector.trace.v1.TraceService\"}[$__rate_interval]))\n",
+          "expr": "sum by (le) (increase(rpc_server_duration_milliseconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", rpc_service=\"opentelemetry.proto.collector.trace.v1.TraceService\"}[$__rate_interval]))\n",
           "format": "heatmap",
           "instant": false,
           "legendFormat": "{{le}}",
@@ -192,7 +192,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum by (le) (increase(otelcol_processor_batch_batch_send_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
+          "expr": "sum by (le) (increase(otelcol_processor_batch_batch_send_size_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))\n",
           "format": "heatmap",
           "instant": false,
           "legendFormat": "{{le}}",
@@ -214,7 +214,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "otelcol_processor_batch_metadata_cardinality{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "expr": "otelcol_processor_batch_metadata_cardinality{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
           "instant": false,
           "legendFormat": "{{ pod }}",
           "range": true
@@ -235,7 +235,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(otelcol_processor_batch_timeout_trigger_send_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "rate(otelcol_processor_batch_timeout_trigger_send_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "{{ pod }}",
           "range": true
@@ -278,7 +278,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(otelcol_exporter_sent_spans_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "rate(otelcol_exporter_sent_spans_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "{{ pod }}",
           "range": true
@@ -310,7 +310,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(otelcol_exporter_send_failed_spans_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "rate(otelcol_exporter_send_failed_spans_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "{{ pod }}",
           "range": true
@@ -351,7 +351,7 @@
         "label": "cluster",
         "name": "cluster",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "query": "label_values(alloy_component_controller_running_components, cluster_id)\n",
           "refId": "cluster"
         },
         "refresh": 2,
@@ -363,7 +363,7 @@
         "label": "namespace",
         "name": "namespace",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\"}, namespace)\n",
           "refId": "namespace"
         },
         "refresh": 2,
@@ -375,7 +375,7 @@
         "label": "job",
         "name": "job",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
           "refId": "job"
         },
         "refresh": 2,
@@ -390,7 +390,7 @@
         "multi": true,
         "name": "instance",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
           "refId": "instance"
         },
         "refresh": 2,

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-prometheus-remote-write.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-prometheus-remote-write.json
@@ -4,7 +4,7 @@
       {
         "datasource": "$loki_datasource",
         "enable": true,
-        "expr": "{cluster=~\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+        "expr": "{cluster_id=~\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
         "iconColor": "rgba(0, 211, 255, 1)",
         "instant": false,
         "name": "Deployments",
@@ -65,7 +65,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum(up{job=~\"$job\", cluster=~\"$cluster\"})\n/\ncount (up{job=~\"$job\", cluster=~\"$cluster\"})\n",
+          "expr": "sum(up{job=~\"$job\", cluster_id=~\"$cluster\"})\n/\ncount (up{job=~\"$job\", cluster_id=~\"$cluster\"})\n",
           "instant": false,
           "legendFormat": "% of targets successfully scraped",
           "range": true
@@ -91,21 +91,21 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "quantile(0.99, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+          "expr": "quantile(0.99, scrape_duration_seconds{job=~\"$job\", cluster_id=~\"$cluster\"})\n",
           "instant": false,
           "legendFormat": "p99",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "quantile(0.95, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+          "expr": "quantile(0.95, scrape_duration_seconds{job=~\"$job\", cluster_id=~\"$cluster\"})\n",
           "instant": false,
           "legendFormat": "p95",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "quantile(0.50, scrape_duration_seconds{job=~\"$job\", cluster=~\"$cluster\"})\n",
+          "expr": "quantile(0.50, scrape_duration_seconds{job=~\"$job\", cluster_id=~\"$cluster\"})\n",
           "instant": false,
           "legendFormat": "p50",
           "range": true
@@ -143,7 +143,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "(\n    1 - \n    (\n        sum(rate(prometheus_remote_storage_samples_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n    /\n    (\n        sum(rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n)\n",
+          "expr": "(\n    1 - \n    (\n        sum(rate(prometheus_remote_storage_samples_failed_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n    /\n    (\n        sum(rate(prometheus_remote_storage_samples_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]))\n    )\n)\n",
           "instant": false,
           "legendFormat": "% of samples successfully sent",
           "range": true
@@ -169,21 +169,21 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "histogram_quantile(0.99, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
+          "expr": "histogram_quantile(0.99, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
           "instant": false,
           "legendFormat": "99th percentile",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "histogram_quantile(0.50, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
+          "expr": "histogram_quantile(0.50, sum by (le) (\n  rate(prometheus_remote_storage_sent_batch_duration_seconds_bucket{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n))\n",
           "instant": false,
           "legendFormat": "50th percentile",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "sum(rate(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval])) /\nsum(rate(prometheus_remote_storage_sent_batch_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval]))\n",
+          "expr": "sum(rate(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval])) /\nsum(rate(prometheus_remote_storage_sent_batch_duration_seconds_count{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}[$__rate_interval]))\n",
           "instant": false,
           "legendFormat": "Average",
           "range": true
@@ -209,7 +209,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum by (instance, component_path, component_id) (\n  prometheus_remote_storage_highest_timestamp_in_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}\n  - ignoring(url, remote_name) group_right(instance)\n  prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+          "expr": "sum by (instance, component_path, component_id) (\n  prometheus_remote_storage_highest_timestamp_in_seconds{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\"}\n  - ignoring(url, remote_name) group_right(instance)\n  prometheus_remote_storage_queue_highest_sent_timestamp_seconds{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
           "instant": false,
           "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
           "range": true
@@ -242,7 +242,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum without (remote_name, url) (\n    rate(prometheus_remote_storage_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]) +\n    rate(prometheus_remote_storage_metadata_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+          "expr": "sum without (remote_name, url) (\n    rate(prometheus_remote_storage_bytes_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval]) +\n    rate(prometheus_remote_storage_metadata_bytes_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
           "instant": false,
           "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
           "range": true
@@ -330,21 +330,21 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum without (remote_name, url) (\n    prometheus_remote_storage_shards{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+          "expr": "sum without (remote_name, url) (\n    prometheus_remote_storage_shards{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
           "instant": false,
           "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "min (\n    prometheus_remote_storage_shards_min{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+          "expr": "min (\n    prometheus_remote_storage_shards_min{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
           "instant": false,
           "legendFormat": "Minimum",
           "range": true
         },
         {
           "datasource": "${datasource}",
-          "expr": "max (\n    prometheus_remote_storage_shards_max{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
+          "expr": "max (\n    prometheus_remote_storage_shards_max{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n)\n",
           "instant": false,
           "legendFormat": "Maximum",
           "range": true
@@ -377,7 +377,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum without (url, remote_name) (\n  rate(prometheus_remote_storage_samples_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+          "expr": "sum without (url, remote_name) (\n  rate(prometheus_remote_storage_samples_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
           "instant": false,
           "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
           "range": true
@@ -410,7 +410,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum without (url,remote_name) (\n  rate(prometheus_remote_storage_samples_failed_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+          "expr": "sum without (url,remote_name) (\n  rate(prometheus_remote_storage_samples_failed_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
           "instant": false,
           "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
           "range": true
@@ -443,7 +443,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum without (url,remote_name) (\n  rate(prometheus_remote_storage_samples_retried_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
+          "expr": "sum without (url,remote_name) (\n  rate(prometheus_remote_storage_samples_retried_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}[$__rate_interval])\n)\n",
           "instant": false,
           "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
           "range": true
@@ -474,7 +474,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum(prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
+          "expr": "sum(prometheus_remote_write_wal_storage_active_series{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
           "instant": false,
           "legendFormat": "Series",
           "range": true
@@ -500,7 +500,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n",
+          "expr": "prometheus_remote_write_wal_storage_active_series{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"}\n",
           "instant": false,
           "legendFormat": "{{instance}} / {{component_path}} {{component_id}}",
           "range": true
@@ -526,7 +526,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "sum by (component_path, component_id) (prometheus_remote_write_wal_storage_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
+          "expr": "sum by (component_path, component_id) (prometheus_remote_write_wal_storage_active_series{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id!=\"\", component_path=~\"$component_path\", component_id=~\"$component\", url=~\"$url\"})\n",
           "instant": false,
           "legendFormat": "{{component_path}} {{component_id}}",
           "range": true
@@ -567,7 +567,7 @@
         "label": "cluster",
         "name": "cluster",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "query": "label_values(alloy_component_controller_running_components, cluster_id)\n",
           "refId": "cluster"
         },
         "refresh": 2,
@@ -579,7 +579,7 @@
         "label": "namespace",
         "name": "namespace",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\"}, namespace)\n",
           "refId": "namespace"
         },
         "refresh": 2,
@@ -591,7 +591,7 @@
         "label": "job",
         "name": "job",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
           "refId": "job"
         },
         "refresh": 2,
@@ -606,7 +606,7 @@
         "multi": true,
         "name": "instance",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
           "refId": "instance"
         },
         "refresh": 2,
@@ -621,7 +621,7 @@
         "multi": true,
         "name": "component_path",
         "query": {
-          "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\", component_path=~\".*\"}, component_path)\n",
+          "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\", component_path=~\".*\"}, component_path)\n",
           "refId": "component_path"
         },
         "refresh": 2,
@@ -636,7 +636,7 @@
         "multi": true,
         "name": "component",
         "query": {
-          "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\"}, component_id)\n",
+          "query": "label_values(prometheus_remote_write_wal_samples_appended_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\", component_id=~\"prometheus.remote_write.*\"}, component_id)\n",
           "refId": "component"
         },
         "refresh": 2,
@@ -651,7 +651,7 @@
         "multi": true,
         "name": "url",
         "query": {
-          "query": "label_values(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", job=\"$job\", instance=~\"$instance\", component_id=~\"$component\"}, url)\n",
+          "query": "label_values(prometheus_remote_storage_sent_batch_duration_seconds_sum{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=\"$job\", instance=~\"$instance\", component_id=~\"$component\"}, url)\n",
           "refId": "url"
         },
         "refresh": 2,

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-resources.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/alloy-resources.json
@@ -4,7 +4,7 @@
       {
         "datasource": "$loki_datasource",
         "enable": true,
-        "expr": "{cluster=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
+        "expr": "{cluster_id=\"$cluster\", container=\"kube-diff-logger\"} | json | namespace_extracted=\"alloy\" | name_extracted=~\"alloy.*\"",
         "iconColor": "rgba(0, 211, 255, 1)",
         "instant": false,
         "name": "Deployments",
@@ -45,7 +45,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(alloy_resources_process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "rate(alloy_resources_process_cpu_seconds_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true
@@ -71,7 +71,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "alloy_resources_process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "expr": "alloy_resources_process_resident_memory_bytes{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true
@@ -101,7 +101,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(go_gc_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[5m])\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "expr": "rate(go_gc_duration_seconds_count{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[5m])\nand on(instance)\nalloy_build_info{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true
@@ -127,7 +127,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "expr": "go_goroutines{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true
@@ -153,7 +153,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
+          "expr": "go_memstats_heap_inuse_bytes{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\nand on(instance)\nalloy_build_info{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}\n",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true
@@ -186,7 +186,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(alloy_resources_machine_rx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "rate(alloy_resources_machine_rx_bytes_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true
@@ -219,7 +219,7 @@
       "targets": [
         {
           "datasource": "${datasource}",
-          "expr": "rate(alloy_resources_machine_tx_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
+          "expr": "rate(alloy_resources_machine_tx_bytes_total{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])\n",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true
@@ -260,7 +260,7 @@
         "label": "cluster",
         "name": "cluster",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components, cluster)\n",
+          "query": "label_values(alloy_component_controller_running_components, cluster_id)\n",
           "refId": "cluster"
         },
         "refresh": 2,
@@ -272,7 +272,7 @@
         "label": "namespace",
         "name": "namespace",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\"}, namespace)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\"}, namespace)\n",
           "refId": "namespace"
         },
         "refresh": 2,
@@ -284,7 +284,7 @@
         "label": "job",
         "name": "job",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}, job)\n",
           "refId": "job"
         },
         "refresh": 2,
@@ -299,7 +299,7 @@
         "multi": true,
         "name": "instance",
         "query": {
-          "query": "label_values(alloy_component_controller_running_components{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
+          "query": "label_values(alloy_component_controller_running_components{cluster_id=~\"$cluster\", namespace=~\"$namespace\", job=~\"$job\"}, instance)\n",
           "refId": "instance"
         },
         "refresh": 2,

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -5,7 +5,7 @@ set -eu
 DASHBOARD_LINTER_VERSION="eb2bc3ba25e3f0ae816b45ed3d05700002f76871"
 MIXTOOL_VERSION="448a81c91e517aa4259e7d3e039c19fed9771864"
 
-JB_VERSION="v0.5.1"
+JB_VERSION="v0.6.0"
 JB_BIN="jb"
 
 YQ_VERSION="v4.44.3"
@@ -74,6 +74,7 @@ go_install() {
 main() {
 				command -v go &>/dev/null || { echo "go is required but not installed"; exit 1; }
 
+                mkdir -p "${TOOLS_DIR}"
 				install_tool "" "${JB_BIN}" "${JB_VERSION}" "https://github.com/jsonnet-bundler/jsonnet-bundler/releases/download/${JB_VERSION}/jb-${OS}-${ARCH}"
 				install_tool "" "${YQ_BIN}" "${YQ_VERSION}" "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_${OS}_${ARCH}"
 


### PR DESCRIPTION
This PR fixes the Alloy / Logs Overview dashboard:

- templates:
   - `cluster_id` instead of `cluster`
   - `scrape_job` instead of `job`
- queries:
  - use proper label names
  - remove unexpected comma


- screenshots before:
![image](https://github.com/user-attachments/assets/0feef57a-5c8e-42ac-bf4f-9ae46f5f2c2d)

- screenshots after:
![image](https://github.com/user-attachments/assets/b6d867ae-48e6-43fd-8f2d-5aa84890bf42)

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
