### PR TITLE
fix alertmanager overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - add links to silences, alerts, notifications
     - fix consistency between alerts timeline and alerts list
     - update title
+- alertmanager overview update to mimir alertmanager
 
 ## [4.4.0] - 2025-03-24
 

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/alertmanager-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/alertmanager-overview.json
@@ -18,15 +18,11 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 79,
+  "id": 48,
   "links": [],
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -35,15 +31,6 @@
       },
       "id": 6,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Alerts",
       "type": "row"
     },
@@ -65,6 +52,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -95,8 +83,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -123,21 +110,24 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(alertmanager_alerts{job=~\"$job\"}) by (job,instance)",
+          "editorMode": "code",
+          "expr": "sum(cortex_alertmanager_alerts{job=~\"$job\"}) by (job,instance)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{instance}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -162,6 +152,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -192,8 +183,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -220,21 +210,24 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(rate(alertmanager_alerts_received_total{job=~\"$job\"}[$__rate_interval])) by (job,instance)",
+          "editorMode": "code",
+          "expr": "sum(rate(cortex_alertmanager_alerts_received_total{job=~\"$job\"}[$__rate_interval])) by (job,instance)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} Received",
+          "range": true,
           "refId": "A"
         },
         {
@@ -242,10 +235,12 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(rate(alertmanager_alerts_invalid_total{job=~\"$job\"}[$__rate_interval])) by (job,instance)",
+          "editorMode": "code",
+          "expr": "sum(rate(cortex_alertmanager_alerts_invalid_total{job=~\"$job\"}[$__rate_interval])) by (job,instance)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} Invalid",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -254,10 +249,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -266,15 +257,6 @@
       },
       "id": 7,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Notifications",
       "type": "row"
     },
@@ -296,6 +278,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -326,8 +309,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -341,7 +323,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 6,
+        "w": 24,
         "x": 0,
         "y": 9
       },
@@ -354,22 +336,26 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "11.6.0",
       "repeat": "integration",
+      "repeatDirection": "h",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(rate(alertmanager_notifications_total{job=~\"$job\", integration=\"$integration\"}[$__rate_interval])) by (integration,job,instance)",
+          "editorMode": "code",
+          "expr": "sum(rate(cortex_alertmanager_notifications_total{job=~\"$job\", integration=\"$integration\"}[$__rate_interval])) by (integration,job,instance)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} Total",
+          "range": true,
           "refId": "A"
         },
         {
@@ -377,10 +363,12 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(rate(alertmanager_notifications_failed_total{job=~\"$job\", integration=\"$integration\"}[$__rate_interval])) by (integration,job,instance)",
+          "editorMode": "code",
+          "expr": "sum(rate(cortex_alertmanager_notifications_failed_total{job=~\"$job\", integration=\"$integration\"}[$__rate_interval])) by (integration,job,instance)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} Failed",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -405,6 +393,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -435,8 +424,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -450,9 +438,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 6,
+        "w": 24,
         "x": 0,
-        "y": 30
+        "y": 16
       },
       "id": 5,
       "options": {
@@ -463,22 +451,25 @@
           "showLegend": false
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
-      "repeat": "integration",
+      "pluginVersion": "11.6.0",
+      "repeatDirection": "h",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "histogram_quantile(0.99,\n  sum(rate(alertmanager_notification_latency_seconds_bucket{job=~\"$job\", integration=\"$integration\"}[$__rate_interval])) by (le,job,instance)\n) \n",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,\n  sum(rate(cortex_alertmanager_notification_latency_seconds_bucket{job=~\"$job\"}[$__rate_interval])) by (le,job,instance)\n) \n",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} 99th Percentile",
+          "range": true,
           "refId": "A"
         },
         {
@@ -486,10 +477,12 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "histogram_quantile(0.50,\n  sum(rate(alertmanager_notification_latency_seconds_bucket{job=~\"$job\", integration=\"$integration\"}[$__rate_interval])) by (le,job,instance)\n) \n",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50,\n  sum(rate(cortex_alertmanager_notification_latency_seconds_bucket{job=~\"$job\"}[$__rate_interval])) by (le,job,instance)\n) \n",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} Median",
+          "range": true,
           "refId": "B"
         },
         {
@@ -497,10 +490,12 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(rate(alertmanager_notification_latency_seconds_sum{job=~\"$job\", integration=\"$integration\"}[$__rate_interval])) by (job,instance)\n/\nsum(rate(alertmanager_notification_latency_seconds_count{job=~\"$job\", integration=\"$integration\"}[$__rate_interval])) by (job,instance)\n",
+          "editorMode": "code",
+          "expr": "sum(rate(cortex_alertmanager_notification_latency_seconds_sum{job=~\"$job\"}[$__rate_interval])) by (job,instance)\n/\nsum(rate(cortex_alertmanager_notification_latency_seconds_count{job=~\"$job\"}[$__rate_interval])) by (job,instance)\n",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} Average",
+          "range": true,
           "refId": "C"
         }
       ],
@@ -513,7 +508,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 23
       },
       "id": 28,
       "panels": [],
@@ -523,18 +518,23 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "uid": "gs-loki"
       },
       "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 24
       },
       "id": 49,
       "options": {
         "dedupStrategy": "none",
+        "enableInfiniteScrolling": false,
         "enableLogDetails": true,
         "prettifyLogMessage": false,
         "showCommonLabels": false,
@@ -543,14 +543,14 @@
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
             "type": "loki",
-            "uid": "P8E80F9AEF21F6940"
+            "uid": "gs-loki"
           },
-          "editorMode": "code",
-          "expr": "{scrape_job=\"kubernetes-pods\", namespace=\"monitoring\", pod=~\"alertmanager-.*\"} | logfmt | integration=~\"($integration).*\" | line_format `{{.integration}}/{{.receiver}}: {{.msg}} / {{.err}}`",
+          "expr": "{scrape_job=\"kubernetes-pods\", namespace=\"mimir\", service_name=\"alertmanager\", pod=~\"mimir-alertmanager-.*\"}",
           "queryType": "range",
           "refId": "A"
         }
@@ -559,8 +559,9 @@
       "type": "logs"
     }
   ],
-  "refresh": "30s",
-  "schemaVersion": 39,
+  "preload": false,
+  "refresh": "15m",
+  "schemaVersion": 41,
   "tags": [
     "owner:team-atlas",
     "topic:observability",
@@ -570,53 +571,44 @@
     "list": [
       {
         "current": {
-          "selected": false,
           "text": "default",
           "value": "default"
         },
-        "hide": 0,
         "includeAll": false,
         "label": "Data source",
-        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
-        "queryValue": "",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "current": {
-          "selected": false,
-          "text": "alertmanager-operated",
-          "value": "alertmanager-operated"
+          "text": "mimir/alertmanager",
+          "value": "mimir/alertmanager"
         },
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "definition": "",
-        "hide": 0,
+        "definition": "label_values(cortex_alertmanager_alerts,job)",
         "includeAll": false,
         "label": "job",
-        "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(alertmanager_alerts, job)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(cortex_alertmanager_alerts,job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "current": {
-          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -624,21 +616,19 @@
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "definition": "",
-        "hide": 0,
+        "definition": "label_values(cortex_alertmanager_notifications_total{integration=~\".*\"},integration)",
         "includeAll": true,
-        "multi": false,
         "name": "integration",
         "options": [],
-        "query": "label_values(alertmanager_notifications_total{integration=~\".*\"}, integration)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(cortex_alertmanager_notifications_total{integration=~\".*\"},integration)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       }
     ]
   },
@@ -646,34 +636,9 @@
     "from": "now-1h",
     "to": "now"
   },
-  "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
-  },
+  "timepicker": {},
   "timezone": "utc",
   "title": "Alertmanager / Overview",
   "uid": "alertmanager-overview",
-  "version": 1,
-  "weekStart": ""
+  "version": 45
 }


### PR DESCRIPTION
This PR fixes alertmanager overview dashboard.

Since we moved from prometheus alertmanager to mimir alertmanager, metrics names and log format has changed, so the dashboard was completely empty.

This PR fixes templates, metrics panels and logs panels to comply with mimir alertmanager data.

Screenshots after:
![image](https://github.com/user-attachments/assets/70362414-4ab2-4f26-989b-308a651bd762)
![image](https://github.com/user-attachments/assets/ae1839ff-7c8e-4da7-b395-f04065bfe8d1)


### Checklist

- [ ] Update changelog in CHANGELOG.md in an end-user friendly language.
