### PR TITLE
Fix Cluster overview dashboard to consistently open links in new tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Cluster overview dashboard to consistently open links in new tabs.
+
 ## [4.0.0] - 2025-02-13
 
 ### Changed

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/cluster-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/cluster-overview.json
@@ -735,6 +735,7 @@
       "id": 13,
       "links": [
         {
+          "targetBlank": true,
           "title": "",
           "url": "/d/qMN01qkWz/nodes-overview?${cluster:queryparam}&${organization:queryparam}"
         }
@@ -1018,6 +1019,7 @@
       "id": 15,
       "links": [
         {
+          "targetBlank": true,
           "title": "Show Details",
           "url": "https://docs.giantswarm.io/changes/"
         }
@@ -1107,6 +1109,7 @@
       "id": 17,
       "links": [
         {
+          "targetBlank": true,
           "title": "",
           "url": "/d/L65Jdq3Zk/alerts?${cluster:queryparam}"
         }


### PR DESCRIPTION
This PR proposes a minor fix to make all links in the Cluster overview dashboard open in new tabs.