### PR TITLE
improve unschedulable-pods dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Improve Unschedulable pods dashboard: better count
+
 ## [4.9.0] - 2025-10-06
 
 ### Added

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/unschedulable-pods.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/unschedulable-pods.json
@@ -37,7 +37,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 198,
+  "id": 207,
   "links": [],
   "panels": [
     {
@@ -82,7 +82,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "max"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
@@ -95,9 +95,11 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "count(\n  kube_pod_status_unschedulable{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}\n) by (cluster_id)",
+          "exemplar": false,
+          "expr": "sum(\n  sum_over_time(\n    kube_pod_status_unschedulable{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__range]\n  )\n) by (cluster_id)",
+          "instant": true,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A"
         }
       ],
@@ -146,7 +148,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "max"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
@@ -159,9 +161,11 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "count(\n  kube_pod_status_unschedulable{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}\n) by (namespace)",
+          "exemplar": false,
+          "expr": "sum(\n  sum_over_time(\n    kube_pod_status_unschedulable{cluster_id=~\"$cluster\", namespace=~\"$namespace\"}[$__range]\n  )\n) by (namespace)",
+          "instant": true,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A"
         }
       ],


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/34318

This PR improves the top counts on `Unschedulable pods` dashboard.
Previously it was counting the max concurrent failing pods, now it counts across the whole timerange, which makes more sense.

<img width="1366" height="499" alt="image" src="https://github.com/user-attachments/assets/f0ceb30e-2e7c-4d0c-a3a3-ec2d9e416d57" />


### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
