### PR TITLE
Cluster Overview dashboard: improve alert links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Chunged
+
+- Cluster Overview dashboard: improve alerts links
+
 ## [4.4.1] - 2025-04-28
 
 ### Changed

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/cluster-overview.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/cluster-overview.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 247,
+  "id": 52,
   "links": [],
   "panels": [
     {
@@ -43,7 +43,7 @@
         "content": "<div style=\"display:flex; justify-content:center;align-items: center;\">\n  <img src=\"https://upload.wikimedia.org/wikipedia/commons/3/39/Kubernetes_logo_without_workmark.svg\" \n   style=\"max-width:160px; float:right; margin-right:20px\"/>\n  <p style=\"float:left;\">\n   Clustername: <b>${cluster}</b><br/>\n   K8S Version: <b>${k8sversion}</b><br/>\n   _____________________<br/>\n   Owner: ${customer}<br/>\n   Installation: ${installation}<br/>\n   Region: ${region}<br/>\n   Service Priority: <b>${priority}</b>\n  </p>\n<div>",
         "mode": "html"
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "title": "Cluster Info",
       "type": "text"
     },
@@ -62,8 +62,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "orange",
@@ -108,7 +107,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "editorMode": "code",
@@ -172,8 +171,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -200,11 +198,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "editorMode": "code",
@@ -258,8 +257,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -298,7 +296,7 @@
         "textMode": "value",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "editorMode": "code",
@@ -341,8 +339,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "text",
-                "value": null
+                "color": "text"
               }
             ]
           }
@@ -373,7 +370,7 @@
         "textMode": "value",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "editorMode": "code",
@@ -402,8 +399,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "text",
-                "value": null
+                "color": "text"
               },
               {
                 "color": "red",
@@ -438,7 +434,7 @@
         "textMode": "value",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "editorMode": "code",
@@ -466,8 +462,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "orange",
@@ -512,7 +507,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "editorMode": "code",
@@ -576,8 +571,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -600,11 +594,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "editorMode": "code",
@@ -640,8 +635,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -758,7 +752,7 @@
           }
         ]
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "editorMode": "code",
@@ -861,13 +855,19 @@
           "color": {
             "mode": "thresholds"
           },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Alerts timeline",
+              "url": "/d/L65Jdq3Zk/alerts-timeline?${cluster:queryparam}﻿﻿﻿&var-severity=page"
+            }
+          ],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "orange",
@@ -892,8 +892,8 @@
       "links": [
         {
           "targetBlank": true,
-          "title": "",
-          "url": "/d/L65Jdq3Zk/alerts?${cluster:queryparam}"
+          "title": "Alerts timeline",
+          "url": "/d/L65Jdq3Zk/alerts-timeline?${cluster:queryparam}&var-severity=page"
         }
       ],
       "options": {
@@ -913,12 +913,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(count(ALERTS{cluster_id=~'($cluster)|$^', severity=\"page\"})by(alertname))",
+          "expr": "count(count(ALERTS{cluster_id=~'($cluster)|$^', severity=~'page|$^'})by(alertname))",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -945,8 +945,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
+                "color": "red"
               },
               {
                 "color": "text",
@@ -989,7 +988,7 @@
         "textMode": "value",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1028,7 +1027,7 @@
         "feedUrl": "https://docs.giantswarm.io/changes/index.xml",
         "showImage": false
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "title": "Change Log",
       "type": "news"
     },
@@ -1050,13 +1049,19 @@
             "filterable": true,
             "inspect": false
           },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Alert timeline for ﻿${__data.fields.alertname}",
+              "url": "/d/L65Jdq3Zk/alerts-timeline?${cluster:queryparam}&var-alertname=${__data.fields.alertname}"
+            }
+          ],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -1110,8 +1115,8 @@
       "links": [
         {
           "targetBlank": true,
-          "title": "",
-          "url": "/d/L65Jdq3Zk/alerts?${cluster:queryparam}"
+          "title": "Alerts timeline",
+          "url": "/d/L65Jdq3Zk/alerts-timeline?${cluster:queryparam}&var-severity=page"
         }
       ],
       "options": {
@@ -1128,7 +1133,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.3.1",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -1240,8 +1245,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "orange",
@@ -1344,8 +1348,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -1397,7 +1400,7 @@
   ],
   "preload": false,
   "refresh": "",
-  "schemaVersion": 40,
+  "schemaVersion": 41,
   "tags": [
     "Managed",
     "Cluster"
@@ -1420,8 +1423,8 @@
       },
       {
         "current": {
-          "text": "gazelle",
-          "value": "gazelle"
+          "text": "golem",
+          "value": "golem"
         },
         "datasource": "${datasource}",
         "definition": "label_values(kubernetes_build_info, cluster_id)",
@@ -1440,8 +1443,8 @@
       },
       {
         "current": {
-          "text": "v1.29.9",
-          "value": "v1.29.9"
+          "text": "v1.30.11",
+          "value": "v1.30.11"
         },
         "datasource": "${datasource}",
         "definition": "label_values(kubernetes_build_info{cluster_id=\"$cluster\"},git_version)",
@@ -1480,8 +1483,8 @@
       },
       {
         "current": {
-          "text": "gazelle",
-          "value": "gazelle"
+          "text": "golem",
+          "value": "golem"
         },
         "datasource": "${datasource}",
         "definition": "label_values(kubernetes_build_info{cluster_id=\"$cluster\"},installation)",
@@ -1500,8 +1503,8 @@
       },
       {
         "current": {
-          "text": "eu-central-1",
-          "value": "eu-central-1"
+          "text": "eu-west-2",
+          "value": "eu-west-2"
         },
         "datasource": "${datasource}",
         "definition": "label_values(kubernetes_build_info{cluster_id=\"$cluster\"},region)",
@@ -1570,6 +1573,5 @@
   "timezone": "browser",
   "title": "Cluster Overview",
   "uid": "gs_cluster-overview",
-  "version": 6,
-  "weekStart": ""
+  "version": 59
 }


### PR DESCRIPTION
This PR updates alert-related links in `Cluster Overview` dashboard:
- align queries so the number of alerts is the same in Cluster Overview and in Alerts Timeline dashboards
- update links to use current dashboard name
- update links to filter on paging alerts
- contextual links in list of firing alerts to only show this specific alert

Towards https://github.com/giantswarm/roadmap/issues/3953

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
