### PR TITLE
Fix Envoy memory/cpu label matchers in loadtesting dashboards

### DIFF
--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/envoy-vs-kong-loadtesting.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/envoy-vs-kong-loadtesting.json
@@ -123,7 +123,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=~\"deployment\"}\n) by (workload)",
+          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=\"deployment\"}\n) by (workload)",
           "legendFormat": "{{workload}}",
           "range": true,
           "refId": "A"
@@ -134,7 +134,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=~\"deployment\"}\n) by (cluster_id)",
+          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=\"deployment\"}\n) by (cluster_id)",
           "instant": false,
           "legendFormat": "Total",
           "range": true,
@@ -335,7 +335,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(container_memory_working_set_bytes{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", container!=\"\", image!=\"\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload=~\"(envoy-gateway|envoy-giantswarm-default-d195d0cf)\", workload_type=~\"deployment\"}\n) by (workload)",
+          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(container_memory_working_set_bytes{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", container!=\"\", image!=\"\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=\"deployment\"}\n) by (workload)",
           "legendFormat": "{{workload}}",
           "range": true,
           "refId": "A"
@@ -346,7 +346,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(container_memory_working_set_bytes{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", container!=\"\", image!=\"\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload=~\"(envoy-gateway|envoy-giantswarm-default-d195d0cf)\", workload_type=~\"deployment\"}\n) by (cluster_id)",
+          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(container_memory_working_set_bytes{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", container!=\"\", image!=\"\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=\"deployment\"}\n) by (cluster_id)",
           "instant": false,
           "legendFormat": "Total",
           "range": true,

--- a/helm/dashboards/charts/public_dashboards/dashboards/shared/public/envoy-vs-nginx-loadtesting.json
+++ b/helm/dashboards/charts/public_dashboards/dashboards/shared/public/envoy-vs-nginx-loadtesting.json
@@ -123,7 +123,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=~\"deployment\"}\n) by (workload)",
+          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=\"deployment\"}\n) by (workload)",
           "legendFormat": "{{workload}}",
           "range": true,
           "refId": "A"
@@ -134,7 +134,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=~\"deployment\"}\n) by (cluster_id)",
+          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=\"deployment\"}\n) by (cluster_id)",
           "instant": false,
           "legendFormat": "Total",
           "range": true,
@@ -335,7 +335,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(container_memory_working_set_bytes{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", container!=\"\", image!=\"\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload=~\"(envoy-gateway|envoy-giantswarm-default-d195d0cf)\", workload_type=~\"deployment\"}\n) by (workload)",
+          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(container_memory_working_set_bytes{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", container!=\"\", image!=\"\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=\"deployment\"}\n) by (workload)",
           "legendFormat": "{{workload}}",
           "range": true,
           "refId": "A"
@@ -346,7 +346,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(container_memory_working_set_bytes{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", container!=\"\", image!=\"\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload=~\"(envoy-gateway|envoy-giantswarm-default-d195d0cf)\", workload_type=~\"deployment\"}\n) by (cluster_id)",
+          "expr": "sum(\n    max by (cluster_id, namespace, pod, container)(container_memory_working_set_bytes{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", container!=\"\", image!=\"\"})\n  * on(cluster_id, namespace, pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster_id=\"$workload_cluster\", namespace=\"envoy-gateway-system\", workload_type=\"deployment\"}\n) by (cluster_id)",
           "instant": false,
           "legendFormat": "Total",
           "range": true,


### PR DESCRIPTION
- Remove hardcoded workload name from Envoy memory queries; namespace
  filter alone is sufficient to scope to the right pods
- Convert workload_type=~"deployment" to exact match workload_type="deployment"

This PR

- adds/changes/removes etc
- screenshots before:
- screenshots after:

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md in an end-user friendly language.
