### PR TITLE
fix: repair and refresh the customer-facing Flux dashboards

### DIFF
--- a/.github/workflows/update-mixins.yaml
+++ b/.github/workflows/update-mixins.yaml
@@ -23,7 +23,12 @@ jobs:
       run: echo "$(pwd)/tools" >> $GITHUB_PATH
 
     - name: Update mixins
-      run: make update-mixin
+      run: make update-all-mixin
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update Flux dashboards
+      run: make update-flux-dashboards
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -36,7 +41,12 @@ jobs:
         author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
         commit-message: "Update mixin dashboards"
         body: |
-          Automated monthly update of Tempo, Mimir, Loki and Alloy mixin dashboards.
+          Automated monthly update of Tempo, Mimir, Loki and Alloy mixin dashboards,
+          plus the Flux dashboards from fluxcd/flux2-monitoring-example.
 
           Version pins are derived from the appVersion in the corresponding
           giantswarm/*-app repositories.
+
+          The Flux dashboards carry Giant Swarm patches (multi-cluster variables,
+          exporter de-duplication, namespace scoping). `update-flux-dashboards.sh`
+          asserts those patches still applied, so review that diff with care.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,47 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Publish the `Flux Logs` dashboard to `Shared Org / GitOps`. It covers the Flux
+  controllers on the management cluster; workload-cluster Flux logs are not
+  ingested yet, because the `flux-system` namespace there has no tenant
+  assignment and Alloy drops untenanted pod logs.
+- Add `scripts/update-flux-dashboards.sh` (`make update-flux-dashboards`), which
+  syncs the Flux dashboards from
+  [fluxcd/flux2-monitoring-example](https://github.com/fluxcd/flux2-monitoring-example)
+  and re-applies our patches. It runs in the monthly dashboard-update workflow
+  and fails loudly if a patch stops applying.
+- Add `Organization` and `Cluster` selectors to both Flux dashboards. They are
+  deployed to the management cluster's Grafana, whose Mimir holds metrics for
+  every workload cluster, so until now every panel aggregated across a
+  customer's whole fleet.
+
 ### Changed
 
+- Synced Flux dashboards from [fluxcd/flux2-monitoring-example@7ab65dc](https://github.com/fluxcd/flux2-monitoring-example/tree/7ab65dc8b90f7a6751d88f18bbb4e1bee33bf334/monitoring/configs/dashboards).
 - Anchor the `etcd-health` dashboard cluster selector to `etcd_server_id` instead of `up`, so clusters with a managed control plane (aks, eks) no longer appear as empty options.
 
 ### Fixed
 
+- Fix the `Flux Cluster Stats` dashboard, which showed no data at all: every
+  panel queried `gotk_reconcile_condition`, a metric the Flux controllers no
+  longer expose. It now uses `gotk_resource_info`, the same metric our Flux
+  alerting rules use, and gains upstream's `Suspended Objects` panel.
+- De-duplicate `gotk_resource_info` on the `Flux Cluster Stats` dashboard. On
+  management clusters both `flux-ksm` and `kube-state-metrics` export identical
+  series, so the resource counts read exactly double.
+- Scope the `Flux Control Plane` dashboard to the Flux namespace. Its
+  `controller_runtime_*` panels matched any operator exposing the same
+  `controller` label values (for example `controller="helmrelease"` is also
+  emitted by `dex-operator` and `team-stamper`).
+- Widen the `Flux Control Plane` range windows from `[1m]` to
+  `[$__rate_interval]`. With our 60s scrape interval a one-minute window cannot
+  hold two samples, so the reconciliation and API-request panels were empty.
 - Fix the worker count expression on the `Nodes Overview` dashboard.
+- Fix the monthly dashboard-update workflow, which called a `make update-mixin`
+  target that no longer exists (it was renamed to `update-all-mixin`), so the
+  automation failed instead of opening a PR.
 
 ## [4.28.0] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   emitted by `dex-operator` and `team-stamper`).
 - Widen the `Flux Control Plane` range windows from `[1m]` to
   `[$__rate_interval]`. With our 60s scrape interval a one-minute window cannot
-  hold two samples, so the reconciliation and API-request panels were empty.
+  hold two samples, so the reconciliation and API-request panels were empty. The
+  `ops/min` panels use `rate(...) * 60` so they stay per-minute rather than
+  reporting the count over the whole (range-dependent) window.
+- Point the `Flux Cluster Stats` targets at the `$datasource` variable. Seven of
+  them were pinned to a `prometheus` datasource uid that does not exist here,
+  and the target-level datasource overrides the panel.
+- Restrict the `Flux namespace` selector on `Flux Control Plane` to the Flux
+  controller pods. It was derived from a generic controller-runtime metric, so on
+  a management cluster it also offered `external-secrets`, `giantswarm` and
+  `kube-system`, and the dashboard could open on another operator's data.
 - Fix the worker count expression on the `Nodes Overview` dashboard.
 - Fix the monthly dashboard-update workflow, which called a `make update-mixin`
   target that no longer exists (it was renamed to `update-all-mixin`), so the

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,4 +1,4 @@
-.PHONY: install-tools lint-dashboards check-dashboard-schema update-all-dashboards update-alloy-mixin update-kafka-dashboardsn update-kubernetes-mixin update-loki-mixi update-memcached-mixin update-mimir-mixin update-tempo-mixin update-mixin-versions
+.PHONY: install-tools lint-dashboards check-dashboard-schema update-all-dashboards update-all-mixin update-alloy-mixin update-flux-dashboards update-kafka-dashboards update-kubernetes-mixin update-loki-mixin update-memcached-mixin update-mimir-mixin update-tempo-mixin update-mixin-versions
 
 SHELL:=/bin/bash -O globstar
 
@@ -11,12 +11,15 @@ install-tools: ## Install dependencies tools
 
 ##@ Dashboards update
 
-update-all-dashboards: update-mixin update-kafka-dashboards ## Update all dashboards (mixins and Kafka)
+update-all-dashboards: update-all-mixin update-kafka-dashboards update-flux-dashboards ## Update all dashboards (mixins, Kafka and Flux)
 
 update-all-mixin: update-mixin-versions update-alloy-mixin update-kubernetes-mixin update-loki-mixin update-memcached-mixin update-mimir-mixin update-tempo-mixin ## Update all mixins dashboards (fetches latest app versions first)
 
 update-alloy-mixin: install-tools ## Update Alloy mixin dashboards
 	./mixins/alloy/update.sh
+
+update-flux-dashboards: ## Update Flux dashboards from the upstream fluxcd/flux2-monitoring-example
+	./scripts/update-flux-dashboards.sh
 
 update-kafka-dashboards: ## Update Strimzi/Kafka dashboards from the giantswarm strimzi-kafka-operator fork
 	./scripts/update-kafka-dashboards.sh

--- a/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-cluster.json
+++ b/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-cluster.json
@@ -3,25 +3,41 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "datasource",
-          "uid": "grafana"
-        },
+        "datasource": "-- Grafana --",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "iconColor": "red",
+        "name": "flux events",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [
+            "flux"
+          ],
+          "type": "tags"
+        }
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "",
@@ -29,6 +45,7 @@
         "defaults": {
           "decimals": 0,
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -65,19 +82,23 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "value",
-        "wideLayout": true
+        "text": {},
+        "textMode": "value"
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
-          "expr": "count(gotk_reconcile_condition{namespace=~\"$namespace\",type=\"Ready\",status=\"True\",kind=~\"Kustomization|HelmRelease\"})\n-\nsum(gotk_reconcile_condition{namespace=~\"$namespace\",type=\"Ready\",status=\"Deleted\",kind=~\"Kustomization|HelmRelease\"})",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(max by (exported_namespace, customresource_kind, name, ready, suspended) (gotk_resource_info{cluster_id=\"$cluster\", exported_namespace=~\"$namespace\", customresource_kind=~\"Kustomization|HelmRelease\"}))",
+          "instant": true,
           "interval": "",
           "legendFormat": "",
+          "range": false,
           "refId": "A"
         }
       ],
@@ -86,6 +107,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "",
@@ -93,6 +115,7 @@
         "defaults": {
           "decimals": 0,
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -125,19 +148,23 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "value",
-        "wideLayout": true
+        "text": {},
+        "textMode": "value"
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
-          "expr": "sum(gotk_reconcile_condition{namespace=~\"$namespace\",type=\"Ready\",status=\"False\",kind=~\"Kustomization|HelmRelease\"})",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(max by (exported_namespace, customresource_kind, name, ready, suspended) (gotk_resource_info{cluster_id=\"$cluster\", exported_namespace=~\"$namespace\", customresource_kind=~\"Kustomization|HelmRelease\", ready=\"False\"}))",
+          "instant": true,
           "interval": "",
           "legendFormat": "",
+          "range": false,
           "refId": "A"
         }
       ],
@@ -146,6 +173,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "",
@@ -153,6 +181,7 @@
         "defaults": {
           "decimals": 0,
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -189,19 +218,23 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "value",
-        "wideLayout": true
+        "text": {},
+        "textMode": "value"
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
-          "expr": "count(gotk_reconcile_condition{namespace=~\"$namespace\",type=\"Ready\",status=\"True\",kind=~\"GitRepository|HelmRepository|HelmChart|Bucket\"})\n-\nsum(gotk_reconcile_condition{namespace=~\"$namespace\",type=\"Ready\",status=\"Deleted\",kind=~\"GitRepository|HelmRepository|HelmChart|Bucket\"})",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(max by (exported_namespace, customresource_kind, name, ready, suspended) (gotk_resource_info{cluster_id=\"$cluster\", exported_namespace=~\"$namespace\", customresource_kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}))",
+          "instant": true,
           "interval": "",
           "legendFormat": "",
+          "range": false,
           "refId": "A"
         }
       ],
@@ -210,6 +243,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "",
@@ -217,6 +251,7 @@
         "defaults": {
           "decimals": 0,
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -249,19 +284,23 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "value",
-        "wideLayout": true
+        "text": {},
+        "textMode": "value"
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
-          "expr": "sum(gotk_reconcile_condition{namespace=~\"$namespace\",type=\"Ready\",status=\"False\",kind=~\"GitRepository|HelmRepository|HelmChart|Bucket\"})",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(max by (exported_namespace, customresource_kind, name, ready, suspended) (gotk_resource_info{cluster_id=\"$cluster\", exported_namespace=~\"$namespace\", customresource_kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\", ready=\"False\"}))",
+          "instant": true,
           "interval": "",
           "legendFormat": "",
+          "range": false,
           "refId": "A"
         }
       ],
@@ -269,9 +308,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -306,10 +343,8 @@
       "id": 8,
       "options": {
         "displayMode": "gradient",
-        "maxVizHeight": 300,
-        "minVizHeight": 16,
-        "minVizWidth": 8,
-        "namePlacement": "auto",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -319,16 +354,14 @@
           "values": false
         },
         "showUnfilled": true,
-        "sizing": "auto",
+        "text": {},
         "valueMode": "color"
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "  sum(rate(gotk_reconcile_duration_seconds_sum{namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)",
+          "exemplar": true,
+          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind))",
           "interval": "",
           "legendFormat": "{{kind}}",
           "refId": "A"
@@ -338,9 +371,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -375,10 +406,8 @@
       "id": 31,
       "options": {
         "displayMode": "gradient",
-        "maxVizHeight": 300,
-        "minVizHeight": 16,
-        "minVizWidth": 8,
-        "namePlacement": "auto",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -388,16 +417,14 @@
           "values": false
         },
         "showUnfilled": true,
-        "sizing": "auto",
+        "text": {},
         "valueMode": "color"
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "  sum(rate(gotk_reconcile_duration_seconds_sum{namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|HelmChart|Bucket\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|HelmChart|Bucket\"}[5m])) by (kind)",
+          "exemplar": true,
+          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind))",
           "interval": "",
           "legendFormat": "{{kind}}",
           "refId": "A"
@@ -408,9 +435,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -419,25 +444,19 @@
       },
       "id": 15,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Status",
       "type": "row"
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "align": "auto",
             "cellOptions": {
               "type": "auto"
             },
@@ -447,11 +466,15 @@
           "mappings": [
             {
               "options": {
-                "0": {
-                  "text": "Ready"
-                },
-                "1": {
+                "False": {
+                  "color": "red",
+                  "index": 1,
                   "text": "Not Ready"
+                },
+                "True": {
+                  "color": "blue",
+                  "index": 0,
+                  "text": "Ready"
                 }
               },
               "type": "value"
@@ -461,16 +484,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "transparent",
                 "value": null
-              },
-              {
-                "color": "blue",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 1
               }
             ]
           }
@@ -478,14 +493,14 @@
         "overrides": [
           {
             "matcher": {
-              "id": "byName",
-              "options": "Status"
+              "id": "byType",
+              "options": "string"
             },
             "properties": [
               {
                 "id": "custom.cellOptions",
                 "value": {
-                  "mode": "gradient",
+                  "mode": "basic",
                   "type": "color-background"
                 }
               }
@@ -494,7 +509,7 @@
         ]
       },
       "gridPos": {
-        "h": 8,
+        "h": 22,
         "w": 12,
         "x": 0,
         "y": 10
@@ -510,15 +525,24 @@
           ],
           "show": false
         },
-        "showHeader": true
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Status"
+          }
+        ]
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
-          "expr": "gotk_reconcile_condition{namespace=~\"$namespace\",type=\"Ready\",status=\"False\",kind=~\"Kustomization|HelmRelease\"}",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "max by (exported_namespace, customresource_kind, name, ready, suspended) (gotk_resource_info{cluster_id=\"$cluster\", exported_namespace=~\"$namespace\", customresource_kind=~\"Kustomization|HelmRelease\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -532,27 +556,67 @@
           "id": "organize",
           "options": {
             "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "app": true,
-              "container": true,
-              "endpoint": true,
-              "exported_namespace": true,
-              "instance": true,
-              "job": true,
-              "kubernetes_namespace": true,
-              "kubernetes_pod_name": true,
-              "pod": true,
-              "pod_template_hash": true,
-              "status": true,
-              "type": true
+              "Time": false,
+              "Value": false,
+              "__name__": false,
+              "app": false,
+              "chart_name": false,
+              "chart_source_name": false,
+              "container": false,
+              "customresource_group": false,
+              "customresource_kind": false,
+              "customresource_version": false,
+              "endpoint": false,
+              "exported_namespace": false,
+              "gotk_type": false,
+              "instance": false,
+              "job": false,
+              "kubernetes_namespace": false,
+              "kubernetes_pod_name": false,
+              "namespace": false,
+              "pod": false,
+              "pod_template_hash": false,
+              "revision": false,
+              "service": false,
+              "source_name": false,
+              "status": false,
+              "suspended": false,
+              "type": false
             },
-            "indexByName": {},
+            "indexByName": {
+              "Time": 0,
+              "Value": 15,
+              "__name__": 1,
+              "container": 2,
+              "customresource_group": 4,
+              "customresource_kind": 5,
+              "customresource_version": 6,
+              "endpoint": 7,
+              "exported_namespace": 3,
+              "instance": 8,
+              "job": 9,
+              "name": 10,
+              "namespace": 11,
+              "pod": 12,
+              "ready": 13,
+              "service": 14
+            },
             "renameByName": {
-              "Value": "Status",
+              "Value": "",
+              "customresource_kind": "Kind",
+              "exported_namespace": "Namespace",
               "kind": "Kind",
               "name": "Name",
-              "namespace": "Namespace"
+              "namespace": "Operator Namespace",
+              "ready": "Status"
+            }
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "(Namespace|Kind|Name|Status)"
             }
           }
         }
@@ -561,12 +625,17 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
+            "align": "auto",
             "cellOptions": {
               "type": "auto"
             },
@@ -576,11 +645,15 @@
           "mappings": [
             {
               "options": {
-                "0": {
-                  "text": "Ready"
-                },
-                "1": {
+                "False": {
+                  "color": "red",
+                  "index": 1,
                   "text": "Not Ready"
+                },
+                "True": {
+                  "color": "blue",
+                  "index": 0,
+                  "text": "Ready"
                 }
               },
               "type": "value"
@@ -590,16 +663,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "transparent",
                 "value": null
-              },
-              {
-                "color": "blue",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 1
               }
             ]
           }
@@ -607,15 +672,34 @@
         "overrides": [
           {
             "matcher": {
-              "id": "byName",
-              "options": "Status"
+              "id": "byType",
+              "options": "string"
             },
             "properties": [
               {
                 "id": "custom.cellOptions",
                 "value": {
-                  "mode": "gradient",
+                  "mode": "basic",
                   "type": "color-background"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "noValue",
+                "value": "Ready"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
                 }
               }
             ]
@@ -623,7 +707,7 @@
         ]
       },
       "gridPos": {
-        "h": 8,
+        "h": 11,
         "w": 12,
         "x": 12,
         "y": 10
@@ -639,15 +723,24 @@
           ],
           "show": false
         },
-        "showHeader": true
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Status"
+          }
+        ]
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
-          "expr": "gotk_reconcile_condition{namespace=~\"$namespace\",type=\"Ready\",status=\"False\",kind=~\"GitRepository|HelmRepository|HelmChart|Bucket\"}",
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "max by (exported_namespace, customresource_kind, name, ready, suspended) (gotk_resource_info{cluster_id=\"$cluster\", exported_namespace=~\"$namespace\", customresource_kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -661,27 +754,227 @@
           "id": "organize",
           "options": {
             "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "app": true,
-              "container": true,
-              "endpoint": true,
-              "exported_namespace": true,
-              "instance": true,
-              "job": true,
-              "kubernetes_namespace": true,
-              "kubernetes_pod_name": true,
-              "pod": true,
-              "pod_template_hash": true,
-              "status": true,
-              "type": true
+              "Time": false,
+              "Value": false,
+              "__name__": false,
+              "app": false,
+              "bucket_name": false,
+              "container": false,
+              "customresource_group": false,
+              "customresource_kind": false,
+              "customresource_version": false,
+              "endpoint": false,
+              "exported_namespace": false,
+              "gotk_type": false,
+              "instance": false,
+              "job": false,
+              "kubernetes_namespace": false,
+              "kubernetes_pod_name": false,
+              "namespace": false,
+              "pod": false,
+              "pod_template_hash": false,
+              "ready": false,
+              "revision": false,
+              "service": false,
+              "status": false,
+              "suspended": false,
+              "type": false,
+              "url": false
             },
-            "indexByName": {},
+            "indexByName": {
+              "Time": 0,
+              "Value": 15,
+              "__name__": 1,
+              "container": 2,
+              "customresource_group": 5,
+              "customresource_kind": 6,
+              "customresource_version": 7,
+              "endpoint": 8,
+              "exported_namespace": 4,
+              "instance": 9,
+              "job": 10,
+              "name": 11,
+              "namespace": 3,
+              "pod": 12,
+              "ready": 13,
+              "service": 14
+            },
             "renameByName": {
-              "Value": "Status",
+              "Value": "",
+              "customresource_kind": "Kind",
+              "exported_namespace": "Namespace",
               "kind": "Kind",
               "name": "Name",
-              "namespace": "Namespace"
+              "namespace": "Operator Namespace",
+              "ready": "Status"
+            }
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "(Namespace|Kind|Name|Status)"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byType",
+              "options": "string"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "id": 36,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Namespace"
+          }
+        ]
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "max by (exported_namespace, customresource_kind, name, ready, suspended) (gotk_resource_info{cluster_id=\"$cluster\", exported_namespace=~\"$namespace\", suspended=\"true\"})",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Suspended Objects",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": false,
+              "Value": false,
+              "__name__": false,
+              "app": false,
+              "bucket_name": false,
+              "container": false,
+              "customresource_group": false,
+              "customresource_kind": false,
+              "customresource_version": false,
+              "endpoint": false,
+              "exported_namespace": false,
+              "gotk_type": false,
+              "instance": false,
+              "job": false,
+              "kubernetes_namespace": false,
+              "kubernetes_pod_name": false,
+              "namespace": false,
+              "pod": false,
+              "pod_template_hash": false,
+              "ready": false,
+              "revision": false,
+              "service": false,
+              "source_name": false,
+              "status": false,
+              "suspended": false,
+              "type": false,
+              "url": false
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 15,
+              "__name__": 1,
+              "container": 2,
+              "customresource_group": 5,
+              "customresource_kind": 6,
+              "customresource_version": 7,
+              "endpoint": 8,
+              "exported_namespace": 4,
+              "instance": 9,
+              "job": 10,
+              "name": 11,
+              "namespace": 3,
+              "pod": 12,
+              "ready": 13,
+              "service": 14
+            },
+            "renameByName": {
+              "customresource_kind": "Kind",
+              "exported_namespace": "Namespace",
+              "name": "Name"
+            }
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "pattern": "(Namespace|Name|Kind)"
             }
           }
         }
@@ -690,32 +983,20 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 32
       },
       "id": 17,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Timing",
       "type": "row"
     },
     {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -723,7 +1004,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -737,7 +1017,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -817,7 +1096,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 33
       },
       "id": 27,
       "options": {
@@ -830,18 +1109,15 @@
           "showLegend": true
         },
         "tooltip": {
-          "maxHeight": 600,
           "mode": "multi",
-          "sort": "none"
+          "sort": "desc"
         }
       },
-      "pluginVersion": "7.2.1",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "  sum(rate(gotk_reconcile_duration_seconds_sum{namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name)",
+          "exemplar": true,
+          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{kind}}/{{name}}",
@@ -852,106 +1128,145 @@
       "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "autoMigrateFrom": "graph",
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsNull",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 41
       },
-      "hiddenSeries": false,
       "id": 35,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": false,
-        "hideEmpty": true,
-        "hideZero": true,
-        "max": false,
-        "min": false,
-        "rightSide": true,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.2.1",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.0.3",
       "targets": [
         {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "  sum(rate(gotk_reconcile_duration_seconds_sum{namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|HelmChart|Bucket\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|HelmChart|Bucket\"}[5m])) by (kind, name)",
+          "exemplar": true,
+          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{kind}}/{{name}}",
           "refId": "B"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
       "title": "Source acquisition duration",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "timeseries",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "type": "timeseries"
     }
   ],
-  "refresh": "10s",
-  "schemaVersion": 39,
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "light",
   "tags": [
     "flux",
+    "component:flux",
+    "topic:gitops",
     "owner:team-honeybadger"
   ],
   "templating": {
@@ -975,28 +1290,90 @@
         "type": "datasource"
       },
       {
-        "allValue": ".*",
         "current": {
           "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "text": "",
+          "value": ""
         },
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "definition": "gotk_reconcile_condition",
+        "definition": "label_values(gotk_reconcile_duration_seconds_count, organization)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Organization",
+        "multi": false,
+        "name": "organization",
+        "options": [],
+        "query": {
+          "query": "label_values(gotk_reconcile_duration_seconds_count, organization)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(gotk_reconcile_duration_seconds_count{organization=\"$organization\"}, cluster_id)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(gotk_reconcile_duration_seconds_count{organization=\"$organization\"}, cluster_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(gotk_resource_info{cluster_id=\"$cluster\"}, exported_namespace)",
         "hide": 0,
         "includeAll": true,
-        "multi": false,
+        "label": "Namespace",
+        "multi": true,
         "name": "namespace",
         "options": [],
-        "query": "gotk_reconcile_condition",
+        "query": {
+          "query": "label_values(gotk_resource_info{cluster_id=\"$cluster\"}, exported_namespace)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
-        "regex": "/.*namespace=\"([^\"]*).*/",
+        "regex": "",
         "skipUrlSync": false,
