### PR TITLE
add grafana org label to public dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add team label to karpenter dashboard.
+- Add grafana organization label to public dashboards
 
 ### Removed
 

--- a/helm/dashboards/charts/public_dashboards/templates/configmap-dashboards.yaml
+++ b/helm/dashboards/charts/public_dashboards/templates/configmap-dashboards.yaml
@@ -9,6 +9,7 @@ items:
   metadata:
     annotations:
       k8s-sidecar-target-directory: "/var/lib/grafana/dashboards/public/shared"
+      observability.giantswarm.io/organization: "Shared Org"
     labels:
       {{- include "labels.common" $ | nindent 6 }}
     name: {{ printf "grafana-shared-%s-dashboard" $dashboardName | trunc 63 | trimSuffix "-" }}

--- a/helm/dashboards/templates/configmap-dashboards.yaml
+++ b/helm/dashboards/templates/configmap-dashboards.yaml
@@ -7,6 +7,7 @@ items:
   metadata:
     annotations:
       k8s-sidecar-target-directory: "/var/lib/grafana/dashboards/public/home"
+      observability.giantswarm.io/organization: "Shared Org"
     labels:
       {{- include "labels.common" $ | nindent 6 }}
     name: grafana-home-dashboard
@@ -37,6 +38,7 @@ items:
   metadata:
     annotations:
       k8s-sidecar-target-directory: "/var/lib/grafana/dashboards/public/{{ $.Values.provider.kind }}"
+      observability.giantswarm.io/organization: "Shared Org"
     labels:
       {{- include "labels.common" $ | nindent 6 }}
     name: {{ printf "grafana-%s-%s-dashboard" $.Values.provider.kind $dashboardName | trunc 63 | trimSuffix "-" }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3696

This PR adds grafana organization label to public and default dashboards, so they are loaded by observability-operator in the `Shared Org` organization.

However, when this is released, we have to disable grafana dashboard loader, otherwise both will conflict.
This is managed in this PR: https://github.com/giantswarm/shared-configs/pull/226

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
