### PR TITLE
Add observability resource usage dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `Observability Resource Usage` dashboard
+
 ## [4.2.0] - 2025-03-05
 
 ### Added

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/observability-resources.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/observability-resources.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 142,
+  "id": 146,
   "links": [],
   "panels": [
     {
@@ -92,7 +92,7 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 5,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -101,7 +101,7 @@
             },
             "insertNulls": false,
             "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -116,6 +116,7 @@
               "mode": "off"
             }
           },
+          "fieldMinMax": false,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -149,8 +150,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.5.1",
@@ -241,7 +242,7 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 5,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -250,7 +251,7 @@
             },
             "insertNulls": false,
             "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -299,8 +300,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.5.1",
@@ -391,7 +392,7 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 5,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -400,7 +401,7 @@
             },
             "insertNulls": false,
             "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -429,13 +430,13 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "Bps"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 24
       },
@@ -449,8 +450,8 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "pluginVersion": "11.5.1",
@@ -462,7 +463,7 @@
           },
           "editorMode": "code",
           "expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"loki|mimir|monitoring\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (namespace, cluster_id)",
-          "legendFormat": "{{namespace}} namespace on {{cluster_id}} - rx",
+          "legendFormat": "{{namespace}} namespace on {{cluster_id}}",
           "range": true,
           "refId": "rx-namespaces"
         },
@@ -475,7 +476,7 @@
           "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"alloy.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
           "hide": false,
           "instant": false,
-          "legendFormat": "alloy on {{cluster_id}} - rx",
+          "legendFormat": "alloy on {{cluster_id}}",
           "range": true,
           "refId": "rx-alloy"
         },
@@ -488,7 +489,7 @@
           "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"promtail.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
           "hide": false,
           "instant": false,
-          "legendFormat": "promtail on {{cluster_id}} - rx",
+          "legendFormat": "promtail on {{cluster_id}}",
           "range": true,
           "refId": "rx-promtail"
         },
@@ -501,7 +502,7 @@
           "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"grafana-agent.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
           "hide": false,
           "instant": false,
-          "legendFormat": "grafana-agent on {{cluster_id}} - rx",
+          "legendFormat": "grafana-agent on {{cluster_id}}",
           "range": true,
           "refId": "rx-grafana-agent"
         },
@@ -514,19 +515,106 @@
           "expr": "sum(rate(container_network_receive_bytes_total{pod=~\".*prometheus-agent.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
           "hide": false,
           "instant": false,
-          "legendFormat": "prometheus-agent on {{cluster_id}} - rx",
+          "legendFormat": "prometheus-agent on {{cluster_id}}",
           "range": true,
           "refId": "rx-prometheus-agent"
+        }
+      ],
+      "title": "Network usage - received",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "gs-mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "gs-mimir"
           },
           "editorMode": "code",
-          "expr": "-sum(rate(container_network_transmit_bytes_total{namespace=~\"loki|mimir|monitoring\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (namespace, cluster_id)",
+          "expr": "sum(rate(container_network_transmit_bytes_total{namespace=~\"loki|mimir|monitoring\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (namespace, cluster_id)",
           "hide": false,
-          "legendFormat": "{{namespace}} namespace on {{cluster_id}} - tx",
+          "legendFormat": "{{namespace}} namespace on {{cluster_id}}",
           "range": true,
           "refId": "tx-namespaces"
         },
@@ -536,11 +624,11 @@
             "uid": "gs-mimir"
           },
           "editorMode": "code",
-          "expr": "-sum(rate(container_network_transmit_bytes_total{pod=~\"alloy.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"alloy.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
           "hide": false,
           "instant": false,
           "interval": "",
-          "legendFormat": "alloy on {{cluster_id}} - tx",
+          "legendFormat": "alloy on {{cluster_id}}",
           "range": true,
           "refId": "tx-alloy"
         },
@@ -550,10 +638,10 @@
             "uid": "gs-mimir"
           },
           "editorMode": "code",
-          "expr": "-sum(rate(container_network_transmit_bytes_total{pod=~\"promtail.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"promtail.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
           "hide": false,
           "instant": false,
-          "legendFormat": "promtail on {{cluster_id}} - tx",
+          "legendFormat": "promtail on {{cluster_id}}",
           "range": true,
           "refId": "tx-promtail"
         },
@@ -566,7 +654,7 @@
           "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"grafana-agent.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
           "hide": false,
           "instant": false,
-          "legendFormat": "grafana-agent on {{cluster_id}} - tx",
+          "legendFormat": "grafana-agent on {{cluster_id}}",
           "range": true,
           "refId": "tx-grafana-agent"
         },
@@ -579,12 +667,12 @@
           "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\".*prometheus-agent.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
           "hide": false,
           "instant": false,
-          "legendFormat": "prometheus-agent on {{cluster_id}} - tx",
+          "legendFormat": "prometheus-agent on {{cluster_id}}",
           "range": true,
           "refId": "tx-prometheus-agent"
         }
       ],
-      "title": "Network usage",
+      "title": "Network usage - transmitted",
       "type": "timeseries"
     }
   ],