-        "sort": 5,
+        "sort": 0,
         "tagValuesQuery": "",
+        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -1007,7 +1384,6 @@
     "from": "now-15m",
     "to": "now"
   },
-  "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {
     "refresh_intervals": [
       "10s",
@@ -1024,6 +1400,5 @@
   "timezone": "UTC",
   "title": "Flux Cluster Stats",
   "uid": "flux-cluster",
-  "version": 1,
   "weekStart": ""
 }

--- a/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-cluster.json
+++ b/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-cluster.json
@@ -90,7 +90,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -156,7 +156,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -226,7 +226,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -292,7 +292,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -361,7 +361,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind))",
+          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=\"\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=\"\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind))",
           "interval": "",
           "legendFormat": "{{kind}}",
           "refId": "A"
@@ -424,7 +424,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind))",
+          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=\"\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=\"\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind))",
           "interval": "",
           "legendFormat": "{{kind}}",
           "refId": "A"
@@ -538,7 +538,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -736,7 +736,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -899,7 +899,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -1117,7 +1117,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name))",
+          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=\"\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=\"\",namespace=~\"$namespace\",kind=~\"Kustomization|HelmRelease\"}[5m])) by (kind, name))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{kind}}/{{name}}",
@@ -1249,7 +1249,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name))",
+          "expr": "(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name))\nor\n(sum(rate(gotk_reconcile_duration_seconds_sum{cluster_id=\"$cluster\",exported_namespace=\"\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name)\n/\n  sum(rate(gotk_reconcile_duration_seconds_count{cluster_id=\"$cluster\",exported_namespace=\"\",namespace=~\"$namespace\",kind=~\"GitRepository|HelmRepository|Bucket|OCIRepository\"}[5m])) by (kind, name))",
           "hide": false,
           "interval": "",
           "legendFormat": "{{kind}}/{{name}}",

