### PR TITLE
ci: add validate-dashboards

### DIFF
--- a/.github/workflows/validate-dashboards.yaml
+++ b/.github/workflows/validate-dashboards.yaml
@@ -1,0 +1,97 @@
+name: Validate dashboards
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'helm/dashboards/**/*.json'
+      - 'scripts/validate-dashboards.sh'
+      - 'github/workflows/validate-dashboards.yaml'
+
+permissions: {}
+
+jobs:
+  # Checks every dashboard has a valid owner: tag and a uid.
+  validate-dashboards:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      fragment: ${{ steps.validate.outputs.fragment }}
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Validate owner tags and uids
+      id: validate
+      env:
+        GH_TOKEN: ${{ secrets.ISSUE_AUTOMATION }}
+      run: |
+        # Capture the script's exit code without aborting (so we can still build
+        # the PR-comment fragment), then re-exit with it at the end to fail the job.
+        set +e
+        ./scripts/validate-dashboards.sh | tee validate.log
+        status=${PIPESTATUS[0]}
+        set -e
+        problems="$(sed -n '/^BEGIN_DASHBOARD_PROBLEMS$/,/^END_DASHBOARD_PROBLEMS$/p' validate.log | sed '1d;$d')"
+        if [ -n "$problems" ]; then
+          echo "::error::Dashboard validation found issues. See the PR comment or the job log."
+          max=50
+          total=$(printf '%s\n' "$problems" | wc -l)
+          {
+            echo "fragment<<DASHBOARD_FRAGMENT_EOF"
+            echo "### Owner / uid — \`validate-dashboards\`"
+            echo
+            printf '%s\n' "$problems" | head -n "$max"
+            if [ "$total" -gt "$max" ]; then
+              echo
+              echo "_…and $((total - max)) more line(s) truncated. See the \`validate-dashboards\` job log for the full list._"
+            fi
+            echo "DASHBOARD_FRAGMENT_EOF"
+          } >> "$GITHUB_OUTPUT"
+        fi
+        exit "$status"
+
+  # Surfaces the check result as a single sticky PR comment so the failures are
+  # visible in the PR timeline alongside the red check.
+  report:
+    needs: [validate-dashboards]
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      VALIDATE_FRAGMENT: ${{ needs.validate-dashboards.outputs.fragment }}
+    steps:
+    - name: Upsert dashboard-checks comment
+      run: |
+        marker='<!-- dashboard-checks -->'
+        body=""
+        if [ -n "$VALIDATE_FRAGMENT" ]; then
+          body+="$marker"$'\n'
+          body+='## ❌ Dashboard checks failed'$'\n\n'
+          [ -n "$VALIDATE_FRAGMENT" ] && body+="$VALIDATE_FRAGMENT"$'\n\n'
+          body+='_These checks are failing. Fix the issues above and push again._'
+        fi
+
+        # Find a previous sticky comment by its hidden marker.
+        existing="$(gh api "repos/$REPO/issues/$PR/comments" \
+          --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1)"
+
+        if [ -n "$body" ]; then
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" >/dev/null
+            echo "Updated dashboard-checks comment."
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$body" >/dev/null
+            echo "Created dashboard-checks comment."
+          fi
+        elif [ -n "$existing" ]; then
+          gh api -X DELETE "repos/$REPO/issues/comments/$existing" >/dev/null
+          echo "Checks clean — removed previous dashboard-checks comment."
+        else
+          echo "Checks clean — nothing to report."
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- CI now check that dashboards are supported version (v1 or v2)
+- CI now checks that dashboards are supported version (v1 or v2)
+- CI now checks that dashboards have an "owner" tag
 - Make Observability dashboards public
 - Move observability related dashboards under Observability folder
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- CI now checks that dashboards are supported version (v1 or v2)
-- CI now checks that dashboards have an "owner" tag
+- CI checks to validate dashboards supported version (v1 or v2)
+- CI checks to validate dashboards have an "owner" tag
 - Make Observability dashboards public
 - Move observability related dashboards under Observability folder
 


### PR DESCRIPTION
CI now runs validate-dashboards script, that checks the `owner` tag in dashboards.

Based on https://github.com/giantswarm/dashboards/pull/904

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
