### PR TITLE
fix: empty folder annotation for org-root dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Fixed Alloy Metrics Targets datasource
+- Fixed broken `folder` annotation for organization-root dashboards
 
 ## [4.24.0] - 2026-06-04
 

--- a/helm/dashboards/templates/_dashboards.tpl
+++ b/helm/dashboards/templates/_dashboards.tpl
@@ -70,8 +70,8 @@ items:
 {{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
 {{- $org := regexReplaceAll "^dashboards/([^/]+)/.*$" $path "${1}" }}
 {{- $folder := "" }}
-{{- if regexMatch "^dashboards/[^/]+/.+/[^/]+\\.json$" $path }}
-{{- $folder = regexReplaceAll "^dashboards/[^/]+/(.*)/[^/]+\\.json$" $path "${1}" }}
+{{- if regexMatch "^dashboards/[^/]+/(.+)/[^/]+\\.json$" $path }}
+{{- $folder = regexReplaceAll "^dashboards/[^/]+/(.+)/[^/]+\\.json$" $path "${1}" }}
 {{- end }}
 {{- include "dashboards.configMap" (dict "teamName" $.teamName "org" $org "folder" $folder "dashboardName" $dashboardName "path" $path "ctx" $.ctx) }}
 {{- end }}
@@ -101,8 +101,8 @@ items:
 {{- $relativePath := trimPrefix $providerPrefix $path }}
 {{- $org := regexReplaceAll "^([^/]+)/.*$" $relativePath "${1}" }}
 {{- $folder := "" }}
-{{- if regexMatch "^[^/]+/.+/[^/]+\\.json$" $relativePath }}
-{{- $folder = regexReplaceAll "^[^/]+/(.*)/[^/]+\\.json$" $relativePath "${1}" }}
+{{- if regexMatch "^[^/]+/(.+)/[^/]+\\.json$" $relativePath }}
+{{- $folder = regexReplaceAll "^[^/]+/(.+)/[^/]+\\.json$" $relativePath "${1}" }}
 {{- end }}
 {{- include "dashboards.configMap" (dict "teamName" $.teamName "org" $org "folder" $folder "dashboardName" $dashboardName "path" $path "providerKind" $providerKind "ctx" $.ctx) }}
 {{- end }}

--- a/helm/dashboards/templates/_dashboards.tpl
+++ b/helm/dashboards/templates/_dashboards.tpl
@@ -69,6 +69,25 @@ items:
 {{- if not (hasPrefix "dashboards/provider/" $path) }}
 {{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
 {{- $org := regexReplaceAll "^dashboards/([^/]+)/.*$" $path "${1}" }}
+{{/*
+Extract the Grafana folder from the path. Expected path layout is
+  dashboards/<organization>/<folder...>/<dashboard>.json
+where <folder...> is optional and may itself contain nested segments
+(e.g. "Observability/Mimir"). A dashboard can sit directly at the
+organization root (dashboards/<organization>/<dashboard>.json), then its
+folder resolves to an empty string.
+
+For the folder:
+- regexMatch is the guard: it is true only when a <folder...> segment
+  exists between the organization and the file name.
+- regexReplaceAll extracts that segment via the "${1}" capture group.
+
+The guard is required because regexReplaceAll returns the input string
+*unchanged* when the pattern does not match. Without it, an org-root
+path would not match and $folder would be set to the whole path instead
+of "". Both patterns are identical so the gate and the extraction stay
+in sync.
+*/}}
 {{- $folder := "" }}
 {{- if regexMatch "^dashboards/[^/]+/(.+)/[^/]+\\.json$" $path }}
 {{- $folder = regexReplaceAll "^dashboards/[^/]+/(.+)/[^/]+\\.json$" $path "${1}" }}

--- a/helm/dashboards/templates/_dashboards.tpl
+++ b/helm/dashboards/templates/_dashboards.tpl
@@ -69,7 +69,10 @@ items:
 {{- if not (hasPrefix "dashboards/provider/" $path) }}
 {{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
 {{- $org := regexReplaceAll "^dashboards/([^/]+)/.*$" $path "${1}" }}
-{{- $folder := regexReplaceAll "^dashboards/[^/]+/(.*)/[^/]+\\.json$" $path "${1}" }}
+{{- $folder := "" }}
+{{- if regexMatch "^dashboards/[^/]+/.+/[^/]+\\.json$" $path }}
+{{- $folder = regexReplaceAll "^dashboards/[^/]+/(.*)/[^/]+\\.json$" $path "${1}" }}
+{{- end }}
 {{- include "dashboards.configMap" (dict "teamName" $.teamName "org" $org "folder" $folder "dashboardName" $dashboardName "path" $path "ctx" $.ctx) }}
 {{- end }}
 {{- end }}
@@ -97,7 +100,10 @@ items:
 {{- $providerPrefix := printf "dashboards/provider/%s/" $providerKind }}
 {{- $relativePath := trimPrefix $providerPrefix $path }}
 {{- $org := regexReplaceAll "^([^/]+)/.*$" $relativePath "${1}" }}
-{{- $folder := regexReplaceAll "^[^/]+/(.*)/[^/]+\\.json$" $relativePath "${1}" }}
+{{- $folder := "" }}
+{{- if regexMatch "^[^/]+/.+/[^/]+\\.json$" $relativePath }}
+{{- $folder = regexReplaceAll "^[^/]+/(.*)/[^/]+\\.json$" $relativePath "${1}" }}
+{{- end }}
 {{- include "dashboards.configMap" (dict "teamName" $.teamName "org" $org "folder" $folder "dashboardName" $dashboardName "path" $path "providerKind" $providerKind "ctx" $.ctx) }}
 {{- end }}
 {{- end }}

--- a/helm/dashboards/templates/_dashboards.tpl
+++ b/helm/dashboards/templates/_dashboards.tpl
@@ -119,6 +119,25 @@ items:
 {{- $providerPrefix := printf "dashboards/provider/%s/" $providerKind }}
 {{- $relativePath := trimPrefix $providerPrefix $path }}
 {{- $org := regexReplaceAll "^([^/]+)/.*$" $relativePath "${1}" }}
+{{/*
+Extract the Grafana folder from the path. Expected path layout is
+  dashboards/<organization>/<folder...>/<dashboard>.json
+where <folder...> is optional and may itself contain nested segments
+(e.g. "Observability/Mimir"). A dashboard can sit directly at the
+organization root (dashboards/<organization>/<dashboard>.json), then its
+folder resolves to an empty string.
+
+For the folder:
+- regexMatch is the guard: it is true only when a <folder...> segment
+  exists between the organization and the file name.
+- regexReplaceAll extracts that segment via the "${1}" capture group.
+
+The guard is required because regexReplaceAll returns the input string
+*unchanged* when the pattern does not match. Without it, an org-root
+path would not match and $folder would be set to the whole path instead
+of "". Both patterns are identical so the gate and the extraction stay
+in sync.
+*/}}
 {{- $folder := "" }}
 {{- if regexMatch "^[^/]+/(.+)/[^/]+\\.json$" $relativePath }}
 {{- $folder = regexReplaceAll "^[^/]+/(.+)/[^/]+\\.json$" $relativePath "${1}" }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/35720

Dashboards placed directly at an organization root (no folder segment between `<Organization>` and the `*.json` file) got a broken `observability.giantswarm.io/folder` annotation containing the full file path instead of an empty folder name.

`regexReplaceAll` returns the input unchanged when the pattern does not match, and the folder pattern required at least one folder segment — so org-root files fell through with the whole path as their "folder".

This guards the extraction with a `regexMatch` in both `dashboards.standard` and `dashboards.provider`, defaulting the folder to `""` when no folder segment exists. Nested folders are unaffected.

Affected dashboards (now render `folder: ""`):
- `team_atlas/dashboards/Shared Org/cluster-overview.json`
- `team_cabbage/dashboards/Shared Org/k6-tests-results.json`
- `team_honeybadger/dashboards/Shared Org/backstage.json`
- `team_honeybadger/dashboards/Shared Org/managed-apps.json`

The dashboards are now correctly placed in the Grafana root directory

<img width="1920" height="1124" alt="image" src="https://github.com/user-attachments/assets/3edcbd21-27a6-40de-b82f-c912029497c3" />

Note that the `dashboards` Grafana folder and its sub folders were not delete, that's mostly a bug in the operator. I'll fix this in the operator then.

Here is the before after for the `cluster-overview-dashboard` ConfigMap (taken as example):

### Before

```yaml
$ km get cm grafana-c15d0af8-cluster-overview-dashboard -oyaml|yq -y -r '.metadata'
annotations:
  application.giantswarm.io/team: atlas
  meta.helm.sh/release-name: dashboards
  meta.helm.sh/release-namespace: monitoring
  observability.giantswarm.io/folder: dashboards/Shared Org/cluster-overview.json <==== Wrong folder
  observability.giantswarm.io/organization: Shared Org
creationTimestamp: '2026-06-19T09:53:01Z'
finalizers:
  - observability.giantswarm.io/grafanadashboard
labels:
  app.giantswarm.io/kind: dashboard
  app.kubernetes.io/instance: dashboards
  app.kubernetes.io/managed-by: Helm
  app.kubernetes.io/name: team_atlas
  app.kubernetes.io/version: 1.0.0
  application.giantswarm.io/team: atlas
  giantswarm.io/service-type: managed
  helm.sh/chart: team_atlas-1.0.0
  helm.toolkit.fluxcd.io/name: dashboards
  helm.toolkit.fluxcd.io/namespace: giantswarm
name: grafana-c15d0af8-cluster-overview-dashboard
namespace: monitoring
resourceVersion: '1280736739'
uid: 721a89b0-1f25-405c-84f9-8d2c4d1c4443

```

### After

```yaml
$ km get cm grafana-bd621079-cluster-overview-dashboard -oyaml|yq -y -r '.metadata'
annotations:
  application.giantswarm.io/team: atlas
  meta.helm.sh/release-name: dashboards
  meta.helm.sh/release-namespace: monitoring
  observability.giantswarm.io/folder: ''                                   <==== Correct empty folder
  observability.giantswarm.io/organization: Shared Org
creationTimestamp: '2026-06-19T09:18:39Z'
finalizers:
  - observability.giantswarm.io/grafanadashboard
labels:
  app.giantswarm.io/kind: dashboard
  app.kubernetes.io/instance: dashboards
  app.kubernetes.io/managed-by: Helm
  app.kubernetes.io/name: team_atlas
  app.kubernetes.io/version: 1.0.0
  application.giantswarm.io/team: atlas
  giantswarm.io/service-type: managed
  helm.sh/chart: team_atlas-1.0.0
  helm.toolkit.fluxcd.io/name: dashboards
  helm.toolkit.fluxcd.io/namespace: giantswarm
name: grafana-bd621079-cluster-overview-dashboard
namespace: monitoring
resourceVersion: '1280663759'
uid: e1361124-0c8d-469e-b645-0905b747ad7e
```