--- a/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-control-plane.json
+++ b/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-control-plane.json
@@ -11,22 +11,44 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "iconColor": "red",
+        "name": "flux events",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [
+            "flux"
+          ],
+          "type": "tags"
+        }
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 57,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
-      "description": "Number of controllers running in the selected namespace.",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "decimals": 0,
@@ -67,18 +89,16 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "value",
-        "wideLayout": true
+        "text": {},
+        "textMode": "value"
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(go_info{namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
+          "expr": "sum(go_info{cluster_id=\"$cluster\", namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
           "interval": "",
           "legendFormat": "pods",
           "refId": "A"
@@ -89,10 +109,9 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
-      "description": "The longest reconciliation time across all the controllers in the selected namespace.",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -136,18 +155,16 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "max(workqueue_longest_running_processor_seconds{namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
+          "expr": "max(workqueue_longest_running_processor_seconds{cluster_id=\"$cluster\", namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "seconds",
@@ -159,10 +176,9 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
-      "description": "Overall memory consumption by controllers in the selected namespace.",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -195,8 +211,6 @@
       },
       "id": 25,
       "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -207,16 +221,15 @@
         },
         "showThresholdLabels": false,
         "showThresholdMarkers": true,
-        "sizing": "auto"
+        "text": {}
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "sum(go_memstats_alloc_bytes{namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
+          "expr": "sum(go_memstats_alloc_bytes{cluster_id=\"$cluster\", namespace=\"$namespace\",pod=~\".*-controller-.*\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -227,10 +240,9 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
-      "description": "Kubernetes API-destinated requests issued by controllers running in the selected namespace.",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -261,7 +273,6 @@
         "y": 0
       },
       "id": 26,
-      "interval": "2m",
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -274,22 +285,18 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(rate(rest_client_requests_total{namespace=\"$namespace\",pod=~\".*-controller-.*\"}[$__interval]))",
+          "expr": "sum(rate(rest_client_requests_total{cluster_id=\"$cluster\", namespace=\"$namespace\",pod=~\".*-controller-.*\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "requests",
-          "range": true,
           "refId": "A"
         }
       ],
@@ -297,138 +304,7 @@
       "type": "stat"
     },
     {
-      "collapsed": false,
       "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 5
-      },
-      "id": 15,
-      "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "refId": "A"
-        }
-      ],
-      "title": "Resource Usage",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
-      "description": "Broken down by controller",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "linear",
-            "barAlignment": 0,
-            "lineWidth": 1,
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "spanNulls": false,
-            "insertNulls": false,
-            "showPoints": "never",
-            "pointSize": 5,
-            "stacking": {
-              "mode": "none",
-              "group": "A"
-            },
-            "axisPlacement": "auto",
-            "axisLabel": "",
-            "axisColorMode": "text",
-            "axisBorderShow": false,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "axisCenteredZero": false,
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "value": null,
-                "color": "green"
-              },
-              {
-                "value": 80,
-                "color": "red"
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 6
-      },
-      "id": 8,
-      "pluginVersion": "10.4.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "expr": "sum(rate(rest_client_requests_total{namespace=\"$namespace\", job=~\".*flux.*\"}[$__rate_interval])) by (job)",
-          "interval": "",
-          "legendFormat": "__auto",
-          "refId": "A",
-          "editorMode": "code",
-          "range": true
-        }
-      ],
-      "title": "Kubernetes API requests rate",
-      "type": "timeseries",
-      "options": {
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        },
-        "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "mean",
-            "lastNotNull"
-          ]
-        }
-      },
-      "interval": "2m",
-      "timeFrom": null,
-      "timeShift": null
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "",
@@ -438,7 +314,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -452,7 +327,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -489,9 +363,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 6
+        "w": 24,
+        "x": 0,
+        "y": 5
       },
       "id": 21,
       "options": {
@@ -509,32 +383,26 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(rate(rest_client_requests_total{namespace=\"$namespace\"}[2m]))",
+          "expr": "sum(rate(rest_client_requests_total{cluster_id=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
           "hide": false,
           "interval": "",
           "legendFormat": "total",
-          "range": true,
           "refId": "A"
         },
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(rate(rest_client_requests_total{namespace=\"$namespace\",code!~\"2..\"}[2m]))",
+          "expr": "sum(rate(rest_client_requests_total{cluster_id=\"$cluster\", namespace=\"$namespace\",code!~\"2..\"}[$__rate_interval]))",
           "hide": false,
           "interval": "",
           "legendFormat": "errors",
-          "range": true,
           "refId": "B"
         }
       ],
@@ -542,8 +410,31 @@
       "type": "timeseries"
     },
     {
+      "collapsed": false,
       "datasource": {
-        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 15,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Resource Usage",
+      "type": "row"
+    },
+    {
+      "datasource": {
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -552,7 +443,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -566,7 +456,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -623,18 +512,15 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "rate(process_cpu_seconds_total{namespace=\"$namespace\",pod=~\".*-controller-.*\"}[2m])",
+          "expr": "rate(process_cpu_seconds_total{cluster_id=\"$cluster\", namespace=\"$namespace\",pod=~\".*-controller-.*\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{pod}}",
-          "range": true,
           "refId": "A"
         }
       ],
@@ -643,7 +529,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -652,7 +537,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -666,7 +550,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -709,7 +592,6 @@
         "y": 14
       },
       "id": 13,
-      "interval": "2m",
       "options": {
         "legend": {
           "calcs": [
@@ -725,19 +607,16 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\",pod=~\".*-controller-.*\"}[2m])",
+          "expr": "sum(container_memory_working_set_bytes{cluster_id=\"$cluster\", namespace=\"$namespace\",container!=\"POD\",container!=\"\",pod=~\".*-controller-.*\"}) by (pod)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{pod}}",
-          "range": true,
           "refId": "A"
         }
       ],
@@ -747,7 +626,6 @@
     {
       "collapsed": false,
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "gridPos": {
@@ -761,7 +639,6 @@
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
           "refId": "A"
@@ -772,17 +649,14 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
-      "description": "Kustomization reconciliation duration per namespace.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -796,7 +670,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -853,14 +726,13 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "expr": "workqueue_longest_running_processor_seconds{name=\"kustomization\",namespace=\"$namespace\"}",
+          "expr": "workqueue_longest_running_processor_seconds{cluster_id=\"$cluster\", namespace=\"$namespace\", name=\"kustomization\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "kustomizations",
@@ -872,7 +744,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "",
@@ -882,7 +753,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -896,7 +766,136 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "opm"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"kustomization\",result!=\"error\"}[$__rate_interval])) by (controller)",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "successful reconciliations ",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"kustomization\",result=\"error\"}[$__rate_interval])) by (controller)",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "failed reconciliations ",
+          "refId": "B"
+        }
+      ],
+      "title": "Cluster Reconciliations ops/min",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 29,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Sources Stats",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "lineInterpolation": "stepAfter",
             "lineWidth": 1,
             "pointSize": 5,
@@ -935,10 +934,9 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 34
+        "y": 43
       },
-      "id": 2,
-      "interval": "2m",
+      "id": 4,
       "options": {
         "legend": {
           "calcs": [
@@ -954,41 +952,34 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"kustomization\",result!=\"error\"}[$__interval])) by (controller)",
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"gitrepository\",result!=\"error\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
-          "legendFormat": "successful reconciliations ",
-          "range": true,
+          "legendFormat": "successful git pulls",
           "refId": "A"
         },
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"kustomization\",result=\"error\"}[$__interval])) by (controller)",
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"gitrepository\",result=\"error\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
-          "legendFormat": "failed reconciliations ",
-          "range": true,
+          "legendFormat": "failed git pulls",
           "refId": "B"
         }
       ],
-      "title": "Cluster Reconciliations ops/min",
+      "title": "Git Repos ops/min",
       "type": "timeseries"
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "",
@@ -998,7 +989,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1012,7 +1002,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "stepAfter",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1051,10 +1040,9 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 34
+        "y": 43
       },
-      "id": 4,
-      "interval": "2m",
+      "id": 30,
       "options": {
         "legend": {
           "calcs": [
@@ -1070,56 +1058,260 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"gitrepository\",result!=\"error\"}[$__interval]))",
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"ocirepository\",result!=\"error\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
-          "legendFormat": "successful git pulls",
-          "range": true,
+          "legendFormat": "successful oci pulls",
           "refId": "A"
         },
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"gitrepository\",result=\"error\"}[$__interval]))",
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"ocirepository\",result=\"error\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
-          "legendFormat": "failed git pulls",
-          "range": true,
+          "legendFormat": "failed oci pulls",
           "refId": "B"
         }
       ],
-      "title": "Git Sources ops/min",
+      "title": "OCI Repos ops/min",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "opm"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrepository\",result!=\"error\"}[$__rate_interval]))",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "successful helm pulls",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrepository\",result=\"error\"}[$__rate_interval]))",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "failed helm pulls",
+          "refId": "B"
+        }
+      ],
+      "title": "Helm Repos ops/min",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "opm"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"bucket\",result!=\"error\"}[$__rate_interval]))",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "successful bucket pulls",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"bucket\",result=\"error\"}[$__rate_interval]))",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "failed bucket pulls",
+          "refId": "B"
+        }
+      ],
+      "title": "Buckets ops/min",
       "type": "timeseries"
     },
     {
       "collapsed": false,
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 61
       },
       "id": 19,
       "panels": [],
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
           "refId": "A"
