### PR TITLE
update alerts timeline dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- alerts timeline dashboard:
+    - fix silences count
+    - add links to silences, alerts, notifications
+    - fix consistency between alerts timeline and alerts list
+
 ## [4.4.0] - 2025-03-24
 
 ### Added

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/alerts.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/alerts.json
@@ -20,15 +20,11 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 128,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -37,24 +33,15 @@
       },
       "id": 17,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Overview",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
       "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 10,
         "w": 8,
@@ -71,16 +58,7 @@
         "content": "This dashboard provides metrics about alerts, inhibitions, and silences on a cluster level (workload cluster or management cluster).\n\n**Alert:** An alert is created by Prometheus Alertmanager based on a set of rules. For example, when some metric exceeds a configured threshold.\n\nAlerts are defined in the [prometheus-rules](https://github.com/giantswarm/prometheus-rules) repository. To learn about a particular alert, you can search that repository for the alert name.\n\n**Inhibition:** An inhibition is a rule to prevent an alert from being created. At Giant Swarm we use this for example to avoid certain alerts from being created when a cluster is freshly created, as this would otherwise trigger pages to staff on call.\n\n**Silence:** A silence is another specific override rule to opress one or several alerts from firing. Silences are not cluster specific, but instead are effective for the entire installation.",
         "mode": "markdown"
       },
-      "pluginVersion": "10.4.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
+      "pluginVersion": "11.6.0",
       "title": "About this dashboard",
       "type": "text"
     },
@@ -101,8 +79,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -117,11 +94,24 @@
         "y": 1
       },
       "id": 2,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "Rules",
+          "url": "/alerting/list"
+        },
+        {
+          "targetBlank": true,
+          "title": "Notifications",
+          "url": "/alerting/groups"
+        }
+      ],
       "options": {
         "colorMode": "none",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -134,7 +124,7 @@
         "textMode": "value_and_name",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -211,8 +201,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -226,11 +215,19 @@
         "y": 6
       },
       "id": 13,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "Silences",
+          "url": "/alerting/silences"
+        }
+      ],
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -243,16 +240,18 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(aggregation:alertmanager:silences_active_total)",
+          "editorMode": "code",
+          "expr": "max(cortex_alertmanager_silences{state=\"active\"})",
           "interval": "",
           "legendFormat": "Active",
+          "range": true,
           "refId": "total"
         },
         {
@@ -260,9 +259,11 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(aggregation:alertmanager:silences_expired_total)",
+          "editorMode": "code",
+          "expr": "max(cortex_alertmanager_silences{state=\"expired\"})",
           "interval": "",
           "legendFormat": "Expired",
+          "range": true,
           "refId": "expired"
         },
         {
@@ -270,9 +271,11 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(aggregation:alertmanager:silences_pending_total)",
+          "editorMode": "code",
+          "expr": "max(cortex_alertmanager_silences{state=\"pending\"})",
           "interval": "",
           "legendFormat": "Pending",
+          "range": true,
           "refId": "pending"
         }
       ],
@@ -280,10 +283,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -291,15 +291,7 @@
         "y": 11
       },
       "id": 15,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
+      "panels": [],
       "title": "Metrics",
       "type": "row"
     },
@@ -315,6 +307,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisPlacement": "auto",
             "fillOpacity": 70,
             "hideFrom": {
               "legend": false,
@@ -330,8 +323,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -360,10 +352,12 @@
         "rowHeight": 0.9,
         "showValue": "never",
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -371,7 +365,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(ALERTS{alertname=~'($alertname)|$^',cluster_id=~'($cluster)|$^', severity=~'($severity)|$^', team=~'($team)|$^'})by(alertname, cluster_id)",
+          "expr": "sum(max_over_time(ALERTS{alertname=~'($alertname)|$^',cluster_id=~'($cluster)|$^', severity=~'($severity)|$^', team=~'($team)|$^'}[2m:]))by(alertname, cluster_id)",
           "instant": false,
           "legendFormat": "{{alertname}} on {{cluster_id}}",
           "range": true,
@@ -432,7 +426,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "10.0.3",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -492,8 +486,9 @@
       "type": "table"
     }
   ],
+  "preload": false,
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 41,
   "tags": [
     "owner:team-atlas",
     "topic:observability",
@@ -503,37 +498,30 @@
     "list": [
       {
         "current": {
-          "selected": false,
           "text": "default",
           "value": "default"
         },
-        "hide": 0,
         "includeAll": false,
         "label": "Data source",
-        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "current": {
-          "selected": false,
-          "text": "gauss",
-          "value": "gauss"
+          "text": "golem",
+          "value": "golem"
         },
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"
         },
         "definition": "label_values(ALERTS{},cluster_id)",
-        "hide": 0,
         "includeAll": false,
         "label": "Cluster",
-        "multi": false,
         "name": "cluster",
         "options": [],
         "query": {
@@ -542,19 +530,12 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
+          "text": "All",
           "value": [
             "$__all"
           ]
@@ -564,7 +545,6 @@
           "uid": "$datasource"
         },
         "definition": "label_values(ALERTS{},severity)",
-        "hide": 0,
         "includeAll": true,
         "label": "Severity",
         "multi": true,
@@ -576,19 +556,12 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
+          "text": "All",
           "value": [
             "$__all"
           ]
@@ -598,7 +571,6 @@
           "uid": "$datasource"
         },
         "definition": "label_values(ALERTS{},team)",
-        "hide": 0,
         "includeAll": true,
         "label": "Team",
         "multi": true,
@@ -610,19 +582,12 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
+          "text": "All",
           "value": [
             "$__all"
           ]
@@ -632,7 +597,6 @@
           "uid": "${datasource}"
         },
         "definition": "query_result(count(max_over_time(ALERTS{alertname!~\"^(Heartbeat|InvalidLabellingSchema)\",cluster_id=~'($cluster)|$^', team=~'($team)|$^', severity=~'($severity)|$^'}[$__range:])) by (alertname))",
-        "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "alertname",
@@ -643,8 +607,6 @@
         },
         "refresh": 2,
         "regex": "/.*{alertname=\"(.*)\"}.*/",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       }
     ]
@@ -653,23 +615,9 @@
     "from": "now-2d",
     "to": "now"
   },
-  "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ]
-  },
+  "timepicker": {},
   "timezone": "UTC",
   "title": "Alerts",
   "uid": "L65Jdq3Zk",
-  "version": 3,
-  "weekStart": ""
+  "version": 38
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3953

This PR updates the alerts timeline dashboard:
    - fix silences count
    - add links to silences, alerts, notifications
    - fix consistency between alerts timeline and alerts list

- screenshots before:
![image](https://github.com/user-attachments/assets/bb495955-e4d2-4d8e-abdb-055a1baea054)
![image](https://github.com/user-attachments/assets/e3a874c3-ce15-4df7-aa28-f9c19d2f3a54)

- screenshots after:
![image](https://github.com/user-attachments/assets/2f14f1bd-dcb5-48ca-bb28-ba405fc79146)
![image](https://github.com/user-attachments/assets/e121cabb-97e0-4163-9d3a-c245b37e7572)


### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
