### PR TITLE
chore: Use same configmap resource name for all dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- update cluster-overview with organization selector
+- Update cluster-overview with organization selector
+- Use same configmap resource name for all dashboards
 
 ## [4.24.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Update cluster-overview with organization selector
-- Use same configmap resource name for all dashboards
+- Update generated configmap names to use the same pattern
 
 ## [4.24.0] - 2026-06-04
 

--- a/helm/dashboards/templates/_dashboards.tpl
+++ b/helm/dashboards/templates/_dashboards.tpl
@@ -9,15 +9,7 @@ Parameters:
   - .providerKind: (optional) The provider kind (e.g., "capa", "capz") for provider-specific dashboards
 */}}
 {{- define "dashboards.configMapName" -}}
-{{- if or (eq .teamName "phoenix") (eq .teamName "tenet") -}}
-  {{- if .providerKind -}}
-  {{- printf "grafana-%s-%s-dashboard" (printf "%s-%s-%s-%s" .teamName .providerKind .org .folder | sha256sum | trunc 8) .dashboardName | trunc 63 | trimSuffix "-" -}}
-  {{- else -}}
-  {{- printf "grafana-%s-%s-dashboard" (printf "%s-%s-%s" .teamName .org .folder | sha256sum | trunc 8) .dashboardName | trunc 63 | trimSuffix "-" -}}
-  {{- end -}}
-{{- else -}}
-  {{- printf "%s-dashboard" .dashboardName | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "grafana-%s-%s-dashboard" (printf "%s-%s-%s-%s" .teamName .providerKind .org .folder | sha256sum | trunc 8) .dashboardName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/35720

### Problem

The generated configmap resources have different naming schema, this prevents easy replication of the same dashboard(s) in different organizations.

### Solution

This PR update the name of the configmap resources being generated to always follow the same pattern.

Here is a diff of the previous names vs the new names.

<details><summary>Details</summary>
<p>

This is the output of the same command run before and after deploying this PR: `kubectl -n monitoring get cm -lapp.giantswarm.io/kind=dashboard  -oname | cut -d/ -f2`

```diff
--- cm-names	2026-06-07 21:27:52.962847446 +0200
+++ cm-names2	2026-06-07 21:36:52.804202225 +0200
@@ -1,51 +1,113 @@
-alloy-cluster-node-dashboard
-alloy-cluster-overview-dashboard
-alloy-controller-dashboard
-alloy-logs-dashboard
-alloy-loki-dashboard
-alloy-opentelemetry-dashboard
-alloy-otel-engine-overview-dashboard
-alloy-prometheus-remote-write-dashboard
-alloy-resources-dashboard
-grafana-15bfff8f-cluster-total-dashboard
-grafana-15bfff8f-controller-manager-dashboard
-grafana-15bfff8f-k8s-resources-cluster-dashboard
-grafana-15bfff8f-k8s-resources-multicluster-dashboard
-grafana-15bfff8f-k8s-resources-namespace-dashboard
-grafana-15bfff8f-k8s-resources-node-dashboard
-grafana-15bfff8f-k8s-resources-pod-dashboard
-grafana-15bfff8f-k8s-resources-workload-dashboard
-grafana-15bfff8f-k8s-resources-workloads-namespace-dashboard
-grafana-15bfff8f-kubelet-dashboard
-grafana-15bfff8f-namespace-by-pod-dashboard
-grafana-15bfff8f-namespace-by-workload-dashboard
-grafana-15bfff8f-persistentvolumesusage-dashboard
-grafana-15bfff8f-pod-total-dashboard
-grafana-15bfff8f-scheduler-dashboard
-grafana-15bfff8f-statefulset-dashboard
-grafana-15bfff8f-workload-total-dashboard
+grafana-2ad000f5-cluster-total-dashboard
+grafana-2ad000f5-controller-manager-dashboard
+grafana-2ad000f5-k8s-resources-cluster-dashboard
+grafana-2ad000f5-k8s-resources-multicluster-dashboard
+grafana-2ad000f5-k8s-resources-namespace-dashboard
+grafana-2ad000f5-k8s-resources-node-dashboard
+grafana-2ad000f5-k8s-resources-pod-dashboard
+grafana-2ad000f5-k8s-resources-workload-dashboard
+grafana-2ad000f5-k8s-resources-workloads-namespace-dashboard
+grafana-2ad000f5-kubelet-dashboard
+grafana-2ad000f5-namespace-by-pod-dashboard
+grafana-2ad000f5-namespace-by-workload-dashboard
+grafana-2ad000f5-persistentvolumesusage-dashboard
+grafana-2ad000f5-pod-total-dashboard
+grafana-2ad000f5-scheduler-dashboard
+grafana-2ad000f5-statefulset-dashboard
+grafana-2ad000f5-workload-total-dashboard
+grafana-43c98b0c-strimzi-cruise-control-dashboard
+grafana-43c98b0c-strimzi-kafka-bridge-dashboard
+grafana-43c98b0c-strimzi-kafka-connect-dashboard
+grafana-43c98b0c-strimzi-kafka-dashboard
+grafana-43c98b0c-strimzi-kafka-exporter-dashboard
+grafana-43c98b0c-strimzi-kafka-mirror-maker-2-dashboard
+grafana-43c98b0c-strimzi-kraft-dashboard
+grafana-43c98b0c-strimzi-operators-dashboard
+grafana-4f5d80b7-loki-canary-dashboard
+grafana-4f5d80b7-loki-chunks-dashboard
+grafana-4f5d80b7-loki-cost-estimation-dashboard
+grafana-4f5d80b7-loki-deletion-dashboard
+grafana-4f5d80b7-loki-log-volume-dashboard
+grafana-4f5d80b7-loki-logs-dashboard
+grafana-4f5d80b7-loki-mixin-recording-rules-dashboard
+grafana-4f5d80b7-loki-operational-dashboard
+grafana-4f5d80b7-loki-reads-dashboard
+grafana-4f5d80b7-loki-resource-efficiency-dashboard
+grafana-4f5d80b7-loki-resources-overview-dashboard
+grafana-4f5d80b7-loki-retention-dashboard
+grafana-4f5d80b7-loki-slowqueries-dashboard
+grafana-4f5d80b7-loki-thanos-object-storage-dashboard
+grafana-4f5d80b7-loki-writes-dashboard
+grafana-67a33acd-memcached-overview-dashboard
+grafana-7f86714c-mimir-alertmanager-dashboard
+grafana-7f86714c-mimir-alertmanager-resources-dashboard
+grafana-7f86714c-mimir-compactor-dashboard
+grafana-7f86714c-mimir-compactor-resources-dashboard
+grafana-7f86714c-mimir-config-dashboard
+grafana-7f86714c-mimir-continuous-tests-dashboard
+grafana-7f86714c-mimir-cost-estimation-dashboard
+grafana-7f86714c-mimir-object-store-dashboard
+grafana-7f86714c-mimir-overrides-dashboard
+grafana-7f86714c-mimir-overview-dashboard
+grafana-7f86714c-mimir-overview-networking-dashboard
+grafana-7f86714c-mimir-overview-resources-dashboard
+grafana-7f86714c-mimir-queries-dashboard
+grafana-7f86714c-mimir-query-stats-dashboard
+grafana-7f86714c-mimir-rate-control-dashboard
+grafana-7f86714c-mimir-reads-dashboard
+grafana-7f86714c-mimir-reads-networking-dashboard
+grafana-7f86714c-mimir-reads-resources-dashboard
+grafana-7f86714c-mimir-remote-ruler-reads-dashboard
+grafana-7f86714c-mimir-remote-ruler-reads-networking-dashboard
+grafana-7f86714c-mimir-remote-ruler-reads-resources-dashboard
+grafana-7f86714c-mimir-resource-efficiency-dashboard
+grafana-7f86714c-mimir-rollout-progress-dashboard
+grafana-7f86714c-mimir-ruler-dashboard
+grafana-7f86714c-mimir-scaling-dashboard
+grafana-7f86714c-mimir-slow-queries-dashboard
+grafana-7f86714c-mimir-tenants-dashboard
+grafana-7f86714c-mimir-top-tenants-dashboard
+grafana-7f86714c-mimir-writes-dashboard
+grafana-7f86714c-mimir-writes-networking-dashboard
+grafana-7f86714c-mimir-writes-resources-dashboard
+grafana-960de0e7-alloy-cluster-node-dashboard
+grafana-960de0e7-alloy-cluster-overview-dashboard
+grafana-960de0e7-alloy-controller-dashboard
+grafana-960de0e7-alloy-logs-dashboard
+grafana-960de0e7-alloy-loki-dashboard
+grafana-960de0e7-alloy-opentelemetry-dashboard
+grafana-960de0e7-alloy-otel-engine-overview-dashboard
+grafana-960de0e7-alloy-prometheus-remote-write-dashboard
+grafana-960de0e7-alloy-resources-dashboard
+grafana-b86d3529-monitoring-landscape-audit-dashboard
 grafana-ca52838f-aws-cluster-info-dashboard
 grafana-ca52838f-node-problem-detector-dashboard
-grafana-ccc195b9-cluster-total-dashboard
-grafana-ccc195b9-controller-manager-dashboard
-grafana-ccc195b9-docker-io-images-dashboard
-grafana-ccc195b9-k8s-resources-cluster-dashboard
-grafana-ccc195b9-k8s-resources-multicluster-dashboard
-grafana-ccc195b9-k8s-resources-namespace-dashboard
-grafana-ccc195b9-k8s-resources-node-dashboard
-grafana-ccc195b9-k8s-resources-pod-dashboard
-grafana-ccc195b9-k8s-resources-workload-dashboard
-grafana-ccc195b9-k8s-resources-workloads-namespace-dashboard
-grafana-ccc195b9-kube-proxy-dashboard
-grafana-ccc195b9-kubelet-dashboard
-grafana-ccc195b9-namespace-by-pod-dashboard
-grafana-ccc195b9-namespace-by-workload-dashboard
-grafana-ccc195b9-persistentvolumesusage-dashboard
-grafana-ccc195b9-pod-total-dashboard
-grafana-ccc195b9-scheduler-dashboard
-grafana-ccc195b9-statefulset-dashboard
-grafana-ccc195b9-workload-total-dashboard
+grafana-f7dcf6ec-tempo-operational-dashboard
+grafana-f7dcf6ec-tempo-reads-dashboard
+grafana-f7dcf6ec-tempo-resources-dashboard
+grafana-f7dcf6ec-tempo-rollout-progress-dashboard
+grafana-f7dcf6ec-tempo-tenants-dashboard
+grafana-f7dcf6ec-tempo-writes-dashboard
 grafana-f90e6b9d-aws-ena-dashboard
+grafana-fe51245d-cluster-total-dashboard
+grafana-fe51245d-controller-manager-dashboard
+grafana-fe51245d-docker-io-images-dashboard
+grafana-fe51245d-k8s-resources-cluster-dashboard
+grafana-fe51245d-k8s-resources-multicluster-dashboard
+grafana-fe51245d-k8s-resources-namespace-dashboard
+grafana-fe51245d-k8s-resources-node-dashboard
+grafana-fe51245d-k8s-resources-pod-dashboard
+grafana-fe51245d-k8s-resources-workload-dashboard
+grafana-fe51245d-k8s-resources-workloads-namespace-dashboard
+grafana-fe51245d-kube-proxy-dashboard
+grafana-fe51245d-kubelet-dashboard
+grafana-fe51245d-namespace-by-pod-dashboard
+grafana-fe51245d-namespace-by-workload-dashboard
+grafana-fe51245d-persistentvolumesusage-dashboard
+grafana-fe51245d-pod-total-dashboard
+grafana-fe51245d-scheduler-dashboard
+grafana-fe51245d-statefulset-dashboard
+grafana-fe51245d-workload-total-dashboard
 grafana-priv-api-performance-dashboard
 grafana-priv-api-security-dashboard
 grafana-priv-capa-aggregated-error-logs-dashboard
@@ -135,67 +197,5 @@
 grafana-shared-slos-reporting-dashboard
 grafana-shared-unschedulable-pods-dashboard
 grafana-shared-webhooks-performance-dashboard
-loki-canary-dashboard
-loki-chunks-dashboard
-loki-cost-estimation-dashboard
-loki-deletion-dashboard
-loki-log-volume-dashboard
-loki-logs-dashboard
-loki-mixin-recording-rules-dashboard
-loki-operational-dashboard
-loki-reads-dashboard
-loki-resource-efficiency-dashboard
-loki-resources-overview-dashboard
-loki-retention-dashboard
-loki-slowqueries-dashboard
-loki-thanos-object-storage-dashboard
-loki-writes-dashboard
-memcached-overview-dashboard
-mimir-alertmanager-dashboard
-mimir-alertmanager-resources-dashboard
-mimir-compactor-dashboard
-mimir-compactor-resources-dashboard
-mimir-config-dashboard
-mimir-continuous-tests-dashboard
-mimir-cost-estimation-dashboard
-mimir-object-store-dashboard
-mimir-overrides-dashboard
-mimir-overview-dashboard
-mimir-overview-networking-dashboard
-mimir-overview-resources-dashboard
-mimir-queries-dashboard
-mimir-query-stats-dashboard
-mimir-rate-control-dashboard
-mimir-reads-dashboard
-mimir-reads-networking-dashboard
-mimir-reads-resources-dashboard
-mimir-remote-ruler-reads-dashboard
-mimir-remote-ruler-reads-networking-dashboard
-mimir-remote-ruler-reads-resources-dashboard
-mimir-resource-efficiency-dashboard
-mimir-rollout-progress-dashboard
-mimir-ruler-dashboard
-mimir-scaling-dashboard
-mimir-slow-queries-dashboard
-mimir-tenants-dashboard
-mimir-top-tenants-dashboard
-mimir-writes-dashboard
-mimir-writes-networking-dashboard
-mimir-writes-resources-dashboard
-monitoring-landscape-audit-dashboard
 sloth-dashboard-sloth
 sloth-dashboard-sloth-overview
-strimzi-cruise-control-dashboard
-strimzi-kafka-bridge-dashboard
-strimzi-kafka-connect-dashboard
-strimzi-kafka-dashboard
-strimzi-kafka-exporter-dashboard
-strimzi-kafka-mirror-maker-2-dashboard
-strimzi-kraft-dashboard
-strimzi-operators-dashboard
-tempo-operational-dashboard
-tempo-reads-dashboard
-tempo-resources-dashboard
-tempo-rollout-progress-dashboard
-tempo-tenants-dashboard
-tempo-writes-dashboard

```

</p>
</details> 