@@ -1130,7 +1322,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -1139,7 +1330,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1153,7 +1343,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1192,10 +1381,9 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 62
       },
       "id": 9,
-      "interval": "5m",
       "options": {
         "legend": {
           "calcs": [
@@ -1211,45 +1399,36 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"helmrelease\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(controller_runtime_reconcile_time_seconds_bucket{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrelease\"}[5m])) by (le))",
           "hide": true,
           "interval": "",
           "legendFormat": "P50",
-          "range": true,
           "refId": "A"
         },
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"helmrelease\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.90, sum(rate(controller_runtime_reconcile_time_seconds_bucket{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrelease\"}[5m])) by (le))",
           "hide": true,
           "interval": "",
           "legendFormat": "P90",
-          "range": true,
           "refId": "B"
         },
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller=\"helmrelease\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(controller_runtime_reconcile_time_seconds_bucket{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrelease\"}[5m])) by (le))",
           "hide": false,
           "interval": "",
           "legendFormat": "P99",
-          "range": true,
           "refId": "C"
         }
       ],
@@ -1258,7 +1437,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "",
@@ -1268,7 +1446,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1282,7 +1459,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "stepAfter",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1321,10 +1497,9 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 52
+        "y": 70
       },
       "id": 5,
-      "interval": "2m",
       "options": {
         "legend": {
           "calcs": [
@@ -1340,32 +1515,26 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"helmrelease\",result!=\"error\"}[$__interval])) by (controller)",
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrelease\",result!=\"error\"}[$__rate_interval])) by (controller)",
           "format": "time_series",
           "interval": "",
           "legendFormat": "successful reconciliations ",
-          "range": true,
           "refId": "A"
         },
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"helmrelease\",result=\"error\"}[$__interval])) by (controller)",
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrelease\",result=\"error\"}[$__rate_interval])) by (controller)",
           "format": "time_series",
           "interval": "",
           "legendFormat": "failed reconciliations ",
-          "range": true,
           "refId": "B"
         }
       ],
@@ -1374,7 +1543,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "description": "",
@@ -1384,7 +1552,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1398,7 +1565,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "stepAfter",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1437,10 +1603,9 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 52
+        "y": 70
       },
       "id": 6,
-      "interval": "2m",
       "options": {
         "legend": {
           "calcs": [
@@ -1456,32 +1621,26 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.0",
+      "pluginVersion": "10.0.3",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"helmchart\",result!=\"error\"}[$__interval])) by (controller)",
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmchart\",result!=\"error\"}[$__rate_interval])) by (controller)",
           "format": "time_series",
           "interval": "",
           "legendFormat": "successful chart pulls",
-          "range": true,
           "refId": "A"
         },
         {
           "datasource": {
-            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(increase(controller_runtime_reconcile_total{controller=\"helmchart\",result=\"error\"}[$__interval])) by (controller)",
+          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmchart\",result=\"error\"}[$__rate_interval])) by (controller)",
           "format": "time_series",
           "interval": "",
           "legendFormat": "failed chart pulls",
-          "range": true,
           "refId": "B"
         }
       ],
@@ -1489,10 +1648,13 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "",
-  "schemaVersion": 39,
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "light",
   "tags": [
     "flux",
+    "component:flux",
+    "topic:gitops",
     "owner:team-honeybadger"
   ],
   "templating": {
@@ -1518,20 +1680,78 @@
       {
         "current": {
           "selected": false,
-          "text": "flux-giantswarm",
-          "value": "flux-giantswarm"
+          "text": "",
+          "value": ""
         },
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "definition": "workqueue_work_duration_seconds_count",
+        "definition": "label_values(gotk_reconcile_duration_seconds_count, organization)",
         "hide": 0,
         "includeAll": false,
+        "label": "Organization",
+        "multi": false,
+        "name": "organization",
+        "options": [],
+        "query": {
+          "query": "label_values(gotk_reconcile_duration_seconds_count, organization)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(gotk_reconcile_duration_seconds_count{organization=\"$organization\"}, cluster_id)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(gotk_reconcile_duration_seconds_count{organization=\"$organization\"}, cluster_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(workqueue_work_duration_seconds_count{cluster_id=\"$cluster\", pod=~\".*-controller-.*\"}, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Flux namespace",
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "workqueue_work_duration_seconds_count",
+        "query": {
+          "query": "label_values(workqueue_work_duration_seconds_count{cluster_id=\"$cluster\", pod=~\".*-controller-.*\"}, namespace)",
+          "refId": "StandardVariableQuery"
+        },
         "refresh": 2,
         "regex": "/.*namespace=\"([^\"]*).*/",
         "skipUrlSync": false,
@@ -1544,7 +1764,7 @@
     ]
   },
   "time": {
-    "from": "now-12h",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {
@@ -1563,6 +1783,5 @@
   "timezone": "UTC",
   "title": "Flux Control Plane",
   "uid": "flux-control-plane",
-  "version": 2,
   "weekStart": ""
 }

--- a/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-control-plane.json
+++ b/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-control-plane.json
@@ -828,7 +828,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"kustomization\",result!=\"error\"}[$__rate_interval])) by (controller)",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"kustomization\",result!=\"error\"}[$__rate_interval])) by (controller) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "successful reconciliations ",
@@ -838,7 +838,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"kustomization\",result=\"error\"}[$__rate_interval])) by (controller)",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"kustomization\",result=\"error\"}[$__rate_interval])) by (controller) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "failed reconciliations ",
@@ -958,7 +958,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"gitrepository\",result!=\"error\"}[$__rate_interval]))",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"gitrepository\",result!=\"error\"}[$__rate_interval])) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "successful git pulls",
@@ -968,7 +968,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"gitrepository\",result=\"error\"}[$__rate_interval]))",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"gitrepository\",result=\"error\"}[$__rate_interval])) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "failed git pulls",
@@ -1064,7 +1064,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"ocirepository\",result!=\"error\"}[$__rate_interval]))",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"ocirepository\",result!=\"error\"}[$__rate_interval])) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "successful oci pulls",
@@ -1074,7 +1074,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"ocirepository\",result=\"error\"}[$__rate_interval]))",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"ocirepository\",result=\"error\"}[$__rate_interval])) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "failed oci pulls",
@@ -1170,7 +1170,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrepository\",result!=\"error\"}[$__rate_interval]))",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrepository\",result!=\"error\"}[$__rate_interval])) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "successful helm pulls",
@@ -1180,7 +1180,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrepository\",result=\"error\"}[$__rate_interval]))",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrepository\",result=\"error\"}[$__rate_interval])) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "failed helm pulls",
@@ -1276,7 +1276,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"bucket\",result!=\"error\"}[$__rate_interval]))",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"bucket\",result!=\"error\"}[$__rate_interval])) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "successful bucket pulls",
@@ -1286,7 +1286,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"bucket\",result=\"error\"}[$__rate_interval]))",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"bucket\",result=\"error\"}[$__rate_interval])) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "failed bucket pulls",
@@ -1521,7 +1521,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrelease\",result!=\"error\"}[$__rate_interval])) by (controller)",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrelease\",result!=\"error\"}[$__rate_interval])) by (controller) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "successful reconciliations ",
@@ -1531,7 +1531,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrelease\",result=\"error\"}[$__rate_interval])) by (controller)",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmrelease\",result=\"error\"}[$__rate_interval])) by (controller) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "failed reconciliations ",
@@ -1627,7 +1627,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmchart\",result!=\"error\"}[$__rate_interval])) by (controller)",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmchart\",result!=\"error\"}[$__rate_interval])) by (controller) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "successful chart pulls",
@@ -1637,7 +1637,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(increase(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmchart\",result=\"error\"}[$__rate_interval])) by (controller)",
+          "expr": "sum(rate(controller_runtime_reconcile_total{cluster_id=\"$cluster\", namespace=\"$namespace\", controller=\"helmchart\",result=\"error\"}[$__rate_interval])) by (controller) * 60",
           "format": "time_series",
           "interval": "",
           "legendFormat": "failed chart pulls",
@@ -1741,7 +1741,7 @@
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "definition": "label_values(workqueue_work_duration_seconds_count{cluster_id=\"$cluster\", pod=~\".*-controller-.*\"}, namespace)",
+        "definition": "label_values(workqueue_work_duration_seconds_count{cluster_id=\"$cluster\", pod=~\"(flux-)?(source|kustomize|helm|notification|image-automation|image-reflector)-controller-.*\"}, namespace)",
         "hide": 0,
         "includeAll": false,
         "label": "Flux namespace",
@@ -1749,13 +1749,13 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(workqueue_work_duration_seconds_count{cluster_id=\"$cluster\", pod=~\".*-controller-.*\"}, namespace)",
+          "query": "label_values(workqueue_work_duration_seconds_count{cluster_id=\"$cluster\", pod=~\"(flux-)?(source|kustomize|helm|notification|image-automation|image-reflector)-controller-.*\"}, namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
         "regex": "/.*namespace=\"([^\"]*).*/",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",

--- a/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-logs.json
+++ b/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-logs.json
@@ -46,6 +46,27 @@
   "liveNow": false,
   "panels": [
     {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1000,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "> **Management cluster only.** Flux controller logs are ingested for the management cluster. Workload clusters run Flux in the `flux-system` namespace, which has no tenant assignment, so their logs are dropped before reaching Loki -- selecting a workload cluster below will show no data even when Flux is running there.",
+        "mode": "markdown"
+      },
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
       "datasource": {
         "type": "loki",
         "uid": "gs-loki"
@@ -105,7 +126,7 @@
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 3
       },
       "id": 4,
       "options": {
@@ -144,7 +165,7 @@
         "h": 25,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 7
       },
       "id": 2,
       "options": {

--- a/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-logs.json
+++ b/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-logs.json
@@ -38,7 +38,7 @@
       }
     ]
   },
-  "description": "Flux logs collected from Kubernetes, stored in Loki",
+  "description": "Only management-cluster Flux logs are ingested. Workload clusters run Flux in the flux-system namespace, which has no tenant assignment, so their controller logs are dropped before reaching Loki and this dashboard will be empty for them.",
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
@@ -50,7 +50,7 @@
         "type": "loki",
         "uid": "gs-loki"
       },
-      "description": "",
+      "description": "Only management-cluster Flux logs are ingested. Workload clusters run Flux in the flux-system namespace, which has no tenant assignment, so their controller logs are dropped before reaching Loki and this dashboard will be empty for them.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -139,7 +139,7 @@
         "type": "loki",
         "uid": "gs-loki"
       },
-      "description": "Logs from services running in Kubernetes",
+      "description": "Only management-cluster Flux logs are ingested. Workload clusters run Flux in the flux-system namespace, which has no tenant assignment, so their controller logs are dropped before reaching Loki and this dashboard will be empty for them.",
       "gridPos": {
         "h": 25,
         "w": 24,

--- a/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-logs.json
+++ b/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps/flux-logs.json
@@ -1,0 +1,341 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "loki",
+          "uid": "gs-loki"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "gs-loki"
+        },
+        "enable": true,
+        "iconColor": "red",
+        "name": "flux events",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [
+            "flux"
+          ],
+          "type": "tags"
+        }
+      }
+    ]
+  },
+  "description": "Flux logs collected from Kubernetes, stored in Loki",
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "gs-loki"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "gs-loki"
+          },
+          "expr": "sum(count_over_time({service_name=~\"flux-app|flux-operator\", cluster_id=\"$cluster\", pod=~\"$controller.*\"} | json | __error__!=\"JSONParserErr\" | level=~\"$level\" |= \"$query\" [$__interval]))",
+          "instant": false,
+          "legendFormat": "Log count",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "gs-loki"
+      },
+      "description": "Logs from services running in Kubernetes",
+      "gridPos": {
+        "h": 25,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 2,
+      "options": {
+        "dedupStrategy": "numbers",
+        "enableLogDetails": false,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "gs-loki"
+          },
+          "expr": "{service_name=~\"flux-app|flux-operator\", cluster_id=\"$cluster\", pod=~\"$controller.*\"} | json | __error__!=\"JSONParserErr\" | level=~\"$level\" |= \"$query\"",
+          "refId": "A"
+        }
+      ],
+      "type": "logs"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "style": "light",
+  "tags": [
+    "flux",
+    "component:flux",
+    "topic:gitops",
+    "owner:team-honeybadger"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(gotk_reconcile_duration_seconds_count, organization)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Organization",
+        "multi": false,
+        "name": "organization",
+        "options": [],
+        "query": {
+          "query": "label_values(gotk_reconcile_duration_seconds_count, organization)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(gotk_reconcile_duration_seconds_count{organization=\"$organization\"}, cluster_id)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(gotk_reconcile_duration_seconds_count{organization=\"$organization\"}, cluster_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "description": "String to search for",
+        "hide": 0,
+        "label": "Search Query",
+        "name": "query",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "allValue": "info|error",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "level",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "info",
+            "value": "info"
+          },
+          {
+            "selected": false,
+            "text": "error",
+            "value": "error"
+          }
+        ],
+        "query": "info,error",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Controller",
+        "multi": true,
+        "name": "controller",
+        "options": [],
+        "query": "source-controller,kustomize-controller,helm-controller,notification-controller,image-automation-controller,image-reflector-controller,flux-operator",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "UTC",
+  "title": "Flux Logs",
+  "uid": "flux-logs"
+}