@@ -600,9 +688,7 @@
       {
         "allowCustomValue": false,
         "current": {
-          "text": [
-            "All"
-          ],
+          "text": "All",
           "value": [
             "$__all"
           ]
@@ -632,6 +718,6 @@
   "timezone": "browser",
   "title": "Observability Resource Usage",
   "uid": "observability-resource-usage",
-  "version": 5,
+  "version": 4,
   "weekStart": ""
 }

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/observability-resources.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/observability-resources.json
@@ -1,0 +1,637 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Overview of resource usage for observability applications",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 142,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Documentation",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "This dashboard shows resource usage for observability-related apps.\n\nFor per-application details, you can have a look at more specific dashboards:\n- [Loki cost estimation](/d/loki-cost-estimation/loki-cost-estimation)\n- [Mimir cost estimation](/d/d37ffc71-9200-4f0b-8f9a-9e2af9f6b3232/mimir-cost-estimation)\n- [Alloy resources](/d/d6a8574c31f3d7cb8f1345ec84d15a67/alloy-resources)",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.5.1",
+      "title": "Observability resource usage",
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 5,
+      "panels": [],
+      "title": "Data",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "gs-mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"loki|mimir|monitoring\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (namespace, cluster_id)",
+          "legendFormat": "{{namespace}} namespace on {{cluster_id}}",
+          "range": true,
+          "refId": "namespaces"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"alloy.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "alloy {{cluster_id}}",
+          "range": true,
+          "refId": "alloy"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"promtail.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "promtail {{cluster_id}}",
+          "range": true,
+          "refId": "promtail"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"grafana-agent.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "grafana-agent {{cluster_id}}",
+          "range": true,
+          "refId": "grafana-agent"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\".*prometheus-agent.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "prometheus-agent {{cluster_id}}",
+          "range": true,
+          "refId": "prometheus-agent"
+        }
+      ],
+      "title": "CPU usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "gs-mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(container_memory_usage_bytes{namespace=~\"loki|mimir|monitoring\", cluster_id=~\"$cluster\"}) by (namespace, cluster_id)",
+          "legendFormat": "{{namespace}} namespace on {{cluster_id}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(container_memory_usage_bytes{pod=~\"alloy.*\", cluster_id=~\"$cluster\"}) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "alloy on {{cluster_id}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(container_memory_usage_bytes{pod=~\"promtail.*\", cluster_id=~\"$cluster\"}) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "promtail on {{cluster_id}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(container_memory_usage_bytes{pod=~\"grafana-agent.*\", cluster_id=~\"$cluster\"}) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "grafana-agent on {{cluster_id}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(container_memory_usage_bytes{pod=~\".*prometheus-agent.*\", cluster_id=~\"$cluster\"}) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "prometheus-agent on {{cluster_id}}",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "RAM usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "gs-mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"loki|mimir|monitoring\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (namespace, cluster_id)",
+          "legendFormat": "{{namespace}} namespace on {{cluster_id}} - rx",
+          "range": true,
+          "refId": "rx-namespaces"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"alloy.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "alloy on {{cluster_id}} - rx",
+          "range": true,
+          "refId": "rx-alloy"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"promtail.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "promtail on {{cluster_id}} - rx",
+          "range": true,
+          "refId": "rx-promtail"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"grafana-agent.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "grafana-agent on {{cluster_id}} - rx",
+          "range": true,
+          "refId": "rx-grafana-agent"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\".*prometheus-agent.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "prometheus-agent on {{cluster_id}} - rx",
+          "range": true,
+          "refId": "rx-prometheus-agent"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "-sum(rate(container_network_transmit_bytes_total{namespace=~\"loki|mimir|monitoring\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (namespace, cluster_id)",
+          "hide": false,
+          "legendFormat": "{{namespace}} namespace on {{cluster_id}} - tx",
+          "range": true,
+          "refId": "tx-namespaces"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "-sum(rate(container_network_transmit_bytes_total{pod=~\"alloy.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "alloy on {{cluster_id}} - tx",
+          "range": true,
+          "refId": "tx-alloy"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "-sum(rate(container_network_transmit_bytes_total{pod=~\"promtail.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "promtail on {{cluster_id}} - tx",
+          "range": true,
+          "refId": "tx-promtail"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"grafana-agent.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "grafana-agent on {{cluster_id}} - tx",
+          "range": true,
+          "refId": "tx-grafana-agent"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "gs-mimir"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\".*prometheus-agent.*\", cluster_id=~\"$cluster\"}[$__rate_interval])) by (cluster_id)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "prometheus-agent on {{cluster_id}} - tx",
+          "range": true,
+          "refId": "tx-prometheus-agent"
+        }
+      ],
+      "title": "Network usage",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 40,
+  "tags": [
+    "owner:team-atlas",
+    "topic:observability"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(capi_cluster_info,cluster_id)",
+        "description": "",
+        "includeAll": true,
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(capi_cluster_info,cluster_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Observability Resource Usage",
+  "uid": "observability-resource-usage",
+  "version": 5,
+  "weekStart": ""
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3888

This PR adds a dashboard showing an overview of observability-related resource usage.

Screenshots:
![image](https://github.com/user-attachments/assets/15afd331-736d-49fc-961c-fa0238d0e2b0)
![image](https://github.com/user-attachments/assets/82747690-4f89-4742-9aef-e4f4a738aab5)


### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
