### PR TITLE
Fix envoy loadtesting dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed hardcoded label in one of `envoy-gateway-loadtesting` dashboard's graph.
+
 ## [4.21.1] - 2026-04-20
 
 ### Changed

--- a/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/envoy-gateway-loadtesting.json
+++ b/helm/dashboards/charts/private_dashboards_al/dashboards/shared/private/envoy-gateway-loadtesting.json
@@ -123,7 +123,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload=~\"(envoy-gateway|envoy-giantswarm-default-d195d0cf)\", workload_type=~\"deployment\"}\n) by (workload)",
+          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=~\"deployment\"}\n) by (workload)",
           "legendFormat": "{{workload}}",
           "range": true,
           "refId": "A"
@@ -134,7 +134,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload=~\"(envoy-gateway|envoy-giantswarm-default-d195d0cf)\", workload_type=~\"deployment\"}\n) by (cluster_id)",
+          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=~\"deployment\"}\n) by (cluster_id)",
           "instant": false,
           "legendFormat": "Total",
           "range": true,


### PR DESCRIPTION
Small PR to remove a label with a hardcoded value in the Envoy Gateway resources' graph on the envoy loadtesting dashboard. This was preventing the graphs from displaying the resources consumption for the proxies and the controller independently .

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