--- a/scripts/update-flux-dashboards.sh
+++ b/scripts/update-flux-dashboards.sh
@@ -48,6 +48,12 @@ FLUX_REF="${1:-main}"
 
 TAGS='["flux","component:flux","topic:gitops","owner:team-honeybadger"]'
 
+# Flux controller deployment names, anchored. Workload clusters prefix them with
+# `flux-`. Used to tell Flux's pods apart from every other controller-runtime
+# operator that exposes the same generic workqueue metrics.
+FLUX_CONTROLLERS='source|kustomize|helm|notification|image-automation|image-reflector'
+FLUX_CONTROLLER_PODS="(flux-)?($FLUX_CONTROLLERS)-controller-.*"
+
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
@@ -105,6 +111,13 @@ gs_common() {
         | del(.id, .version, .iteration, .__inputs, .__requires, .__elements)
         # Drop upstream'"'"'s datasource-picker variables; we add our own.
         | .templating.list |= map(select(.type != "datasource"))
+        # Point every Prometheus reference at the $datasource variable. Upstream
+        # hardcodes `uid: "prometheus"` on some *targets* while their panel uses
+        # the variable; no datasource with that uid exists in our Grafana, and the
+        # target-level datasource wins, so those panels would query nothing. The
+        # linter only inspects panel-level datasources and cannot catch it.
+        | (.. | objects | select(.uid? == "prometheus" and .type? == "prometheus"))
+              |= {"type": "prometheus", "uid": "$datasource"}
     '
 }
 
