### PR TITLE
fix: worker count expression on the Nodes Overview dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Anchor the `etcd-health` dashboard cluster selector to `etcd_server_id` instead of `up`, so clusters with a managed control plane (aks, eks) no longer appear as empty options.
 
+### Fixed
+
+- Fix the worker count expression on the `Nodes Overview` dashboard.
+
 ## [4.28.0] - 2026-07-01
 
 ### Changed

--- a/helm/dashboards/charts/cloud/dashboards/Shared Org/Kubernetes/nodes-overview.json
+++ b/helm/dashboards/charts/cloud/dashboards/Shared Org/Kubernetes/nodes-overview.json
@@ -78,7 +78,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "count(kube_node_role{cluster_id=\"$cluster\",organization=~\"$organization\",role=\"worker\"})",
+          "expr": "count(kube_node_info{cluster_id=\"$cluster\",organization=~\"$organization\"} unless on(node, cluster_id) kube_node_role{cluster_id=\"$cluster\",organization=~\"$organization\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
This PR:

Updates the expression used to count the number of workers in a cluster.

The previous expression used the role of worker to count the number of filtered nodes, however now that we no longer label workers this doesn't work. The new approach counts the total number of nodes in the cluster and only keeps those which have no role. This works because the CP nodes have roles assigned and are therefore filtered out.

### Checklist

- [x] Update changelog in CHANGELOG.md in an end-user friendly language.
