### PR TITLE
Mimir Continuous Tests: fix datasource selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Mimir Continuous Tests: fix datasource selector
+
 ## [4.3.0] - 2025-03-12
 
 ### Added

--- a/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-continuous-tests.json
+++ b/helm/dashboards/charts/private_dashboards_mz/dashboards/shared/private/mimir-continuous-tests.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 143,
+  "id": 122,
   "links": [
     {
       "asDropdown": true,
@@ -52,7 +52,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "mimir"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -66,6 +66,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -139,15 +140,17 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "mimir"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(rate(mimir_continuous_test_queries_total[$__rate_interval])) by (cluster_id, test)",
@@ -163,7 +166,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "mimir"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -177,6 +180,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -234,15 +238,17 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "mimir"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(rate(mimir_continuous_test_queries_failed_total[$__rate_interval])) by(cluster_id, test)",
@@ -258,7 +264,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "mimir"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -272,6 +278,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -345,15 +352,17 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "mimir"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(rate(mimir_continuous_test_query_result_checks_total[$__rate_interval])) by (cluster_id, test)",
@@ -369,7 +378,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "mimir"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -383,6 +392,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -456,15 +466,17 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "mimir"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(rate(mimir_continuous_test_query_result_checks_failed_total[$__rate_interval])) by (cluster_id, test)",
@@ -478,6 +490,7 @@
       "type": "timeseries"
     },
     {
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -485,13 +498,14 @@
         "y": 17
       },
       "id": 1,
+      "panels": [],
       "title": "Write path",
       "type": "row"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "mimir"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -505,6 +519,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -562,15 +577,17 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "mimir"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(rate(mimir_continuous_test_writes_total[$__rate_interval])) by (cluster_id, test)",
@@ -586,7 +603,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "mimir"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -600,6 +617,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -657,15 +675,17 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "mimir"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(rate(mimir_continuous_test_writes_failed_total[$__rate_interval])) by (cluster_id, test)",
@@ -679,8 +699,9 @@
       "type": "timeseries"
     }
   ],
+  "preload": false,
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 40,
   "tags": [
     "owner:team-atlas",
     "topic:observability",
@@ -690,20 +711,16 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "Mimir",
+          "value": "gs-mimir"
         },
-        "hide": 0,
         "includeAll": false,
         "label": "Data source",
-        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
         "type": "datasource"
       }
     ]
@@ -716,6 +733,6 @@
   "timezone": "browser",
   "title": "Mimir / Continuous test",
   "uid": "mimir-continuous-test",
-  "version": 7,
+  "version": 50,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR fixes Mimir Continuous Tests dashboard, by fixing the datasource selector

- screenshots before: 
![image](https://github.com/user-attachments/assets/0b50c094-f702-4258-9d4a-7c3d99a0aced)

- screenshots after:
![image](https://github.com/user-attachments/assets/8061f619-b4b7-4dc7-ab94-4bd9a5180eb1)


### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