@@ -132,10 +145,20 @@ patch_cluster() {
 
         # For the duration panels, add an `or` fallback so the namespace filter
         # works on management clusters (exported_namespace) and on workload
-        # clusters (namespace) alike. Only one branch ever returns series.
+        # clusters (namespace) alike.
+        #
+        # The fallback branch is pinned to `exported_namespace=""` so the two
+        # branches stay mutually exclusive. Without it the branches overlap on a
+        # management cluster: there `namespace` is the *controller* namespace
+        # (flux-giantswarm), which is also one of the object namespaces the
+        # dropdown offers, and `or` only suppresses right-hand series whose exact
+        # label set already exists on the left. Selecting flux-giantswarm then
+        # pulled in objects from every other namespace (205 series, not 52).
         def dual_namespace:
             if test("gotk_reconcile_duration_seconds") and test("exported_namespace")
-            then "(" + . + ")\nor\n(" + gsub("exported_namespace=~"; "namespace=~") + ")"
+            then "(" + . + ")\nor\n("
+                 + gsub("exported_namespace=~"; "exported_namespace=\"\",namespace=~")
+                 + ")"
             else . end;
 
         (.. | objects | select(has("expr")) | .expr) |= (patch_expr | dual_namespace)
@@ -171,30 +194,50 @@ patch_control_plane() {
                    "{cluster_id=\"$cluster\", namespace=\"$namespace\", ")
             # 3. Our scrape interval is 60s, so upstream'"'"'s `[1m]` range windows
             #    contain at most one sample and rate()/increase() return nothing.
+            #    Widening the window is not enough for the `increase()` panels:
+            #    they are titled "ops/min" with unit `opm`, so the value must stay
+            #    per-minute. `increase(m[$__rate_interval])` would report the count
+            #    over 4m+ (and grow as the time range widens), reading several
+            #    times high. Convert those to a per-second rate scaled to a minute.
+            #    The `by (...)` clause belongs to the aggregation, so it has to
+            #    stay before the multiplication -- hence the two passes.
+            | gsub("sum\\(increase\\((?<body>[^\\[]*)\\[1m\\]\\)\\)\\s*by\\s*\\((?<grp>[^)]*)\\)";
+                   "sum(rate(\(.body)[$__rate_interval])) by (\(.grp)) * 60")
+            | gsub("sum\\(increase\\((?<body>[^\\[]*)\\[1m\\]\\)\\)";
+                   "sum(rate(\(.body)[$__rate_interval])) * 60")
             | gsub("\\[1m\\]"; "[$__rate_interval]");
 
         (.. | objects | select(has("expr")) | .expr) |= patch_expr
         # The namespace variable must list the *controller* namespace, which
         # differs by cluster type (flux-giantswarm on MCs, flux-system on WCs).
         # workqueue metrics are scraped from the controller pods, so their
-        # `namespace` label is the controller namespace on both.
+        # `namespace` label is the controller namespace on both -- but they are
+        # generic controller-runtime metrics, and a loose `.*-controller-.*` pod
+        # match also selects unrelated operators (on a management cluster it
+        # returns external-secrets, giantswarm and kube-system alongside
+        # flux-giantswarm, and Grafana would auto-select the alphabetically first).
+        # Anchoring on the Flux controller deployment names yields exactly one
+        # namespace per cluster type.
         | (.templating.list[] | select(.name == "namespace")) |= (
               .datasource = {"type": "prometheus", "uid": "$datasource"}
-            | .definition = "label_values(workqueue_work_duration_seconds_count{cluster_id=\"$cluster\", pod=~\".*-controller-.*\"}, namespace)"
-            | .query = {"query": "label_values(workqueue_work_duration_seconds_count{cluster_id=\"$cluster\", pod=~\".*-controller-.*\"}, namespace)", "refId": "StandardVariableQuery"}
+            | .definition = $q
+            | .query = {"query": $q, "refId": "StandardVariableQuery"}
             | .label = "Flux namespace"
             | .refresh = 2
+            | .sort = 1
             | .current = {"selected": false, "text": "", "value": ""}
           )
-    '
+    ' --arg q "label_values(workqueue_work_duration_seconds_count{cluster_id=\"\$cluster\", pod=~\"$FLUX_CONTROLLER_PODS\"}, namespace)"
 }
 
 # --- logs.json ---------------------------------------------------------------
 
 patch_logs() {
     local selector='{service_name=~"flux-app|flux-operator", cluster_id="$cluster", pod=~"$controller.*"}'
+    local caveat
+    caveat="Only management-cluster Flux logs are ingested. Workload clusters run Flux in the flux-system namespace, which has no tenant assignment, so their controller logs are dropped before reaching Loki and this dashboard will be empty for them."
 
-    jq --arg selector "$selector" '
+    jq --arg selector "$selector" --arg caveat "$caveat" '
         # Replace upstream'"'"'s stream selector wholesale: `stream` is dropped by
         # our Alloy config and `app` names the Helm release, not the controller.
         (.. | objects | select(has("expr")) | .expr) |=
@@ -206,6 +249,12 @@ patch_logs() {
              else {"type": "loki", "uid": "gs-loki"} end)
         # `namespace` and `stream` no longer parameterise anything.
         | .templating.list |= map(select(.name != "namespace" and .name != "stream"))
+        # The Cluster dropdown lists every cluster running Flux, but only
+        # management-cluster logs are ingested, so state that where a customer
+        # picking a workload cluster will actually see it rather than only in the
+        # docs.
+        | .description = $caveat
+        | (.. | objects | select(has("targets")) | .description) |= $caveat
         # Controller identity comes from the pod name prefix.
         | (.templating.list[] | select(.name == "controller")) |= (
               {
@@ -235,33 +284,57 @@ fetch() {
 assert_scoped() {
     local file="$1" require_namespace="$2" bad rc=0
 
-    bad=$(jq -r '[.. | objects | select(has("expr")) | .expr
-                  | select(test("\\{") and (test("cluster_id") | not))] | .[]' "$file")
-    if [[ -n "$bad" ]]; then
-        echo "ERROR: $(basename "$file") has expressions with no cluster_id filter:" >&2
-        echo "$bad" >&2
+    fail() {
+        echo "ERROR: $(basename "$file") $1:" >&2
+        echo "$2" >&2
         rc=1
-    fi
+    }
+
+    # Every *selector* must be cluster-scoped -- checked per selector rather than
+    # per expression, so `count(a{cluster_id=...}) / count(b{})` cannot slip by.
+    bad=$(jq -r '[.. | objects | select(has("expr")) | .expr
+                  | [match("\\{[^}]*\\}"; "g").string]
+                  | map(select(test("cluster_id") | not)) | .[]] | unique | .[]' "$file")
+    [[ -n "$bad" ]] && fail "has selectors with no cluster_id filter" "$bad"
+
+    # A bare metric name with no selector at all is neither patched nor caught by
+    # the check above, and would query the whole fleet.
+    bad=$(jq -r --arg fams "gotk_|controller_runtime_|workqueue_|rest_client_|go_|process_|container_" '
+              [.. | objects | select(has("expr")) | .expr
+               | select(test("(^|[^a-z_{\"])(\($fams))[a-z0-9_]*\\s*(\\[|\\)|$|\\s)"))] | unique | .[]' "$file")
+    [[ -n "$bad" ]] && fail "has metrics used without a label selector" "$bad"
 
     # Every selector on the control-plane dashboard must be namespace-scoped,
     # otherwise generic controller-runtime metrics from other operators leak in.
     if [[ "$require_namespace" == "yes" ]]; then
         bad=$(jq -r '[.. | objects | select(has("expr")) | .expr
-                      | select(test("\\{(?![^}]*namespace)"))] | .[]' "$file")
-        if [[ -n "$bad" ]]; then
-            echo "ERROR: $(basename "$file") has selectors with no namespace filter:" >&2
-            echo "$bad" >&2
-            rc=1
-        fi
+                      | [match("\\{[^}]*\\}"; "g").string]
+                      | map(select(test("namespace") | not)) | .[]] | unique | .[]' "$file")
+        [[ -n "$bad" ]] && fail "has selectors with no namespace filter" "$bad"
     fi
 
     # 60s scrape interval: a [1m] window cannot hold two samples.
-    bad=$(jq -r '[.. | objects | select(has("expr")) | .expr | select(test("\\[1m\\]"))] | .[]' "$file")
-    if [[ -n "$bad" ]]; then
-        echo "ERROR: $(basename "$file") still has [1m] range windows:" >&2
-        echo "$bad" >&2
-        rc=1
-    fi
+    bad=$(jq -r '[.. | objects | select(has("expr")) | .expr | select(test("\\[1m\\]"))] | unique | .[]' "$file")
+    [[ -n "$bad" ]] && fail "still has [1m] range windows" "$bad"
+
+    # `increase()` over $__rate_interval is not a per-minute value; the ops/min
+    # panels must use rate() * 60.
+    bad=$(jq -r '[.. | objects | select(has("expr")) | .expr | select(test("increase\\("))] | unique | .[]' "$file")
+    [[ -n "$bad" ]] && fail "still uses increase() (ops/min panels need rate() * 60)" "$bad"
+
+    # Every $variable referenced must actually exist. This is what catches an
+    # upstream rename: the text-anchored rewrites above would silently no-op while
+    # the variable they depend on has already been dropped, leaving a dead panel.
+    bad=$(jq -r '
+        (.templating.list | map(.name)) as $defined
+        | ["__rate_interval", "__interval", "__interval_ms", "__auto", "__all",
+           "__range", "__from", "__to", "__timeFilter", "__dashboard", "__user", "__org"] as $builtin
+        | [.. | objects | (.expr?, .query?, .definition?) | select(type == "string")]
+          + [.. | objects | .query? | objects | .query? | select(type == "string")]
+        | map([match("\\$\\{?([a-zA-Z_][a-zA-Z0-9_]*)"; "g").captures[0].string]) | add // []
+        | unique | map(select(. as $v | ($defined | index($v)) == null and ($builtin | index($v)) == null)) | .[]
+    ' "$file")
+    [[ -n "$bad" ]] && fail "references undefined dashboard variables" "$bad"
 
     if [[ $rc -ne 0 ]]; then
         echo "Upstream likely changed. Update the patch functions in $(basename "${BASH_SOURCE[0]}")." >&2

--- a/scripts/update-flux-dashboards.sh
+++ b/scripts/update-flux-dashboards.sh
@@ -1,0 +1,362 @@
+#!/bin/bash
+#
+# Sync the Flux Grafana dashboards from the upstream Flux monitoring example and
+# adapt them to the Giant Swarm observability platform.
+#
+# Source: https://github.com/fluxcd/flux2-monitoring-example
+#         monitoring/configs/dashboards/{cluster,control-plane,logs}.json
+#
+# Usage:
+#   ./scripts/update-flux-dashboards.sh [ref]     # ref defaults to "main"
+#
+# Upstream has no tags, so the resolved commit SHA is printed and written to the
+# CHANGELOG entry to keep each sync reproducible.
+#
+# Why a patch layer is needed (all verified against a live installation):
+#
+#   * Multi-cluster. Our dashboards live in the management cluster's Grafana,
+#     whose Mimir holds metrics for every workload cluster. Upstream is written
+#     for a single cluster, so every selector needs a `cluster_id` filter, plus
+#     the standard Giant Swarm `organization`/`cluster` variable pair.
+#   * Double counting. On a management cluster BOTH `job="flux-ksm"` and
+#     `job="kube-state-metrics"` export identical `gotk_resource_info` series, so
+#     upstream's unfiltered `count(...)` reads exactly 2x. We aggregate with
+#     `max by (<displayed labels>)` which de-duplicates on the MC and is a no-op
+#     on workload clusters, where only one exporter is present.
+#   * Namespace label is not consistent across cluster types. On
+#     `gotk_reconcile_duration_seconds_*` the management cluster carries
+#     `namespace` (controller) + `exported_namespace` (object), while workload
+#     clusters carry only `namespace` (object) and no `exported_namespace`. The
+#     duration panels therefore get an `or` fallback so one query works on both.
+#     `gotk_resource_info` is consistent (`exported_namespace` everywhere) and
+#     needs no such treatment.
+#   * Logs. `stream` is moved to structured metadata by our Alloy config and then
+#     label-dropped, and `app` identifies the Helm release (`flux-app`) rather
+#     than a controller, so upstream's `{namespace, stream, app}` selector cannot
+#     work. We select on `service_name` + `cluster_id` + `pod` instead, matching
+#     charts/networking/.../cilium-agent-logs.json.
+#
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd -P)
+DEST_DIR="$REPO_ROOT/helm/dashboards/charts/app_platform/dashboards/Shared Org/GitOps"
+
+UPSTREAM_REPO="fluxcd/flux2-monitoring-example"
+UPSTREAM_PATH="monitoring/configs/dashboards"
+FLUX_REF="${1:-main}"
+
+TAGS='["flux","component:flux","topic:gitops","owner:team-honeybadger"]'
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# --- shared jq fragments -----------------------------------------------------
+
+# The Giant Swarm standard Prometheus datasource variable.
+read -r -d '' VAR_DATASOURCE <<'EOF' || true
+{
+  "current": {"selected": false, "text": "default", "value": "default"},
+  "hide": 0, "includeAll": false, "label": "Data source", "multi": false,
+  "name": "datasource", "options": [], "query": "prometheus", "refresh": 1,
+  "regex": "", "skipUrlSync": false, "type": "datasource"
+}
+EOF
+
+# Chained organization -> cluster variables, following
+# charts/cloud/dashboards/Shared Org/Kubernetes/nodes-overview.json.
+# `gotk_reconcile_duration_seconds_count` is emitted only by Flux controllers, so
+# the dropdowns list exactly the clusters that actually run Flux.
+gs_cluster_vars() {
+    local base="$1"
+    cat <<EOF
+[
+  {
+    "current": {"selected": false, "text": "", "value": ""},
+    "datasource": {"type": "prometheus", "uid": "\$datasource"},
+    "definition": "label_values($base, organization)",
+    "hide": 0, "includeAll": false, "label": "Organization", "multi": false,
+    "name": "organization", "options": [],
+    "query": {"query": "label_values($base, organization)", "refId": "StandardVariableQuery"},
+    "refresh": 2, "regex": "", "skipUrlSync": false, "sort": 1, "type": "query"
+  },
+  {
+    "current": {"selected": false, "text": "", "value": ""},
+    "datasource": {"type": "prometheus", "uid": "\$datasource"},
+    "definition": "label_values($base{organization=\"\$organization\"}, cluster_id)",
+    "hide": 0, "includeAll": false, "label": "Cluster", "multi": false,
+    "name": "cluster", "options": [],
+    "query": {"query": "label_values($base{organization=\"\$organization\"}, cluster_id)", "refId": "StandardVariableQuery"},
+    "refresh": 2, "regex": "", "skipUrlSync": false, "sort": 1, "type": "query"
+  }
+]
+EOF
+}
+
+# Normalise metadata every dashboard shares.
+gs_common() {
+    local uid="$1"
+    jq --arg uid "$uid" --argjson tags "$TAGS" '
+        .uid = $uid
+        | .tags = $tags
+        | .timezone = "UTC"
+        # Provisioned dashboards are read-only; the linter enforces this.
+        | .editable = false
+        | del(.id, .version, .iteration, .__inputs, .__requires, .__elements)
+        # Drop upstream'"'"'s datasource-picker variables; we add our own.
+        | .templating.list |= map(select(.type != "datasource"))
+    '
+}
+
+# --- cluster.json ------------------------------------------------------------
+
+patch_cluster() {
+    # Labels the readiness/suspended tables actually display (they end with a
+    # filterFieldsByName on Namespace|Kind|Name|Status). Aggregating by exactly
+    # these de-duplicates the two management-cluster exporters without losing a
+    # displayed column.
+    local keep='exported_namespace, customresource_kind, name, ready, suspended'
+
+    jq --arg keep "$keep" '
+        def patch_expr:
+            # 1. gotk_resource_info: scope to the selected cluster and de-duplicate.
+            gsub("gotk_resource_info\\{(?<sel>[^}]*)\\}";
+                 "max by (" + $keep + ") (gotk_resource_info{cluster_id=\"$cluster\", \(.sel)})")
+            # 2. Drop the operator_namespace matcher: on workload clusters
+            #    `namespace` is the object namespace, so filtering it by the
+            #    controller namespace returns nothing.
+            | gsub("namespace=~\"\\$operator_namespace\",\\s*"; "")
+            # 3. Scope the duration metrics to the selected cluster.
+            | gsub("gotk_reconcile_duration_seconds_(?<s>sum|count)\\{";
+                   "gotk_reconcile_duration_seconds_\(.s){cluster_id=\"$cluster\",");
+
+        # For the duration panels, add an `or` fallback so the namespace filter
+        # works on management clusters (exported_namespace) and on workload
+        # clusters (namespace) alike. Only one branch ever returns series.
+        def dual_namespace:
+            if test("gotk_reconcile_duration_seconds") and test("exported_namespace")
+            then "(" + . + ")\nor\n(" + gsub("exported_namespace=~"; "namespace=~") + ")"
+            else . end;
+
+        (.. | objects | select(has("expr")) | .expr) |= (patch_expr | dual_namespace)
+        | .templating.list |= map(select(.name != "operator_namespace"))
+        | (.templating.list[] | select(.name == "namespace")) |= (
+              .datasource = {"type": "prometheus", "uid": "$datasource"}
+            | .definition = "label_values(gotk_resource_info{cluster_id=\"$cluster\"}, exported_namespace)"
+            | .query = {"query": "label_values(gotk_resource_info{cluster_id=\"$cluster\"}, exported_namespace)", "refId": "StandardVariableQuery"}
+            | .label = "Namespace"
+            | .refresh = 2
+          )
+    '
+}
+
+# --- control-plane.json ------------------------------------------------------
+
+patch_control_plane() {
+    jq '
+        def patch_expr:
+            # 1. Every selector gets a cluster filter. Metric names are the only
+            #    thing followed by `{` in PromQL (aggregations use parentheses),
+            #    so this is a safe injection point.
+            gsub("(?<m>\\b[a-z_][a-z0-9_]*)\\{(?<sel>[^}]*)\\}";
+                 "\(.m){cluster_id=\"$cluster\", \(.sel)}")
+            # 2. Every selector also gets the Flux namespace. `controller_runtime_*`
+            #    and `workqueue_*` are generic controller-runtime metrics: on a
+            #    management cluster dozens of unrelated operators expose them, and
+            #    several expose the very same `controller` label values Flux does
+            #    (`controller="helmrelease"` is also emitted by dex-operator and
+            #    team-stamper). Without this the panels silently mix in other
+            #    operators. The lookahead skips selectors already scoped.
+            | gsub("\\{cluster_id=\"\\$cluster\", (?![^}]*namespace)";
+                   "{cluster_id=\"$cluster\", namespace=\"$namespace\", ")
+            # 3. Our scrape interval is 60s, so upstream'"'"'s `[1m]` range windows
+            #    contain at most one sample and rate()/increase() return nothing.
+            | gsub("\\[1m\\]"; "[$__rate_interval]");
+
+        (.. | objects | select(has("expr")) | .expr) |= patch_expr
+        # The namespace variable must list the *controller* namespace, which
+        # differs by cluster type (flux-giantswarm on MCs, flux-system on WCs).
+        # workqueue metrics are scraped from the controller pods, so their
+        # `namespace` label is the controller namespace on both.
+        | (.templating.list[] | select(.name == "namespace")) |= (
+              .datasource = {"type": "prometheus", "uid": "$datasource"}
+            | .definition = "label_values(workqueue_work_duration_seconds_count{cluster_id=\"$cluster\", pod=~\".*-controller-.*\"}, namespace)"
+            | .query = {"query": "label_values(workqueue_work_duration_seconds_count{cluster_id=\"$cluster\", pod=~\".*-controller-.*\"}, namespace)", "refId": "StandardVariableQuery"}
+            | .label = "Flux namespace"
+            | .refresh = 2
+            | .current = {"selected": false, "text": "", "value": ""}
+          )
+    '
+}
+
+# --- logs.json ---------------------------------------------------------------
+
+patch_logs() {
+    local selector='{service_name=~"flux-app|flux-operator", cluster_id="$cluster", pod=~"$controller.*"}'
+
+    jq --arg selector "$selector" '
+        # Replace upstream'"'"'s stream selector wholesale: `stream` is dropped by
+        # our Alloy config and `app` names the Helm release, not the controller.
+        (.. | objects | select(has("expr")) | .expr) |=
+            gsub("\\{namespace=~\"\\$namespace\",\\s*stream=~\"\\$stream\",\\s*app\\s*=~\"\\$controller\"\\}"; $selector)
+        # Panels query Loki directly; the repo convention for v1 dashboards is a
+        # hardcoded gs-loki datasource (see cilium-agent-logs.json).
+        | (.. | objects | select(has("datasource")) | .datasource) |=
+            (if type == "object" and .type == "grafana" then .
+             else {"type": "loki", "uid": "gs-loki"} end)
+        # `namespace` and `stream` no longer parameterise anything.
+        | .templating.list |= map(select(.name != "namespace" and .name != "stream"))
+        # Controller identity comes from the pod name prefix.
+        | (.templating.list[] | select(.name == "controller")) |= (
+              {
+                "allValue": ".*",
+                "current": {"selected": true, "text": ["All"], "value": ["$__all"]},
+                "hide": 0, "includeAll": true, "label": "Controller",
+                "multi": true, "name": "controller",
+                "options": [], "query": "source-controller,kustomize-controller,helm-controller,notification-controller,image-automation-controller,image-reflector-controller,flux-operator",
+                "skipUrlSync": false, "type": "custom"
+              }
+          )
+    '
+}
+
+# --- driver ------------------------------------------------------------------
+
+resolve_sha() {
+    curl -sSfL "https://api.github.com/repos/$UPSTREAM_REPO/commits/$FLUX_REF" | jq -r '.sha'
+}
+
+fetch() {
+    curl -sSfL "https://raw.githubusercontent.com/$UPSTREAM_REPO/$1/$UPSTREAM_PATH/$2"
+}
+
+# Fails loudly when upstream adds a panel our injectors did not reach, so the
+# monthly PR surfaces the gap instead of silently shipping a fleet-wide query.
+assert_scoped() {
+    local file="$1" require_namespace="$2" bad rc=0
+
+    bad=$(jq -r '[.. | objects | select(has("expr")) | .expr
+                  | select(test("\\{") and (test("cluster_id") | not))] | .[]' "$file")
+    if [[ -n "$bad" ]]; then
+        echo "ERROR: $(basename "$file") has expressions with no cluster_id filter:" >&2
+        echo "$bad" >&2
+        rc=1
+    fi
+
+    # Every selector on the control-plane dashboard must be namespace-scoped,
+    # otherwise generic controller-runtime metrics from other operators leak in.
+    if [[ "$require_namespace" == "yes" ]]; then
+        bad=$(jq -r '[.. | objects | select(has("expr")) | .expr
+                      | select(test("\\{(?![^}]*namespace)"))] | .[]' "$file")
+        if [[ -n "$bad" ]]; then
+            echo "ERROR: $(basename "$file") has selectors with no namespace filter:" >&2
+            echo "$bad" >&2
+            rc=1
+        fi
+    fi
+
+    # 60s scrape interval: a [1m] window cannot hold two samples.
+    bad=$(jq -r '[.. | objects | select(has("expr")) | .expr | select(test("\\[1m\\]"))] | .[]' "$file")
+    if [[ -n "$bad" ]]; then
+        echo "ERROR: $(basename "$file") still has [1m] range windows:" >&2
+        echo "$bad" >&2
+        rc=1
+    fi
+
+    if [[ $rc -ne 0 ]]; then
+        echo "Upstream likely changed. Update the patch functions in $(basename "${BASH_SOURCE[0]}")." >&2
+    fi
+    return $rc
+}
+
+main() {
+    local sha
+    sha=$(resolve_sha)
+    echo "====> Syncing Flux dashboards from $UPSTREAM_REPO@$FLUX_REF ($sha)"
+
+    mkdir -p "$DEST_DIR"
+
+    # upstream file : our file : uid : patch function : require namespace scoping
+    local specs=(
+        "cluster.json:flux-cluster.json:flux-cluster:patch_cluster:no"
+        "control-plane.json:flux-control-plane.json:flux-control-plane:patch_control_plane:yes"
+        "logs.json:flux-logs.json:flux-logs:patch_logs:no"
+    )
+    # `gotk_reconcile_duration_seconds_count` is emitted only by Flux controllers,
+    # so the organization/cluster dropdowns list exactly the clusters running Flux.
+    local base="gotk_reconcile_duration_seconds_count"
+
+    local spec src dst uid fn needs_ns out
+    for spec in "${specs[@]}"; do
+        IFS=: read -r src dst uid fn needs_ns <<<"$spec"
+        echo "  Patching $src -> $dst"
+        out="$TMPDIR/$dst"
+
+        fetch "$sha" "$src" \
+            | sed -e 's/\${DS_PROMETHEUS}/$datasource/g' -e 's/\$DS_PROMETHEUS/$datasource/g' \
+                  -e 's/\${DS_LOKI}/gs-loki/g' -e 's/\$DS_LOKI/gs-loki/g' \
+            | "$fn" \
+            | gs_common "$uid" \
+            | jq --argjson ds "$VAR_DATASOURCE" --argjson cv "$(gs_cluster_vars "$base")" \
+                 '.templating.list = ([$ds] + $cv + .templating.list)' \
+            > "$out"
+
+        assert_scoped "$out" "$needs_ns"
+        # Stable key order keeps the monthly diff to real changes only.
+        jq -S . "$out" > "$DEST_DIR/$dst"
+    done
+
+    echo "====> Dashboards written to $DEST_DIR"
+
+    local gst entry
+    gst=$(cd "$REPO_ROOT" && git status --short -- "$DEST_DIR")
+    if [[ -z "$gst" ]]; then
+        echo "====> No changes."
+        return 0
+    fi
+    echo "$gst"
+
+    # Re-running the script must not stack duplicate CHANGELOG entries, so skip
+    # when this upstream commit is already recorded.
+    entry="- Synced Flux dashboards from [$UPSTREAM_REPO@${sha:0:7}](https://github.com/$UPSTREAM_REPO/tree/$sha/$UPSTREAM_PATH)."
+    # `--` matters: the entry starts with "- ", which grep would read as an option.
+    if grep -qF -- "$entry" "$REPO_ROOT/CHANGELOG.md"; then
+        echo "====> CHANGELOG already mentions ${sha:0:7}, not adding a duplicate entry."
+    else
+        # Add the bullet to the existing "### Changed" block under [Unreleased]
+        # when there is one, so we do not leave two identical headings behind.
+        awk -v entry="$entry" '
+            /^## \[Unreleased\]/ { print; in_unreleased = 1; next }
+            in_unreleased && /^## / {
+                # Left [Unreleased] without finding a Changed section: add one.
+                if (!done) { print "### Changed\n\n" entry "\n"; done = 1 }
+                in_unreleased = 0
+            }
+            in_unreleased && !done && /^### Changed[[:space:]]*$/ {
+                print; pending = 1; next
+            }
+            # Emit the bullet after the blank line that follows the heading, so it
+            # joins the existing list instead of starting a detached one.
+            pending { print; print entry; pending = 0; done = 1; next }
+            { print }
+            END { if (in_unreleased && !done) print "### Changed\n\n" entry }
+        ' "$REPO_ROOT/CHANGELOG.md" > "$TMPDIR/CHANGELOG.md"
+        mv "$TMPDIR/CHANGELOG.md" "$REPO_ROOT/CHANGELOG.md"
+    fi
+
+    cat <<'WARN'
+
+====> These dashboards carry Giant Swarm patches. Review the diff.
+
+Known custom changes (see the header of this script for the reasoning):
+  - organization/cluster variables added; every selector filtered by cluster_id
+  - gotk_resource_info aggregated with `max by (...)` to de-duplicate the two
+    management-cluster exporters
+  - duration panels carry an `or` fallback for the MC/WC namespace-label split
+  - logs dashboard selects on service_name/cluster_id/pod, not namespace/stream/app
+  - Flux logs are only ingested for the management cluster: workload-cluster
+    `flux-system` has no tenant assignment, so Alloy drops those pod logs
+WARN
+}
+
+main "$@"

--- a/scripts/update-flux-dashboards.sh
+++ b/scripts/update-flux-dashboards.sh
@@ -192,7 +192,11 @@ patch_control_plane() {
             #    (`controller="helmrelease"` is also emitted by dex-operator and
             #    team-stamper). Without this the panels silently mix in other
             #    operators. The lookahead skips selectors already scoped.
-            | gsub("\\{cluster_id=\"\\$cluster\", (?![^}]*namespace)";
+            #    It must match the `namespace=` label, not the bare substring:
+            #    `exported_namespace=` contains "namespace" and would otherwise
+            #    look already-scoped, so an exported_namespace-only selector would
+            #    silently keep a fleet-wide generic metric.
+            | gsub("\\{cluster_id=\"\\$cluster\", (?![^}]*(?<![a-z_])namespace=)";
                    "{cluster_id=\"$cluster\", namespace=\"$namespace\", ")
             # 3. Our scrape interval is 60s, so upstream'"'"'s `[1m]` range windows
             #    contain at most one sample and rate()/increase() return nothing.
@@ -312,7 +316,7 @@ assert_scoped() {
     # per expression, so `count(a{cluster_id=...}) / count(b{})` cannot slip by.
     bad=$(jq -r '[.. | objects | select(has("expr")) | .expr
                   | [match("\\{[^}]*\\}"; "g").string]
-                  | map(select(test("cluster_id") | not)) | .[]] | unique | .[]' "$file")
+                  | map(select(test("(?<![a-z_])cluster_id=") | not)) | .[]] | unique | .[]' "$file")
     [[ -n "$bad" ]] && fail "has selectors with no cluster_id filter" "$bad"
 
     # A bare metric name with no selector at all is neither patched nor caught by
@@ -327,7 +331,7 @@ assert_scoped() {
     if [[ "$require_namespace" == "yes" ]]; then
         bad=$(jq -r '[.. | objects | select(has("expr")) | .expr
                       | [match("\\{[^}]*\\}"; "g").string]
-                      | map(select(test("namespace") | not)) | .[]] | unique | .[]' "$file")
+                      | map(select(test("(?<![a-z_])namespace=") | not)) | .[]] | unique | .[]' "$file")
         [[ -n "$bad" ]] && fail "has selectors with no namespace filter" "$bad"
     fi
 

--- a/scripts/update-flux-dashboards.sh
+++ b/scripts/update-flux-dashboards.sh
@@ -116,7 +116,9 @@ gs_common() {
         # the variable; no datasource with that uid exists in our Grafana, and the
         # target-level datasource wins, so those panels would query nothing. The
         # linter only inspects panel-level datasources and cannot catch it.
-        | (.. | objects | select(.uid? == "prometheus" and .type? == "prometheus"))
+        # Rewriting every prometheus-typed reference (not just uid=="prometheus")
+        # means a different hardcoded uid upstream cannot reintroduce this.
+        | (.. | objects | select(.type? == "prometheus" and has("uid")))
               |= {"type": "prometheus", "uid": "$datasource"}
     '
 }
@@ -234,10 +236,25 @@ patch_control_plane() {
 
 patch_logs() {
     local selector='{service_name=~"flux-app|flux-operator", cluster_id="$cluster", pod=~"$controller.*"}'
-    local caveat
+    local caveat banner
     caveat="Only management-cluster Flux logs are ingested. Workload clusters run Flux in the flux-system namespace, which has no tenant assignment, so their controller logs are dropped before reaching Loki and this dashboard will be empty for them."
+    banner=$(cat <<'EOF'
+{
+  "type": "text",
+  "title": "",
+  "gridPos": {"h": 3, "w": 24, "x": 0, "y": 0},
+  "id": 1000,
+  "transparent": true,
+  "options": {
+    "mode": "markdown",
+    "code": {"language": "plaintext", "showLineNumbers": false, "showMiniMap": false},
+    "content": "> **Management cluster only.** Flux controller logs are ingested for the management cluster. Workload clusters run Flux in the `flux-system` namespace, which has no tenant assignment, so their logs are dropped before reaching Loki -- selecting a workload cluster below will show no data even when Flux is running there."
+  }
+}
+EOF
+)
 
-    jq --arg selector "$selector" --arg caveat "$caveat" '
+    jq --arg selector "$selector" --arg caveat "$caveat" --argjson banner "$banner" '
         # Replace upstream'"'"'s stream selector wholesale: `stream` is dropped by
         # our Alloy config and `app` names the Helm release, not the controller.
         (.. | objects | select(has("expr")) | .expr) |=
@@ -250,11 +267,12 @@ patch_logs() {
         # `namespace` and `stream` no longer parameterise anything.
         | .templating.list |= map(select(.name != "namespace" and .name != "stream"))
         # The Cluster dropdown lists every cluster running Flux, but only
-        # management-cluster logs are ingested, so state that where a customer
-        # picking a workload cluster will actually see it rather than only in the
-        # docs.
+        # management-cluster logs are ingested. A panel description only shows on
+        # hover, which is no help to someone looking at two empty panels, so push
+        # the existing panels down and put a visible banner on top.
         | .description = $caveat
         | (.. | objects | select(has("targets")) | .description) |= $caveat
+        | .panels |= (map(.gridPos.y += 3) | [$banner] + .)
         # Controller identity comes from the pod name prefix.
         | (.templating.list[] | select(.name == "controller")) |= (
               {


### PR DESCRIPTION
Towards [roadmap#3259](https://github.com/giantswarm/roadmap/issues/3259).

## What was wrong

`Flux Cluster Stats` (customer-facing, `Shared Org / GitOps`) **showed no data at all**. Every panel — and its `namespace` variable — queried `gotk_reconcile_condition`, which the Flux controllers no longer expose. Verified on `gazelle`: zero series over 30 days. Upstream has moved to `gotk_resource_info`, which is also what our own Flux alerting rules in `giantswarm/prometheus-rules` use.

While verifying against live Mimir/Loki I found four more issues:

| Issue | Effect before |
|---|---|
| No cluster selector | These dashboards live in the MC's Grafana, whose Mimir holds metrics for *every* workload cluster, so all panels aggregated across a customer's whole fleet |
| `gotk_resource_info` exported twice on MCs (`flux-ksm` **and** `kube-state-metrics`, identical series) | Resource counts read exactly double — measured 410 instead of 206 |
| `controller_runtime_*` panels not namespace-scoped | Matched any operator with the same `controller` label values; `controller="helmrelease"` is also emitted by `dex-operator` and `team-stamper` |
| Upstream `[1m]` range windows vs. our 60s scrape interval | A 1m window cannot hold two samples, so the reconciliation and API-request panels were empty |

## What this does

- Syncs all three dashboards from `fluxcd/flux2-monitoring-example` and **publishes `Flux Logs`**, which we never shipped.
- Adds `scripts/update-flux-dashboards.sh` / `make update-flux-dashboards`, wired into the monthly dashboard-update workflow, so upstream fixes keep flowing in. The patch layer is asserted: if a patch stops applying, the script **fails loudly** rather than silently shipping a fleet-wide query.
- Adds the standard `Organization` / `Cluster` variables and a `cluster_id` filter to every selector.
- De-duplicates `gotk_resource_info` with `max by (<displayed labels>)` — correct on MCs, a no-op on WCs.
- Adds an `or` fallback to the duration panels, because `gotk_reconcile_duration_seconds_*` carries `exported_namespace` on MCs but only `namespace` on WCs. Proven necessary: on a WC with a specific namespace selected, the `exported_namespace` branch returns 0 series and the fallback returns 1.
- **Also fixes the monthly workflow**, which called a `make update-mixin` target that no longer exists (renamed to `update-all-mixin`) — that automation has been failing outright.

## Verification

- Every generated expression run against live Mimir on `gazelle`, for both a management cluster and a workload cluster: **all 11 cluster-dashboard and all 26 control-plane expressions return data on both**. Both Loki queries return streams, and the `controller` filter narrows them.
- `make check-dashboard-schema`: all three pass as v1.
- `dashboard-linter --strict`: `flux-cluster` and `flux-control-plane` are **completely clean**. `flux-logs` reports only the two findings every existing Loki dashboard in this repo also reports (hardcoded `gs-loki` datasource, LogQL parsed as PromQL) — consistent with `cilium-agent-logs.json`.
- `helm template`: three ConfigMaps render with `organization: Shared Org`, `folder: GitOps`, `team: honeybadger`, `app.giantswarm.io/kind: dashboard`.
- Re-running the sync script is idempotent — dashboards byte-identical, no duplicate CHANGELOG entry.
- `scripts/validate-dashboards.sh` could not run locally (it needs GNU `find`/`mapfile`; macOS bash 3.2), so it will run in CI. Its two checks — `uid` present and `owner:` matching a real team — hold for all three files.

## Note for reviewers

`Flux Logs` covers the **management cluster** Flux only. Workload-cluster Flux logs never reach Loki: the Alloy pipeline drops pod logs whose namespace has no tenant assignment (`stage.drop` on empty `__tenant_id__`), and WC `flux-system` has none. Worth a follow-up with the observability owners; I did not want to ship a panel that silently looks empty without saying so.

Adding a cluster selector changes what customers see (numbers drop from all-clusters to one-cluster) — worth a line in the release notes.